### PR TITLE
Added optional groupId for prompts while targeting entity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # **THIS IS A WORK IN PROGRESS AND NOT READY FOR PRODUCTION USE YET!**
 
 # Feather Core
+
 > Welcome to Feather Core, the beating heart of the Feather Framework; An extraordinary open-source RedM framework designed to bring the ultimate RedM server vision to life.
 
 # TODO
+
 - Spawn character at coords on initiateCharacter
 - xp/lv ui
 - money ui
@@ -13,65 +15,76 @@
 - pvp toggle/ui
 
 ## First time setup
+
 Run our easy-to-use [txadmin recipe](https://github.com/FeatherFramework/feather-recipe)!
 
 ## Features
+
 - Interiors Fixes
 - Population density control
 - Easy Developer API's
-    - Discord Webhook API
-    - User Management
-    - Character Management
-    - Remote Procedure Callbacks (RPC)
-    - PrettyPrint
-    - Dataview
-    - Game Events
-    - Prompts
-    - Pedestrians
-    - Objects
-    - Notifications
-    - Text Rendering
-    - Blips
+  - Discord Webhook API
+  - User Management
+  - Character Management
+  - Remote Procedure Callbacks (RPC)
+  - PrettyPrint
+  - Dataview
+  - Game Events
+  - Prompts
+  - Pedestrians
+  - Objects
+  - Notifications
+  - Text Rendering
+  - Blips
 
 ## API Documentation and usage
 
 ### Core API Setup
+
 ```lua
 feather =  exports['feather-core'].initiate()
 ```
 
 ### Character
+
 #### Create
+
 ```lua
 feather.Character.CreateCharacter(userid, firstname, lastname, dob, dollars, gold, xp, x, y, z)
 ```
 
 #### Initiate(spawn)
+
 ```lua
 feather.Character.InitiateCharacter(src, charid)
 ```
 
 #### Get All Available
+
 ```lua
 feather.Character.GetAvailableCharactersFromDB(src)
 ```
 
 #### Get Character by src
+
 ```lua
 feather.Character.GetCharacterBySrc(src)
 ```
 
 #### Get Character by ID
+
 ```lua
 feather.Character.GetCharacterByID(ID)
 ```
 
 #### Remove Character (despawn)
+
 ```lua
 feather.Character.RemoveCharacter(src)
 ```
 
 #### Update Character Field
+
 ```lua
 feather.Character.UpdateAttribute(src, key, val)
 ```
@@ -79,48 +92,51 @@ feather.Character.UpdateAttribute(src, key, val)
 ### User
 
 #### Get User by src
+
 ```lua
 feather.Character.GetUserBySrc(src)
 ```
 
 #### Get User by ID
+
 ```lua
 feather.Character.GetUserByID(ID)
 ```
-
-
 
 ### Blips
 
 You can leverage Feathers built in function for map blips.
 
 #### Create a Blip
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Create a marker (blip) on the players map
 
-|Parameter| Description|
-|--|--|
-| text | What the blip will display on the map |
-| bliphash | The hashname of the blip ([found here](https://github.com/femga/rdr3_discoveries/blob/a4b4bcd5a3006b0c1434b03e4095d038164932f7/useful_info_from_rpfs/textures/blips_mp/README.md)) |
-| scale | How big the blip is |
-| x | The x coordinate in the game world |
-| y | The y coordinate in the game world |
-| z | The z coordinate in the game world |
-| vector3 | instead of params send whole vector3 just add nil to x y z|
-  
-  Example Usage:
+| Parameter | Description                                                                                                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| text      | What the blip will display on the map                                                                                                                                              |
+| bliphash  | The hashname of the blip ([found here](https://github.com/femga/rdr3_discoveries/blob/a4b4bcd5a3006b0c1434b03e4095d038164932f7/useful_info_from_rpfs/textures/blips_mp/README.md)) |
+| scale     | How big the blip is                                                                                                                                                                |
+| x         | The x coordinate in the game world                                                                                                                                                 |
+| y         | The y coordinate in the game world                                                                                                                                                 |
+| z         | The z coordinate in the game world                                                                                                                                                 |
+| vector3   | instead of params send whole vector3 just add nil to x y z                                                                                                                         |
+
+Example Usage:
+
 ```lua
 -- client side only
 
 Citizen.CreateThread(function()
-    
+
     local  blip = feather.Blip:SetBlip('Gift', 'blip_special_series_1', 0.2, x, y, z, vector3 or nil)
 end)
 ```
 
 #### Get Raw Blip
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 If you want to use any natives that are not yet included, you can utilize the raw blip.
 
@@ -132,13 +148,14 @@ Citizen.CreateThread(function()
     local rawblip = blip.rawblip
     -- OR
     -- local rawblip = blip:Get()
-    
+
     -- use rawblip with any other native.
 end)
 ```
 
 #### Delete a Blip
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Delete a marker (blip) on the players map
 
@@ -154,16 +171,18 @@ end)
 ```
 
 #### Add Radius to Blip
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Create a Radius blip
 
-|Parameter| Description|
-|--|--|
-| radius | A decimal radius |
+| Parameter    | Description                                                                                                                                                                                                                |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| radius       | A decimal radius                                                                                                                                                                                                           |
 | bliphahashsh | The hashname of the blip ([found here](https://github.com/femga/rdr3_discoveries/blob/a4b4bcd5a3006b0c1434b03e4095d038164932f7/useful_info_from_rpfs/textures/blips_mp/README.md)) [Optional, will default to -1282792512] |
-  
-  Example Usage:
+
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -181,33 +200,40 @@ end)
 You can leverage Feathers built in function for easy in-game prompts.
 
 #### Setup a Prompt Group
-<Badge type="warning" text="Client Side Only" /> 
 
-This sets up the Prompt Group, which will allow you to attach future prompts to this group so that they can be displayed. This is required.
+<Badge type="warning" text="Client Side Only" />
+
+This sets up the Prompt Group, which will allow you to attach future prompts to this group so that they can be displayed. Optionally you can set the groupId yourself. This is useful for when creating a prompt when targeting an entity. This is required.
 
 **Example Usage:**
+
 ```lua
 
 -- client side only
 Citizen.CreateThread(function()
 	local  PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
+
+    -- Optional: Setting the Prompt Group for entities. (Used for prompts when targeting)
+    local promptGroupId = Citizen.InvokeNative(0xB796970BD125FCE8, targetEntity) -- PromptGetGroupIdForTargetEntity
+    local  PromptGroup = feather.Prompt:SetupPromptGroup(promptGroupId)
 end)
 ```
 
 #### Register Prompt
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Once you have the Prompt Group setup, you can now register a prompt to display within the group.
 
-|Parameter| Description|
-|--|--|
-| title| What the Prompt group will display next to the press button |
-| button | The hash key |
-| enabled | If 0 you cannot click, if 1 you can click |
-| visible | If 0 you cannot see the prompt, if 1 you can see the group |
-| pulsing | If true prompt will urgently pulse, if false it will not |
-| mode | What kind of prompt. (Options: click, hold, customhold, mash, timed) |
-| options | Extra Options for the Mode you select. (See Mode Options below)|
+| Parameter | Description                                                          |
+| --------- | -------------------------------------------------------------------- |
+| title     | What the Prompt group will display next to the press button          |
+| button    | The hash key                                                         |
+| enabled   | If 0 you cannot click, if 1 you can click                            |
+| visible   | If 0 you cannot see the prompt, if 1 you can see the group           |
+| pulsing   | If true prompt will urgently pulse, if false it will not             |
+| mode      | What kind of prompt. (Options: click, hold, customhold, mash, timed) |
+| options   | Extra Options for the Mode you select. (See Mode Options below)      |
 
 **Modes Options**
 | Mode | Key | Options | example|
@@ -218,16 +244,17 @@ Once you have the Prompt Group setup, you can now register a prompt to display w
 | mash | mashamount | > 0 | { mashamount = 20 }|
 | timed | depletiontime | Miliseconds | { depletiontime = 10000}|
 
-  `PromptGroup:RegisterPrompt(title, button, enabled, visible, pulsing, mode, options)`
-  
-  Example Usage:
+`PromptGroup:RegisterPrompt(title, button, enabled, visible, pulsing, mode, options)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
 
 Citizen.CreateThread(function()
 	local PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
-	
+
 	local firstprompt = PromptGroup:RegisterPrompt("Press Me", 0x4CC0E2FE, 1, 1, true, 'hold', {timedeventhash = "MEDIUM_TIMED_EVENT"}) --Register your first prompt
 
     while  true  do
@@ -237,60 +264,64 @@ end)
 ```
 
 #### Display Prompt Group
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Now that you have a Group setup and a registered Prompt, you can now display the group!
 
-|Parameter| Description|
-|--|--|
-| text| Text to display under all the prompts |
-  
-  `PromptGroup:ShowGroup(text)`
-  
-  Example Usage:
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| text      | Text to display under all the prompts |
+
+`PromptGroup:ShowGroup(text)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
 
 Citizen.CreateThread(function()
 	local PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
-	
+
 	local firstprompt = PromptGroup:RegisterPrompt("Press Me", 0x4CC0E2FE, 1, 1, true, 'hold', {timedeventhash = "MEDIUM_TIMED_EVENT"}) --Register your first prompt
 
     while  true  do
         Citizen.Wait(0)
-		PromptGroup:ShowGroup("My first prompt group") --Show your prompt group        
+		PromptGroup:ShowGroup("My first prompt group") --Show your prompt group
     end
 end)
 ```
 
 #### Handle Prompt Completion Events
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 You can trigger code when a prompt has a completion event triggered (Example: clicked, held, etc)
 
-|Parameter| Description|
-|--|--|
+| Parameter      | Description                                                                                                                      |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | hideoncomplete | Some Options may hide or disapear when completed, Set this to false to not hide. This will default to true if nothing is entered |
 
-`firstprompt:HasCompleted()` 
-  
-  Example Usage:
+`firstprompt:HasCompleted()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
 
 Citizen.CreateThread(function()
 	local  PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
-	
+
 	local firstprompt = PromptGroup:RegisterPrompt("Press Me", 0x4CC0E2FE, 1, 1, true, 'hold', {timedeventhash = "MEDIUM_TIMED_EVENT"}) --Register your first prompt
 
     while  true  do
         Citizen.Wait(0)
-        
+
         --Show your prompt group
 		PromptGroup:ShowGroup("My first prompt group")
-		  
+
 		-- Lets listed for the prompt click and enact some code!
         if firstprompt:HasCompleted() then
             print("First Prompt Completed!")
@@ -300,33 +331,34 @@ end)
 ```
 
 #### Handle Prompt Failure Events
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 You can trigger code when a prompt has a failure event triggered (Example: timed, mashed)
 
-
-|Parameter| Description|
-|--|--|
+| Parameter      | Description                                                                                                                      |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | hideoncomplete | Some Options may hide or disapear when completed, Set this to false to not hide. This will default to true if nothing is entered |
 
-`firstprompt:HasFailed()` 
-  
-  Example Usage:
+`firstprompt:HasFailed()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
 
 Citizen.CreateThread(function()
 	local  PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
-	
+
 	local firstprompt = PromptGroup:RegisterPrompt("Press Me", 0x4CC0E2FE, 1, 1, true, 'hold', {timedeventhash = "MEDIUM_TIMED_EVENT"}) --Register your first prompt
 
     while  true  do
         Citizen.Wait(0)
-        
+
         --Show your prompt group
 		PromptGroup:ShowGroup("My first prompt group")
-		  
+
 		-- Lets listed for the prompt click and enact some code!
         if firstprompt:HasCompleted() then
             print("First Prompt Completed!")
@@ -340,28 +372,30 @@ end)
 ```
 
 #### Delete Prompt
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Remove a prompt completely
 
-`firstprompt:DeletePrompt()` 
-  
-  Example Usage:
+`firstprompt:DeletePrompt()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
 
 Citizen.CreateThread(function()
 	local  PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
-	
+
 	local firstprompt = PromptGroup:RegisterPrompt("Press Me", 0x4CC0E2FE, 1, 1, true, 'hold', {timedeventhash = "MEDIUM_TIMED_EVENT"}) --Register your first prompt
 
     while  true  do
         Citizen.Wait(0)
-        
+
         --Show your prompt group
 		PromptGroup:ShowGroup("My first prompt group")
-		  
+
 		Wait(3000)
 
         firstprompt:DeletePrompt()
@@ -370,32 +404,34 @@ end)
 ```
 
 #### Toggle Prompt Visibility
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Make a prompt visible or hidden
 
-|Parameter| Description|
-|--|--|
-| toggle | true or false; true = visible, false = hidden |
+| Parameter | Description                                   |
+| --------- | --------------------------------------------- |
+| toggle    | true or false; true = visible, false = hidden |
 
-`firstprompt:TogglePrompt(toggle)` 
-  
-  Example Usage:
+`firstprompt:TogglePrompt(toggle)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
 
 Citizen.CreateThread(function()
 	local  PromptGroup = feather.Prompt:SetupPromptGroup() --Setup Prompt Group
-	
+
 	local firstprompt = PromptGroup:RegisterPrompt("Press Me", 0x4CC0E2FE, 1, 1, true, 'hold', {timedeventhash = "MEDIUM_TIMED_EVENT"}) --Register your first prompt
 
     while  true  do
         Citizen.Wait(0)
-        
+
         --Show your prompt group
 		PromptGroup:ShowGroup("My first prompt group")
-		  
+
 		Wait(3000)
 
         firstprompt:TogglePrompt(false)
@@ -408,20 +444,21 @@ end)
 You can leverage Feathers built in function for easy spawn and manipulate in-game pedestrian entities.
 
 #### Create Ped
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 This will spawn a pedestrian in your game world
 
-|Parameter| Description|
-|--|--|
-| modelhash | The [hash](https://github.com/femga/rdr3_discoveries/blob/f729ba03f75a591ce5c841642dc873345242f612/peds/peds_list.lua) of the model you want the ped to be |
-| x | x world position coordinate |
-| y | y world position coordinate |
-| z | z world position coordinate |
-| heading | The heading of the ped (Which way it is facing) |
-| location | Where to spawn ped. (world, vehicle, mount)|
-| safeground | Should the ped spawn in a known ok location (default true, disable for more dine accuracy of ped placement) |
-| options | Extra Options for the Location you select. (See Mode Options below)|
+| Parameter  | Description                                                                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| modelhash  | The [hash](https://github.com/femga/rdr3_discoveries/blob/f729ba03f75a591ce5c841642dc873345242f612/peds/peds_list.lua) of the model you want the ped to be |
+| x          | x world position coordinate                                                                                                                                |
+| y          | y world position coordinate                                                                                                                                |
+| z          | z world position coordinate                                                                                                                                |
+| heading    | The heading of the ped (Which way it is facing)                                                                                                            |
+| location   | Where to spawn ped. (world, vehicle, mount)                                                                                                                |
+| safeground | Should the ped spawn in a known ok location (default true, disable for more dine accuracy of ped placement)                                                |
+| options    | Extra Options for the Location you select. (See Mode Options below)                                                                                        |
 
 **Modes Options**
 | Location | Key | Options | example|
@@ -431,10 +468,10 @@ This will spawn a pedestrian in your game world
 | vehicle | seat | VS_ANY_PASSENGER, VS_DRIVER, VS_FRONT_RIGHT, VS_BACK_LEFT, VS_BACK_RIGHT, VS_EXTRA_LEFT_1, VS_EXTRA_RIGHT_1, VS_EXTRA_LEFT_2, VS_EXTRA_RIGHT_2, VS_EXTRA_LEFT_3, VS_EXTRA_RIGHT_3, VS_NUM_SEATS | { seat = "VS_FRONT_RIGHT" } |
 | mount | mount | mount entity | { mount = yourmount } |
 
+`featherPeds:Create()`
 
-`featherPeds:Create()` 
-  
-  Example Usage:
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -449,17 +486,19 @@ end)
 ```
 
 #### Freeze Ped
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Freeze a ped where they stand
 
-| Parameter| Description|
-|--|--|
-| state | freeze or unfreeze (true/false), default true |
+| Parameter | Description                                   |
+| --------- | --------------------------------------------- |
+| state     | freeze or unfreeze (true/false), default true |
 
-`ped:Freeze()` 
-  
-  Example Usage:
+`ped:Freeze()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -476,17 +515,19 @@ end)
 ```
 
 #### Invincible Ped
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Make a ped Invincible
 
-| Parameter| Description|
-|--|--|
-| state | Invincible (true/false), default true |
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| state     | Invincible (true/false), default true |
 
-`ped:Invincible()` 
-  
-  Example Usage:
+`ped:Invincible()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -503,17 +544,19 @@ end)
 ```
 
 #### Ped CanBeDamaged
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Make a ped not take damage
 
-| Parameter| Description|
-|--|--|
-| state | CanBeDamaged (true/false), default true |
+| Parameter | Description                             |
+| --------- | --------------------------------------- |
+| state     | CanBeDamaged (true/false), default true |
 
-`ped:CanBeDamaged()` 
-  
-  Example Usage:
+`ped:CanBeDamaged()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -530,17 +573,19 @@ end)
 ```
 
 #### Set Ped Heading
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 change the directon a ped is facing
 
-| Parameter| Description|
-|--|--|
-| head | the game world direction to face |
+| Parameter | Description                      |
+| --------- | -------------------------------- |
+| head      | the game world direction to face |
 
-`ped:SetHeading()` 
-  
-  Example Usage:
+`ped:SetHeading()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -557,17 +602,19 @@ end)
 ```
 
 #### Set Ped Seeing Range
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Change how far the ped can see
 
-| Parameter| Description|
-|--|--|
-| range | 0.0 - 100.0|
+| Parameter | Description |
+| --------- | ----------- |
+| range     | 0.0 - 100.0 |
 
-`ped:SeeingRange()` 
-  
-  Example Usage:
+`ped:SeeingRange()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -584,17 +631,19 @@ end)
 ```
 
 #### Set Ped Hearing Range
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Change how far the ped can hear
 
-| Parameter| Description|
-|--|--|
-| range | 0.0 - 100.0|
+| Parameter | Description |
+| --------- | ----------- |
+| range     | 0.0 - 100.0 |
 
-`ped:HearingRange()` 
-  
-  Example Usage:
+`ped:HearingRange()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -611,17 +660,19 @@ end)
 ```
 
 #### Set Ped Can Mount
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Change if a ped can mount something.
 
-| Parameter| Description|
-|--|--|
-| state | true/false|
+| Parameter | Description |
+| --------- | ----------- |
+| state     | true/false  |
 
-`ped:CanBeMounted(true)` 
-  
-  Example Usage:
+`ped:CanBeMounted(true)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -638,17 +689,19 @@ end)
 ```
 
 #### Add Ped to Group
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Add ped to a group
 
-| Parameter| Description|
-|--|--|
-| group | index of the group to add to |
+| Parameter | Description                  |
+| --------- | ---------------------------- |
+| group     | index of the group to add to |
 
-`ped:AddPedToGroup(group)` 
-  
-  Example Usage:
+`ped:AddPedToGroup(group)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -666,13 +719,15 @@ end)
 ```
 
 #### Clear a ped task
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Clear any active tasks
 
-`ped:ClearTasks()` 
-  
-  Example Usage:
+`ped:ClearTasks()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -690,13 +745,15 @@ end)
 ```
 
 #### Get Task Status
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Check the status of a ped task
 
-`ped:GetTaskStatus(taskid)` 
-  
-  Example Usage:
+`ped:GetTaskStatus(taskid)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -718,17 +775,19 @@ end)
 ```
 
 #### Follow to offset
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Add ped to a group
 
-| Parameter| Description|
-|--|--|
-| pedid | id of ped to follow |
+| Parameter | Description         |
+| --------- | ------------------- |
+| pedid     | id of ped to follow |
 
-`ped:FollowToOffsetOfEntity(pedid)` 
-  
-  Example Usage:
+`ped:FollowToOffsetOfEntity(pedid)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -746,17 +805,19 @@ end)
 ```
 
 #### Follow to offset
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Add ped to a group
 
-| Parameter| Description|
-|--|--|
-| skinhash | hash of skin meta cloth |
+| Parameter | Description             |
+| --------- | ----------------------- |
+| skinhash  | hash of skin meta cloth |
 
-`ped:ChangeOutfit(skinhash)` 
-  
-  Example Usage:
+`ped:ChangeOutfit(skinhash)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -774,18 +835,20 @@ end)
 ```
 
 #### Set Ped Blip
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Set a blip on ped that follows
 
-| Parameter| Description|
-|--|--|
-| bliphash | What the [blip](https://github.com/femga/rdr3_discoveries/blob/a4b4bcd5a3006b0c1434b03e4095d038164932f7/useful_info_from_rpfs/textures/blips_mp/README.md) should show on the map |
-| title | What the blip should say |
+| Parameter | Description                                                                                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bliphash  | What the [blip](https://github.com/femga/rdr3_discoveries/blob/a4b4bcd5a3006b0c1434b03e4095d038164932f7/useful_info_from_rpfs/textures/blips_mp/README.md) should show on the map |
+| title     | What the blip should say                                                                                                                                                          |
 
-`ped:SetBlip(bliphash, title)` 
-  
-  Example Usage:
+`ped:SetBlip(bliphash, title)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -802,24 +865,26 @@ end)
 ```
 
 #### Give Ped Weapon
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Give a ped a weapon (they will only use it if they are set to be agro)
 
-| Parameter| Description|
-|--|--|
-| weaponhash | What the [weapon](https://github.com/femga/rdr3_discoveries/blob/f729ba03f75a591ce5c841642dc873345242f612/weapons/weapons.lua) will be|
-| ammocount | how much ammo |
-| forceinhand | Force the weapon to be held |
-| forceinholster | Force the weapon to be holstered |
-| attachpoint | Where to attach to the body |
-| allowmultiplecopies | How many of this gun can the ped have |
-| ignoreunlocks | Ingore unlockables |
-| permanentdegredation | permanent degredation |
-  
+| Parameter            | Description                                                                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| weaponhash           | What the [weapon](https://github.com/femga/rdr3_discoveries/blob/f729ba03f75a591ce5c841642dc873345242f612/weapons/weapons.lua) will be |
+| ammocount            | how much ammo                                                                                                                          |
+| forceinhand          | Force the weapon to be held                                                                                                            |
+| forceinholster       | Force the weapon to be holstered                                                                                                       |
+| attachpoint          | Where to attach to the body                                                                                                            |
+| allowmultiplecopies  | How many of this gun can the ped have                                                                                                  |
+| ignoreunlocks        | Ingore unlockables                                                                                                                     |
+| permanentdegredation | permanent degredation                                                                                                                  |
+
 `ped:GiveWeapon(weaponhash, ammocount, forceinhand, forceinholster, attachpoint, allowmultiplecopies, ignoreunlocks, permanentdegredation)`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -836,18 +901,20 @@ end)
 ```
 
 #### Set Ped Flee Attribute
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Enable or disable pedestrian flee attributes
 
-| Parameter| Description|
-|--|--|
-| flag | What [flee attribute](https://github.com/femga/rdr3_discoveries/tree/master/AI/FLEE_ATTRIBUTES) to enable/disable |
-| enabled | is active of not (true/false) |
-  
+| Parameter | Description                                                                                                       |
+| --------- | ----------------------------------------------------------------------------------------------------------------- |
+| flag      | What [flee attribute](https://github.com/femga/rdr3_discoveries/tree/master/AI/FLEE_ATTRIBUTES) to enable/disable |
+| enabled   | is active of not (true/false)                                                                                     |
+
 `ped:FleeAtribute(flag, enabled)`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -863,20 +930,22 @@ end)
 ```
 
 #### Set Ped Combat Attributes
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Enable or disable pedestrian combat attributes
 
-| Parameter| Description|
-|--|--|
-| attributes | This is a list of [attributes](https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_ATTRIBUTES) you want to change Example { {flag = 1, enabled = false}, {flag = 2, enabled = false} } |
-| attackrange | The distance for aggro |
-| abilitylevel | how good or not the ped is at fighting |
-| movement | What kind of movement (0: Stationary (Will just stand in place), 1: Defensive (Will try to find cover and very likely to blind fire), 2: Offensive (Will attempt to charge at enemy but take cover as well), 3: Suicidal Offensive (Will try to flank enemy in a suicidal attack)) |
+| Parameter    | Description                                                                                                                                                                                                                                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| attributes   | This is a list of [attributes](https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_ATTRIBUTES) you want to change Example { {flag = 1, enabled = false}, {flag = 2, enabled = false} }                                                                                 |
+| attackrange  | The distance for aggro                                                                                                                                                                                                                                                             |
+| abilitylevel | how good or not the ped is at fighting                                                                                                                                                                                                                                             |
+| movement     | What kind of movement (0: Stationary (Will just stand in place), 1: Defensive (Will try to find cover and very likely to blind fire), 2: Offensive (Will attempt to charge at enemy but take cover as well), 3: Suicidal Offensive (Will try to flank enemy in a suicidal attack)) |
 
 `ped:SetPedCombatAttributes(attributes, attackrange, abilitylevel, movement)`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -894,18 +963,20 @@ end)
 ```
 
 #### Set Ped Combat Style
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Set the pedestrians combat style
 
-| Parameter| Description|
-|--|--|
+| Parameter  | Description                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------ |
 | combathash | The [combat style](https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_STYLES) for the ped |
-| duration | How long the ped has this combat style |
+| duration   | How long the ped has this combat style                                                                 |
 
 `ped:SetCombatStyle(combathash, duration)`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -921,13 +992,15 @@ end)
 ```
 
 #### Clear Ped Combat Style
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Clear the pedestrians combat style
 
 `ped:ClearCombatStyle()`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -943,18 +1016,20 @@ end)
 ```
 
 #### Attack Target
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Set a target for the ped to attack
 
-| Parameter| Description|
-|--|--|
-| target | the ped to attack (can be player) |
-| style | How long the ped has this combat style (GUARD, COMBAT_ANIMAL, LAW, LAW_SHERIFF) |
+| Parameter | Description                                                                     |
+| --------- | ------------------------------------------------------------------------------- |
+| target    | the ped to attack (can be player)                                               |
+| style     | How long the ped has this combat style (GUARD, COMBAT_ANIMAL, LAW, LAW_SHERIFF) |
 
 `ped:AttackTarget(target, style)`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -970,13 +1045,15 @@ end)
 ```
 
 #### Remove Ped
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Remove a Ped
 
 `ped:Remove()`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -992,13 +1069,15 @@ end)
 ```
 
 #### Get Ped
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 If there are natives this util does not yet support, you can use this to get the ped to utilize against any native.
 
 `ped:GetPed()`
 
-  Example Usage:
+Example Usage:
+
 ```lua
 -- client side only
 
@@ -1020,23 +1099,25 @@ end)
 You can leverage Feathers built in function for easy spawn and manipulate in-game Object entities.
 
 #### Create Object
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 This will spawn an object in your game world
 
-|Parameter| Description|
-|--|--|
+| Parameter | Description                                                                                                                                                |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | modelhash | The [hash](https://github.com/femga/rdr3_discoveries/blob/f729ba03f75a591ce5c841642dc873345242f612/peds/peds_list.lua) of the model you want the ped to be |
-| x | x world position coordinate |
-| y | y world position coordinate |
-| z | z world position coordinate |
-| heading | The heading of the ped (Which way it is facing) |
-| networked | Where to spawn ped. (world, vehicle, mount)|
-| method | standard or custom - Standard will run place on ground and a few other house keeping |
+| x         | x world position coordinate                                                                                                                                |
+| y         | y world position coordinate                                                                                                                                |
+| z         | z world position coordinate                                                                                                                                |
+| heading   | The heading of the ped (Which way it is facing)                                                                                                            |
+| networked | Where to spawn ped. (world, vehicle, mount)                                                                                                                |
+| method    | standard or custom - Standard will run place on ground and a few other house keeping                                                                       |
 
-`featherObjects:Create()` 
-  
-  Example Usage:
+`featherObjects:Create()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1051,17 +1132,19 @@ end)
 ```
 
 #### Pickup Light
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Add a light to the object
 
-|Parameter| Description|
-|--|--|
-| state | True/False |
+| Parameter | Description |
+| --------- | ----------- |
+| state     | True/False  |
 
-`obj:PickupLight(state)` 
-  
-  Example Usage:
+`obj:PickupLight(state)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1078,17 +1161,19 @@ end)
 ```
 
 #### Freeze
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Freeze Object
 
-|Parameter| Description|
-|--|--|
-| state | True/False |
+| Parameter | Description |
+| --------- | ----------- |
+| state     | True/False  |
 
-`obj:Freeze(state)` 
-  
-  Example Usage:
+`obj:Freeze(state)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1105,17 +1190,19 @@ end)
 ```
 
 #### Set Heading
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Set the heading of an object
 
-|Parameter| Description|
-|--|--|
-| heading | number coord relative to the game world |
+| Parameter | Description                             |
+| --------- | --------------------------------------- |
+| heading   | number coord relative to the game world |
 
-`obj:SetHeading(heading)` 
-  
-  Example Usage:
+`obj:SetHeading(heading)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1132,17 +1219,19 @@ end)
 ```
 
 #### Place On Ground
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 place the object on the groun properly
 
-|Parameter| Description|
-|--|--|
-| state | true/false |
+| Parameter | Description |
+| --------- | ----------- |
+| state     | true/false  |
 
-`obj:PlaceOnGround(state)` 
-  
-  Example Usage:
+`obj:PlaceOnGround(state)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1159,17 +1248,19 @@ end)
 ```
 
 #### Set As Mission
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 The engine will keep object when players leave the area
 
-|Parameter| Description|
-|--|--|
-| state | true/false |
+| Parameter | Description |
+| --------- | ----------- |
+| state     | true/false  |
 
-`obj:SetAsMission(state)` 
-  
-  Example Usage:
+`obj:SetAsMission(state)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1186,14 +1277,15 @@ end)
 ```
 
 #### Set As No Longer Needed
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 The engine will remove when players leave the area
 
+`obj:SetAsNoLongerNeeded()`
 
-`obj:SetAsNoLongerNeeded()` 
-  
-  Example Usage:
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1210,17 +1302,19 @@ end)
 ```
 
 #### Invincible
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Set object as invincible
 
-|Parameter| Description|
-|--|--|
-| state | true/false |
+| Parameter | Description |
+| --------- | ----------- |
+| state     | true/false  |
 
-`obj:Invincible(state)` 
-  
-  Example Usage:
+`obj:Invincible(state)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1237,17 +1331,19 @@ end)
 ```
 
 #### Horse Jumpable
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Sets object as not jumpable by horse.
 
-|Parameter| Description|
-|--|--|
-| state | true/false |
+| Parameter | Description |
+| --------- | ----------- |
+| state     | true/false  |
 
-`obj:SetNotHorseJumpable(state)` 
-  
-  Example Usage:
+`obj:SetNotHorseJumpable(state)`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1264,13 +1360,15 @@ end)
 ```
 
 #### Remove
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Remove Object
 
-`obj:Remove()` 
-  
-  Example Usage:
+`obj:Remove()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1289,13 +1387,15 @@ end)
 ```
 
 #### Get Object
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Remove Object
 
-`obj:GetObj()` 
-  
-  Example Usage:
+`obj:GetObj()`
+
+Example Usage:
+
 ```lua
 
 -- client side only
@@ -1314,6 +1414,7 @@ end)
 ```
 
 ### DataView
+
 A DataView utility
 
 Example Usage:
@@ -1339,18 +1440,21 @@ end
 ```
 
 ### PrettyPrint
+
 Feather provides an enhanced `print` functionality to the default Lua.
 
 #### Features
+
 - Table printing support
 - ANSI Color and text formatting support
 
 #### Setup
+
 ```lua
 
 -- Server and Client
 Citizen.CreateThread(function()
-    --Use print as you normally would. 
+    --Use print as you normally would.
     feather.Print('%{bold} %{red}TEST', {
         hello = "world"
     })
@@ -1363,57 +1467,59 @@ end)
 
 Colors and backgrounds can be used usilizing the `%{attribute}` format
 
-
-| Type | format | Description |
-|--|--|--|
-| Text Format | %{bold} | Make Text Font weight heavier |
-| Text Color | %{reset} | Set back to default color |
-| Text Color | %{red} |  |
-| Text Color | %{green} |  |
-| Text Color | %{orange} |  |
-| Text Color | %{navy} |  |
-| Text Color | %{magenta} or %{purple} |  |
-| Text Color | %{cyan} |  |
-| Text Color | %{gray} or %{grey}|  |
-| Text Color | %{lightgray} or %{lightgrey} |  |
-| Text Color | %{peach} |  |
-| Text Color | %{lightgreen} |  |
-| Text Color | %{yellow} |  |
-| Text Color | %{blue} |  |
-| Text Color | %{pink} |  |
-| Text Color | %{babyblue} |  |
-| Background Color | %{highlight red} |  |
-| Background Color | %{highlight green} |  |
-| Background Color | %{highlight orange} |  |
-| Background Color | %{highlight navy} |  |
-| Background Color | %{highlight magenta} |  |
-| Background Color | %{highlight cyan} |  |
-| Background Color | %{highlight gray} or %{highlight grey} |  |
-| Background Color | %{highlight lightgray} or %{highlight lightgrey} |  |
-| Background Color | %{highlight peach} |  |
-| Background Color | %{highlight lightgreen} |  |
-| Background Color | %{highlight yellow} |  |
-| Background Color | %{highlight blue} |  |
-| Background Color | %{highlight pink} |  |
-| Background Color | %{highlight babyblue} |  |
+| Type             | format                                           | Description                   |
+| ---------------- | ------------------------------------------------ | ----------------------------- |
+| Text Format      | %{bold}                                          | Make Text Font weight heavier |
+| Text Color       | %{reset}                                         | Set back to default color     |
+| Text Color       | %{red}                                           |                               |
+| Text Color       | %{green}                                         |                               |
+| Text Color       | %{orange}                                        |                               |
+| Text Color       | %{navy}                                          |                               |
+| Text Color       | %{magenta} or %{purple}                          |                               |
+| Text Color       | %{cyan}                                          |                               |
+| Text Color       | %{gray} or %{grey}                               |                               |
+| Text Color       | %{lightgray} or %{lightgrey}                     |                               |
+| Text Color       | %{peach}                                         |                               |
+| Text Color       | %{lightgreen}                                    |                               |
+| Text Color       | %{yellow}                                        |                               |
+| Text Color       | %{blue}                                          |                               |
+| Text Color       | %{pink}                                          |                               |
+| Text Color       | %{babyblue}                                      |                               |
+| Background Color | %{highlight red}                                 |                               |
+| Background Color | %{highlight green}                               |                               |
+| Background Color | %{highlight orange}                              |                               |
+| Background Color | %{highlight navy}                                |                               |
+| Background Color | %{highlight magenta}                             |                               |
+| Background Color | %{highlight cyan}                                |                               |
+| Background Color | %{highlight gray} or %{highlight grey}           |                               |
+| Background Color | %{highlight lightgray} or %{highlight lightgrey} |                               |
+| Background Color | %{highlight peach}                               |                               |
+| Background Color | %{highlight lightgreen}                          |                               |
+| Background Color | %{highlight yellow}                              |                               |
+| Background Color | %{highlight blue}                                |                               |
+| Background Color | %{highlight pink}                                |                               |
+| Background Color | %{highlight babyblue}                            |                               |
 
 Example Usage:
+
 ```lua
     print('%{blue}moon over the rainbow')
 ```
+
 ![image](https://user-images.githubusercontent.com/10902965/206995197-bf635488-75a1-4f40-866a-080b5f09b065.png)
 
-
 ### Render
+
 Render is an API to help with in-world and on screen drawing. (Text, Sprites, etc.)
 
 #### WorldToScreen
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Converts an in-world coordinate to a screen position
 
-|Parameter| Description|
-|--|--|
+| Parameter     | Description       |
+| ------------- | ----------------- |
 | pos (vector3) | in-world position |
 
 > Returns vector 2 screen coords.
@@ -1423,6 +1529,7 @@ Converts an in-world coordinate to a screen position
 `object:WorldToScreen(vector3(x, y, z))`
 
 Example Usage:
+
 ```lua
 -- Client
 RegisterCommand('trigger', function()
@@ -1433,12 +1540,13 @@ end)
 ```
 
 #### WorldToHud
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Converts in-world coordinate to a hud position (bounded to screen)
 
-|Parameter| Description|
-|--|--|
+| Parameter     | Description       |
+| ------------- | ----------------- |
 | pos (vector3) | in-world position |
 
 > Returns vector 2 screen coords
@@ -1448,6 +1556,7 @@ Converts in-world coordinate to a hud position (bounded to screen)
 `object:WorldToHud(vector3(x, y, z))`
 
 Example Usage:
+
 ```lua
 -- Client
 RegisterCommand('trigger', function()
@@ -1458,22 +1567,24 @@ end)
 ```
 
 #### DrawSprite
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Draw Sprites on screen
 
-|Parameter| Description|
-|--|--|
-| pos (vector2) | table containing x and y coords of sprite position on screen |
-| size (vector2) | table containing x and y sizes (relative to screen x and y size, ranges from 0.0-1.0) |
-| rotation (float) | number of sprite rotation in degrees |
-| color (vector3) | table of rgba values |
-| texturedict | [Name of texture](https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs) dictionary to load texture from (e.g. "CommonMenu", "MPWeaponsCommon", etc.) |
-| texturename | [Name of texture](https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs) to load from texture dictionary (e.g. "last_team_standing_icon", "tennis_icon", etc.)|
+| Parameter        | Description                                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| pos (vector2)    | table containing x and y coords of sprite position on screen                                                                                                                         |
+| size (vector2)   | table containing x and y sizes (relative to screen x and y size, ranges from 0.0-1.0)                                                                                                |
+| rotation (float) | number of sprite rotation in degrees                                                                                                                                                 |
+| color (vector3)  | table of rgba values                                                                                                                                                                 |
+| texturedict      | [Name of texture](https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs) dictionary to load texture from (e.g. "CommonMenu", "MPWeaponsCommon", etc.)          |
+| texturename      | [Name of texture](https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs) to load from texture dictionary (e.g. "last_team_standing_icon", "tennis_icon", etc.) |
 
 `featherRender:DrawSprite(pos, size, rotation, color, texturedict, texturename)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1490,19 +1601,21 @@ end)
 ```
 
 #### Draw Rectangle
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Draw a rectangle on screen
 
-|Parameter| Description|
-|--|--|
-| pos (vector2) | table containing x and y coords of sprite position on screen (ranges from 0.0-1.0) |
-| size (vector2) | table containing x and y sizes (ranges from 0.0-1.0) |
-| color (vector3) | table of rgba values |
+| Parameter       | Description                                                                        |
+| --------------- | ---------------------------------------------------------------------------------- |
+| pos (vector2)   | table containing x and y coords of sprite position on screen (ranges from 0.0-1.0) |
+| size (vector2)  | table containing x and y sizes (ranges from 0.0-1.0)                               |
+| color (vector3) | table of rgba values                                                               |
 
 `featherRender:DrawRectangle(pos, size, color)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1519,27 +1632,28 @@ end)
 ```
 
 #### Draw Marker
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Draw a Marker in-world
 
-|Parameter| Description|
-|--|--|
-| type |  |
-| pos | table containing x y and z coords |
-| dir | table containing x y and z coords |
-| rot | rotation of the marker |
-| scale |  table containing x y and z scale |
-| color | table of rgba values |
-| bobupanddown | does it bounce (true/false) |
-| facecamera | should it face the camera (true/false) |
-| rotate | does the marker rotate (true/false)  |
-| drawonents | (true/false) |
-
+| Parameter    | Description                            |
+| ------------ | -------------------------------------- |
+| type         |                                        |
+| pos          | table containing x y and z coords      |
+| dir          | table containing x y and z coords      |
+| rot          | rotation of the marker                 |
+| scale        | table containing x y and z scale       |
+| color        | table of rgba values                   |
+| bobupanddown | does it bounce (true/false)            |
+| facecamera   | should it face the camera (true/false) |
+| rotate       | does the marker rotate (true/false)    |
+| drawonents   | (true/false)                           |
 
 `featherRender:DrawMarker(type, pos, dir, rot, scale, color, bob, facevamera, rotate, drawonents)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1552,21 +1666,23 @@ end)
 ```
 
 #### Draw Text
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Draw a Text on screen
 
-|Parameter| Description|
-|--|--|
-| pos | table containing x and y coords of text position (0-1, 0-1) |
-| text | table containing x y and z coords |
-| color | table of rgba values |
-| scale | scale of the text |
-| shadow | if shadow is enabled (true/false) |
+| Parameter | Description                                                 |
+| --------- | ----------------------------------------------------------- |
+| pos       | table containing x and y coords of text position (0-1, 0-1) |
+| text      | table containing x y and z coords                           |
+| color     | table of rgba values                                        |
+| scale     | scale of the text                                           |
+| shadow    | if shadow is enabled (true/false)                           |
 
 `feather.Render:DrawText(pos, text, color, scale, shadow)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1583,21 +1699,23 @@ end)
 ```
 
 #### Draw Text 3D
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Draw 3D Text on screen
 
-|Parameter| Description|
-|--|--|
-| x | x coord |
-| y | y coord |
-| z | z coord |
-| text | text to display |
-| scale | scale of the text |
+| Parameter | Description       |
+| --------- | ----------------- |
+| x         | x coord           |
+| y         | y coord           |
+| z         | z coord           |
+| text      | text to display   |
+| scale     | scale of the text |
 
 `feather.Render:Draw3DText(x, y, z, text, scale)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1611,21 +1729,24 @@ end)
 ```
 
 ### Game Events
+
 Feather has a built-in network and entity event watcher that can be utilized by other scripts easily.
 
 #### Register Event Listener
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Register a callback that will be triggered whenever an in-game client event triggers.
 
-|Parameter| Description|
-|--|--|
-| eventname | name of the event to watch/listen to |
-| callback | fucntion to be triggered when an event is triggered |
+| Parameter | Description                                         |
+| --------- | --------------------------------------------------- |
+| eventname | name of the event to watch/listen to                |
+| callback  | fucntion to be triggered when an event is triggered |
 
 `featherEvents:RegisterEventListener(eventname, callback)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1636,17 +1757,19 @@ end)
 ```
 
 #### Remove Event Listener
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 Removes an event from the listener queue, listener will no longer listen once removed. This frees up in-game memory andis best practice if using listeners in a dynamic, or temporary way.
 
-|Parameter| Description|
-|--|--|
-| listener | object returns from RegisterEventListener |
+| Parameter | Description                               |
+| --------- | ----------------------------------------- |
+| listener  | object returns from RegisterEventListener |
 
 `featherEvents:RenoveEventListener(listener)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1662,18 +1785,20 @@ end)
 ```
 
 #### DevMode
-<Badge type="warning" text="Client Side Only" /> 
+
+<Badge type="warning" text="Client Side Only" />
 
 This provides the ability to print every in-game event for development purpose.
 
-|Parameter| Description|
-|--|--|
-| state | object returns from RegisterEventListener |
-| type | (optional, will default to all) the type of event to listen too (entities, network, or all) |
+| Parameter | Description                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------- |
+| state     | object returns from RegisterEventListener                                                   |
+| type      | (optional, will default to all) the type of event to listen too (entities, network, or all) |
 
 `featherEvents:DevMode(listener)`
 
 Example Usage:
+
 ```lua
 -- Client
 Citizen.CreateThread(function()
@@ -1681,7 +1806,6 @@ Citizen.CreateThread(function()
     --  featherEvents:DevMode(true, 'network')
 end)
 ```
-
 
 ### Discord Webhooks
 
@@ -1722,16 +1846,17 @@ discord:sendMessage('user789', 'this user kinda really awesome', {
 ```
 
 ### Remote Procedure Callback - RPC
-An RPC allows developers to easily communicate between the client and server without interrupting the runtime queue. 
+
+An RPC allows developers to easily communicate between the client and server without interrupting the runtime queue.
 
 Learn more here: https://en.wikipedia.org/wiki/Remote_procedure_call
 
-#### Register your remote prodecure 
+#### Register your remote prodecure
 
 > feather.RPC.Register(name, callback)
 
-* `name<string>` - remote method name
-* `callback<function>` - method function (see method callback)
+- `name<string>` - remote method name
+- `callback<function>` - method function (see method callback)
 
 ```lua
 feather.RPC.Register("doSomething", myProcedure)
@@ -1751,14 +1876,15 @@ end
 ```
 
 #### Call RPC with inline callback.
+
 Calls remote method.
 
 > feather.RPC.Call(name, params, callback [, player])
 
-* `name<string>` - method name
-* `params<table>` - params passed to method
-* `callback<function>` - callback called when results are received
-* `player<player>` - optional player source to call method on (only for server-side)
+- `name<string>` - method name
+- `params<table>` - params passed to method
+- `callback<function>` - callback called when results are received
+- `player<player>` - optional player source to call method on (only for server-side)
 
 ```lua
 feather.RPC.Call("doSomethingRemote", { text = "World", delay = 1000 }, function (result)
@@ -1771,10 +1897,11 @@ end)
 Calls remote method asynchronously. Can only be used inside `Citizen.CreateThread`.
 
 > feather.RPC.CallAsync(name, params [, player])
-* `name<string>` - method name
-* `params<table>` - params passed to method
-* `player<player>` - optional player source to call method on (only for server-side)
-* returns `result<any>` - any data returned by remote method
+
+- `name<string>` - method name
+- `params<table>` - params passed to method
+- `player<player>` - optional player source to call method on (only for server-side)
+- returns `result<any>` - any data returned by remote method
 
 ```lua
 Citizen.CreateThread(function ()
@@ -1788,13 +1915,14 @@ end)
 ```
 
 #### Notify Remote Procedure
+
 Calls remote method without receiving return values.
 
 > feather.RPC.Notify(name, params [, player])
 
-* `name<string>` - method name
-* `params<table>` - params passed to method
-* `player<player>` - optional player source to call method on (only for server-side)
+- `name<string>` - method name
+- `params<table>` - params passed to method
+- `player<player>` - optional player source to call method on (only for server-side)
 
 ```lua
 feather.RPC.Notify("doSomethingRemote", { text = "World", delay = 1000 }, function (result)
@@ -1803,14 +1931,17 @@ end)
 ```
 
 ### Key codes
-easy game keycodes are exposed to the API. 
+
+easy game keycodes are exposed to the API.
 
 example
+
 ```lua
 feather.Keys.A -- returns 0x7065027D
 ```
 
 ### Github Version Control
+
 You can have feather check if your script is up-to-date by adding the following to your github repo
 
 ```
@@ -1828,16 +1959,16 @@ For Example version '1.0'
 
 _How to use [Github Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)_
 
-> Create a Release and tag  with the version number
+> Create a Release and tag with the version number
 
 _Correct: `1.0.0`_
 
 _Wrong: `v1.1.0`_
 
-
 #### Version File Based Checks
 
 > Create a file called `version` with the following contents
+
 ```txt
 <1.3>
 - More awesome updates
@@ -1848,4 +1979,5 @@ _Wrong: `v1.1.0`_
 ```
 
 ### Notifications
+
 TBD

--- a/client/services/prompts.lua
+++ b/client/services/prompts.lua
@@ -1,18 +1,17 @@
 PromptsAPI = {}
-function PromptsAPI:SetupPromptGroup()
+function PromptsAPI:SetupPromptGroup(groupId)
     ----------------- Setup PromptGroup class and add attributes to prompt-----------------
     local GroupsClass = {}
-    GroupsClass.PromptGroup = GetRandomIntInRange(0, 0xffffff)
+    GroupsClass.PromptGroup = CheckVar(groupId, GetRandomIntInRange(0, 0xffffff))
     ----------------- ----------------- ----------------- ----------------- ----------
 
     ----------------- PromptGroup Specific APIs below -----------------
     function GroupsClass:ShowGroup(text)
-        PromptSetActiveGroupThisFrame(self.PromptGroup, CreateVarString(10, 'LITERAL_STRING', CheckVar(text, 'Prompt Info')))
+        PromptSetActiveGroupThisFrame(self.PromptGroup,
+            CreateVarString(10, 'LITERAL_STRING', CheckVar(text, 'Prompt Info')))
     end
 
-
     function GroupsClass:RegisterPrompt(title, button, enabled, visible, pulsing, mode, options)
-        
         ----------------- Setup Prompt class and add attributes to prompt-----------------
         local PromptClass = {}
         PromptClass.Prompt = PromptRegisterBegin()
@@ -34,7 +33,8 @@ function PromptsAPI:SetupPromptGroup()
 
         if mode == 'hold' then
             -- Posible hashes SHORT_TIMED_EVENT_MP, SHORT_TIMED_EVENT, MEDIUM_TIMED_EVENT, LONG_TIMED_EVENT, RUSTLING_CALM_TIMING, PLAYER_FOCUS_TIMING, PLAYER_REACTION_TIMING
-            Citizen.InvokeNative(0x74C7D7B72ED0D3CF, PromptClass.Prompt, CheckVar(options and options.timedeventhash, 'MEDIUM_TIMED_EVENT')) -- PromptSetStandardizedHoldMode
+            Citizen.InvokeNative(0x74C7D7B72ED0D3CF, PromptClass.Prompt,
+                CheckVar(options and options.timedeventhash, 'MEDIUM_TIMED_EVENT')) -- PromptSetStandardizedHoldMode
         end
 
         if mode == 'mash' then
@@ -43,15 +43,16 @@ function PromptsAPI:SetupPromptGroup()
 
         if mode == 'timed' then
             print('timed mode set!')
-            Citizen.InvokeNative(0x1473D3AF51D54276, PromptClass.Prompt, CheckVar(options and options.depletiontime, 10000))
+            Citizen.InvokeNative(0x1473D3AF51D54276, PromptClass.Prompt,
+                CheckVar(options and options.depletiontime, 10000))
         end
 
         PromptSetGroup(PromptClass.Prompt, self.PromptGroup)
         Citizen.InvokeNative(0xC5F428EE08FA7F2C, PromptClass.Prompt, CheckVar(pulsing, true))
         PromptRegisterEnd(PromptClass.Prompt)
-    
+
         ----------------- Prompt Specific APIs below -----------------
-         function PromptClass:TogglePrompt(toggle)
+        function PromptClass:TogglePrompt(toggle)
             PromptSetVisible(self.Prompt, toggle)
         end
 
@@ -67,26 +68,26 @@ function PromptsAPI:SetupPromptGroup()
             if self.Mode == 'click' then
                 return Citizen.InvokeNative(0xC92AC953F0A982AE, self.Prompt) --UiPromptHasStandardModeCompleted
             end
-    
+
             if self.Mode == 'hold' or self.Mode == 'customhold' then
                 local result = Citizen.InvokeNative(0xE0F65F0640EF0617, self.Prompt) --UiPromptHasHoldModeCompleted
 
-                if result then 
-                    Wait(500) --Prevents the spamming of the result (ensures it only gets triggered 1 time)
-                end
-    
-                return result
-            end
-    
-            if self.Mode == 'mash' then
-                local result = Citizen.InvokeNative(0x845CE958416DC473, self.Prompt) --UiPromptHasMashModeCompleted
-                if result then 
+                if result then
                     Wait(500) --Prevents the spamming of the result (ensures it only gets triggered 1 time)
                 end
 
                 return result
             end
-    
+
+            if self.Mode == 'mash' then
+                local result = Citizen.InvokeNative(0x845CE958416DC473, self.Prompt) --UiPromptHasMashModeCompleted
+                if result then
+                    Wait(500)                                                        --Prevents the spamming of the result (ensures it only gets triggered 1 time)
+                end
+
+                return result
+            end
+
             if self.Mode == 'timed' then
                 local result = Citizen.InvokeNative(0x3CE854D250A88DAF, self.Prompt) --UiPromptHasPressedTimedModeCompleted
 
@@ -103,17 +104,17 @@ function PromptsAPI:SetupPromptGroup()
             if self.Mode == 'click' or self.Mode == 'hold' or self.Mode == 'customhold' then
                 return false
             end
-    
+
             if self.Mode == 'mash' then
                 local result = Citizen.InvokeNative(0x25B18E530CF39D6F, self.Prompt) --UiPromptHasMashModeFailed
 
                 if result then
                     self:TogglePrompt(false)
                 end
-    
+
                 return result
             end
-    
+
             if self.Mode == 'timed' then
                 local result = Citizen.InvokeNative(0x1A17B9ECFF617562, self.Prompt) --UiPromptHasPressedTimedModeFailed
 


### PR DESCRIPTION
Used when creating prompts for targeting. This is optional. Leaving the promptGroupId out will result in a random Prompt Group.

```lua
local promptGroupId = Citizen.InvokeNative(0xB796970BD125FCE8, targetEntity) -- PromptGetGroupIdForTargetEntity
   
local  PromptGroup = feather.Prompt:SetupPromptGroup(promptGroupId)
-- Build rest of the prompt here
```