### PR TITLE
nameChecking

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -10,4 +10,10 @@ function RunCore()
 
     ClientReady = true
 end
-RunCore()
+
+if GetCurrentResourceName() ~= "feather-core" then
+    print("ERROR feather-core failed to load if you are a player report this to the server owner, if you are the server owner Feather Core resource must be named feather-core")
+    print("Feather Core faled to load.")
+else
+    RunCore()
+end

--- a/client/main.lua
+++ b/client/main.lua
@@ -12,8 +12,7 @@ function RunCore()
 end
 
 if GetCurrentResourceName() ~= "feather-core" then
-    print("ERROR feather-core failed to load if you are a player report this to the server owner, if you are the server owner Feather Core resource must be named feather-core")
-    print("Feather Core faled to load.")
+    error("ERROR feather-core failed to load if you are a player report this to the server owner, if you are the server owner Feather Core resource must be named feather-core")
 else
     RunCore()
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -7,8 +7,7 @@ function RunCore()
 end
 
 if GetCurrentResourceName() ~= "feather-core" then
-    print("ERROR, resource must be named feather-core otherwise Feather Core will not work properly")
-    print("Feather Core failed to load.")
+    error("ERROR feather-core failed to load, resource must be named feather-core otherwise Feather Core will not work properly")
 else
     RunCore()
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,4 +6,9 @@ function RunCore()
     SetupPlayerEvents()
 end
 
-RunCore()
+if GetCurrentResourceName() ~= "feather-core" then
+    print("ERROR, resource must be named feather-core otherwise Feather Core will not work properly")
+    print("Feather Core failed to load.")
+else
+    RunCore()
+end


### PR DESCRIPTION
- Resource name checking added
- # What this will do
Alot of people tend to rename our scripts from thier original name for example feather-core to feather_core which will break exports since  exports are sensitive to the resource name. This just ensures that if you change the name of feather-core and try to run it it will not run and will print the error in the console. 