### PR TITLE
Add LuaLS IntelliSense config (.luarc.json + generated native stubs)

### DIFF
--- a/.luals/cfx-runtime.lua
+++ b/.luals/cfx-runtime.lua
@@ -1,0 +1,173 @@
+---@meta
+
+-- CFX (RedM/FiveM) Lua scripting-runtime globals -- not RDR3 game natives
+-- (those are in redm-natives.lua alongside this file), but the scheduler/
+-- event/resource primitives every CFX resource is built on. Verified
+-- against citizenfx/fivem (data/shared/citizen/scripting/lua/scheduler.lua
+-- and friends) during the Feather Framework security audit, not guessed.
+--
+-- This file only declares signatures for LuaLS's benefit -- it has no
+-- runtime effect and is never loaded by the game.
+
+---@param cb fun()
+function CreateThread(cb) end
+
+---@param ms number
+function Wait(ms) end
+
+---@param eventName string
+---@param cb function
+function RegisterNetEvent(eventName, cb) end
+
+---@param eventName string
+---@param cb function
+function RegisterServerEvent(eventName, cb) end
+
+---@param eventName string
+---@param cb function
+---@return function handler
+function AddEventHandler(eventName, cb) end
+
+---@param eventName string
+---@param handler function
+function RemoveEventHandler(eventName, handler) end
+
+---@param eventName string
+---@param ... any
+function TriggerEvent(eventName, ...) end
+
+---@param eventName string
+---@param ... any
+function TriggerServerEvent(eventName, ...) end
+
+---@param eventName string
+---@param target number
+---@param ... any
+function TriggerClientEvent(eventName, target, ...) end
+
+function CancelEvent() end
+
+---@param commandName string
+---@param cb fun(source: number, args: string[], rawCommand: string)
+---@param restricted? boolean
+function RegisterCommand(commandName, cb, restricted) end
+
+---@param resourceName string
+---@return table
+function exports(resourceName) end
+
+---@return number
+function GetGameTimer() end
+
+---@return number
+function GetNetworkTimer() end
+
+---@return string
+function GetCurrentResourceName() end
+
+---@return string|nil
+function GetInvokingResource() end
+
+---@param resourceName string
+---@return string
+function GetResourceState(resourceName) end
+
+---@return boolean
+function IsDuplicityVersion() end
+
+---@param url string
+---@param cb fun(statusCode: number, resultData: string, resultHeaders: table)
+---@param method? string
+---@param data? string
+---@param headers? table
+function PerformHttpRequest(url, cb, method, data, headers) end
+
+---@param model string
+---@return number
+function GetHashKey(model) end
+
+---@param s string
+---@return number
+function joaat(s) end
+
+---@return number
+function PlayerPedId() end
+
+---@param player number|string
+---@return number
+function GetPlayerPed(player) end
+
+---@return number
+function PlayerId() end
+
+---@return table
+function GetPlayers() end
+
+---@param netId number
+---@return number
+function NetworkGetEntityFromNetworkId(netId) end
+
+---@param entity number
+---@return number
+function NetworkGetNetworkIdFromEntity(entity) end
+
+---@param entity number
+---@return number
+function ObjToNet(entity) end
+
+---@param netId number
+---@return number
+function NetToObj(netId) end
+
+---@param name string
+---@return userdata
+function Player(name) end
+
+---@param entity number
+---@return userdata
+function Entity(entity) end
+
+Citizen = {}
+
+---@param hash number
+---@param ... any
+---@return any
+function Citizen.InvokeNative(hash, ...) end
+
+---@param cb fun()
+function Citizen.CreateThread(cb) end
+
+---@param cb fun()
+function Citizen.CreateThreadNow(cb) end
+
+---@param ms number
+function Citizen.Wait(ms) end
+
+---@param msg string
+function Citizen.Trace(msg) end
+
+json = {}
+
+---@param value any
+---@return string
+function json.encode(value) end
+
+---@param str string
+---@return any
+function json.decode(str) end
+
+---@type number Set by the scheduler for the duration of a networked event
+---handler; do not read after a yield (see the audit's §1.1 runtime note --
+---capture it into a local on the handler's first line instead).
+source = nil
+
+---@class vector3
+---@field x number
+---@field y number
+---@field z number
+
+---@param x number
+---@param y number
+---@param z number
+---@return vector3
+function vector3(x, y, z) end

--- a/.luals/generate-redm-natives.js
+++ b/.luals/generate-redm-natives.js
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// Generates LuaLS ---@meta stub files (one per native namespace) from the
+// redm-natives skill's rdr3-nativedb-data (references/natives.json).
+//
+// Usage: node generate_natives.js <path-to-natives.json> <output-dir>
+//
+// Naming: the Lua-callable global for a native is derived from its
+// SCREAMING_SNAKE_CASE name by PascalCasing each underscore-separated
+// segment (SET_ENTITY_COORDS -> SetEntityCoords), preserving a leading
+// underscore if the native's own name has one (_GET_MAP_ZONE_AT_COORDS ->
+// _GetMapZoneAtCoords -- CFX's convention for natives without a confirmed
+// official name, ~60% of the RDR3 set). This transform was spot-checked
+// against every native this framework's own audited codebases actually
+// call by name and matched all of them (TaskPlayAnim, SetEntityAlpha,
+// GiveWeaponToPed, IsEntityDead, GetEntityCoords, SetEntityCoords, ...) --
+// but it is a derived name, not data straight from the DB, so treat any
+// stub that doesn't resolve/autocomplete as a signal to double-check via
+// the redm-natives skill or fall back to Citizen.InvokeNative(hash, ...).
+//
+// Pointer param types (Entity*, BOOL*, int*, etc. -- NOT char*/const char*,
+// which are strings) are CFX out-params: the Lua runtime does not take them
+// as call arguments, it returns them as additional values after the
+// primary return. This generator moves them from @param to @return
+// accordingly, in declared order.
+
+const fs = require('fs');
+const path = require('path');
+
+const LUA_KEYWORDS = new Set([
+  'and', 'break', 'do', 'else', 'elseif', 'end', 'false', 'for', 'function',
+  'goto', 'if', 'in', 'local', 'nil', 'not', 'or', 'repeat', 'return',
+  'then', 'true', 'until', 'while',
+]);
+
+// ~26% of RDR3 natives have no confirmed name at all -- their "name" field
+// is just their own hash (optionally underscore-prefixed), e.g.
+// "_0x4B6C9A43F7D9109B". PascalCasing that produces garbage
+// (_0x4b6c9a43f7d9109b, mixed-case hex, not a real identifier). CFX's own
+// convention for these is to expose them as N_0x<HASH> -- use that instead
+// of attempting a word-segment transform on something that isn't words.
+function toLuaName(nativeName, hash) {
+  const bare = nativeName.replace(/^_/, '');
+  if (/^0x[0-9A-Fa-f]+$/i.test(bare)) {
+    return 'N_' + hash;
+  }
+
+  let leading = '';
+  let rest = nativeName;
+  if (rest.startsWith('_')) {
+    leading = '_';
+    rest = rest.slice(1);
+  }
+  const pascal = rest
+    .split('_')
+    .filter(Boolean)
+    .map((seg) => seg[0].toUpperCase() + seg.slice(1).toLowerCase())
+    .join('');
+  return leading + pascal;
+}
+
+function baseLuaType(rawType) {
+  const t = (rawType || '').trim();
+  if (t === 'char*' || t === 'const char*') return 'string';
+  const stripped = t.replace(/\*$/, '');
+  const map = {
+    Any: 'any',
+    AnimScene: 'number',
+    BOOL: 'boolean',
+    Blip: 'number',
+    Cam: 'number',
+    Entity: 'number',
+    FireId: 'number',
+    Hash: 'number',
+    Interior: 'number',
+    ItemSet: 'number',
+    Object: 'number',
+    Ped: 'number',
+    PersChar: 'number',
+    Pickup: 'number',
+    Player: 'number',
+    PopZone: 'number',
+    Prompt: 'number',
+    PropSet: 'number',
+    ScrHandle: 'number',
+    Vector3: 'vector3',
+    Vehicle: 'number',
+    Volume: 'number',
+    int: 'number',
+    float: 'number',
+    void: 'nil',
+  };
+  return map[stripped] || 'any';
+}
+
+function isOutParam(rawType) {
+  const t = (rawType || '').trim();
+  if (t === 'char*' || t === 'const char*') return false;
+  return t.endsWith('*');
+}
+
+function safeParamName(name, usedNames) {
+  let n = (name || 'arg').replace(/[^A-Za-z0-9_]/g, '_');
+  if (/^[0-9]/.test(n)) n = '_' + n;
+  if (LUA_KEYWORDS.has(n)) n = n + '_';
+  if (n === '') n = 'arg';
+  let candidate = n;
+  let i = 2;
+  while (usedNames.has(candidate)) {
+    candidate = n + i;
+    i++;
+  }
+  usedNames.add(candidate);
+  return candidate;
+}
+
+function commentBlock(text, indent) {
+  if (!text) return [];
+  return text
+    .split('\n')
+    .map((line) => `${indent}-- ${line}`);
+}
+
+function generateEntry(namespace, hash, entry, usedNamesInFile) {
+  const luaName = toLuaName(entry.name, hash);
+  if (usedNamesInFile.has(luaName)) {
+    return { skipped: true, luaName };
+  }
+  usedNamesInFile.add(luaName);
+
+  const usedParamNames = new Set();
+  const inParams = [];
+  const outTypes = [];
+
+  for (const p of entry.params || []) {
+    if (isOutParam(p.type)) {
+      outTypes.push(baseLuaType(p.type));
+    } else {
+      inParams.push({ name: safeParamName(p.name, usedParamNames), type: baseLuaType(p.type) });
+    }
+  }
+
+  const returns = [];
+  if (entry.return_type && entry.return_type !== 'void') {
+    returns.push(baseLuaType(entry.return_type));
+  }
+  returns.push(...outTypes);
+
+  const lines = [];
+  lines.push(`-- ${entry.name}  (${hash})`);
+  if (entry.comment) lines.push(...commentBlock(entry.comment, ''));
+  if (entry.build) lines.push(`-- min build: ${entry.build}`);
+  for (const p of inParams) lines.push(`---@param ${p.name} ${p.type}`);
+  for (const r of returns) lines.push(`---@return ${r}`);
+  const paramList = inParams.map((p) => p.name).join(', ');
+  lines.push(`function ${luaName}(${paramList}) end`);
+  lines.push('');
+
+  return { skipped: false, text: lines.join('\n') };
+}
+
+function main() {
+  const [, , dataPath, outDir] = process.argv;
+  if (!dataPath || !outDir) {
+    console.error('Usage: node generate_natives.js <natives.json> <output-dir>');
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  let totalNatives = 0;
+  let totalSkipped = 0;
+  const namespaceSummaries = [];
+
+  for (const ns of Object.keys(data).sort()) {
+    const natives = data[ns];
+    const usedNamesInFile = new Set();
+    const chunks = [];
+    chunks.push('---@meta');
+    chunks.push('');
+    chunks.push(`-- RDR3 namespace: ${ns} -- generated from rdr3-nativedb-data, do not hand-edit.`);
+    chunks.push('-- Regenerate via generate_natives.js if the source natives.json is updated.');
+    chunks.push('');
+
+    const hashes = Object.keys(natives).sort((a, b) => {
+      const na = natives[a].name || '';
+      const nb = natives[b].name || '';
+      return na.localeCompare(nb);
+    });
+
+    let count = 0;
+    let skipped = 0;
+    for (const h of hashes) {
+      const entry = natives[h];
+      const result = generateEntry(ns, h, entry, usedNamesInFile);
+      if (result.skipped) {
+        skipped++;
+        continue;
+      }
+      chunks.push(result.text);
+      count++;
+    }
+
+    const outPath = path.join(outDir, `${ns}.lua`);
+    fs.writeFileSync(outPath, chunks.join('\n'), 'utf8');
+    totalNatives += count;
+    totalSkipped += skipped;
+    namespaceSummaries.push({ ns, count, skipped });
+  }
+
+  console.log(`Generated ${Object.keys(data).length} namespace files, ${totalNatives} natives, ${totalSkipped} name collisions skipped.`);
+  for (const s of namespaceSummaries) {
+    if (s.skipped > 0) console.log(`  ${s.ns}: ${s.count} written, ${s.skipped} skipped (duplicate derived name)`);
+  }
+}
+
+main();

--- a/.luals/oxmysql.lua
+++ b/.luals/oxmysql.lua
@@ -1,0 +1,78 @@
+---@meta
+
+-- oxmysql (overextended/oxmysql) -- every server_scripts manifest in this
+-- framework pulls in `@oxmysql/lib/MySQL.lua`, which defines this global at
+-- runtime. It lives in a separate resource, so LuaLS can't see its
+-- definition from inside this repo without this stub. Only `.await` methods
+-- are currently used in this codebase (verified by grep); the rest of
+-- oxmysql's documented API is included for completeness since this file's
+-- only job is describing an external library's shape.
+
+---@class MySQLQueryResult
+---@field affectedRows number
+---@field insertId number
+
+MySQL = {}
+
+---@param query string
+---@param parameters? table
+---@param cb? fun(result: table)
+MySQL.query = function(query, parameters, cb) end
+---@param query string
+---@param parameters? table
+---@return table
+MySQL.query.await = function(query, parameters) end
+
+---@param query string
+---@param parameters? table
+---@param cb? fun(result: table)
+MySQL.single = function(query, parameters, cb) end
+---@param query string
+---@param parameters? table
+---@return table|nil
+MySQL.single.await = function(query, parameters) end
+
+---@param query string
+---@param parameters? table
+---@param cb? fun(result: any)
+MySQL.scalar = function(query, parameters, cb) end
+---@param query string
+---@param parameters? table
+---@return any
+MySQL.scalar.await = function(query, parameters) end
+
+---@param query string
+---@param parameters? table
+---@param cb? fun(insertId: number)
+MySQL.insert = function(query, parameters, cb) end
+---@param query string
+---@param parameters? table
+---@return number insertId
+MySQL.insert.await = function(query, parameters) end
+
+---@param query string
+---@param parameters? table
+---@param cb? fun(affectedRows: number)
+MySQL.update = function(query, parameters, cb) end
+---@param query string
+---@param parameters? table
+---@return number affectedRows
+MySQL.update.await = function(query, parameters) end
+
+---@param query string
+---@param parameters? table
+---@param cb? fun(affectedRows: number)
+MySQL.rawExecute = function(query, parameters, cb) end
+---@param query string
+---@param parameters? table
+MySQL.rawExecute.await = function(query, parameters) end
+
+---@param queries table
+---@param cb? fun(success: boolean)
+MySQL.transaction = function(queries, cb) end
+---@param queries table
+---@return boolean
+MySQL.transaction.await = function(queries) end
+
+---@param cb fun()
+MySQL.ready = function(cb) end

--- a/.luals/redm-natives/AICOVERPOINT.lua
+++ b/.luals/redm-natives/AICOVERPOINT.lua
@@ -1,0 +1,108 @@
+---@meta
+
+-- RDR3 namespace: AICOVERPOINT -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x140B3CB1D424A945  (0x140B3CB1D424A945)
+-- weaponHash can also be -1
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+function N_0x140B3CB1D424A945(ped, weaponHash) end
+
+-- _0x3C7A9C2C953128FE  (0x3C7A9C2C953128FE)
+-- min build: 1207
+---@param ped number
+function N_0x3C7A9C2C953128FE(ped) end
+
+-- _0x53E4D0C079CA6855  (0x53E4D0C079CA6855)
+-- min build: 1207
+---@param handle number
+---@return number
+function N_0x53E4D0C079CA6855(handle) end
+
+-- _0x64340DC208D671D5  (0x64340DC208D671D5)
+-- coverLayer: see levels_0/levels/rdr3/coverlayers
+-- min build: 1207
+---@param coverLayer string
+function N_0x64340DC208D671D5(coverLayer) end
+
+-- _0x7A1FDCF35EAA140F  (0x7A1FDCF35EAA140F)
+-- coverLayer: see levels_0/levels/rdr3/coverlayers
+-- min build: 1207
+---@param coverLayer string
+function N_0x7A1FDCF35EAA140F(coverLayer) end
+
+-- _0x957D7E750216D74B  (0x957D7E750216D74B)
+-- min build: 1207
+---@param ped number
+---@return number
+function N_0x957D7E750216D74B(ped) end
+
+-- _0xEBA51A294C73292E  (0xEBA51A294C73292E)
+-- min build: 1207
+---@return any
+function N_0xEBA51A294C73292E() end
+
+-- _ADD_COVER_BLOCKING_AREA  (0x733077295AB51304)
+-- args: f_0 = Volume Handle
+-- f_1 = integer (?) (only the number 1 is ever used here, or is not used at all)
+-- f_2 = integer (-1 to 32 in R* Scripts)
+-- min build: 1207
+---@return any
+function _AddCoverBlockingArea() end
+
+-- _ADD_SCRIPTED_COVER_POINT  (0x975BD6351648935F)
+-- min build: 1207
+---@return number
+---@return any
+function _AddScriptedCoverPoint() end
+
+-- _ARE_LOAD_COVER_ANIMS_LOADED  (0x8CBE916CFC64AD5C)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _AreLoadCoverAnimsLoaded(ped) end
+
+-- _DOES_COVER_POINT_EXIST  (0xC276FE69DDA22BAD)
+-- min build: 1207
+---@param handle number
+---@return boolean
+function _DoesCoverPointExist(handle) end
+
+-- _GET_COVER_POINT_STATE_FROM_PED  (0x5F5B1B7E8E8F94C6)
+-- 1 = In cover while crouched
+-- 2 = In cover while standing
+-- 3 = Not in cover
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetCoverPointStateFromPed(ped) end
+
+-- _REQUEST_FLINCH_COVER_ANIM  (0x2A31D13C5F021D0D)
+-- Makes ped flinch (if in cover) like they have been shot at
+-- min build: 1207
+---@param ped number
+function _RequestFlinchCoverAnim(ped) end
+
+-- _STOP_RUNNING_COVER_ANIMS  (0x1A7A802B2301EDC0)
+-- Stops running cover anims and releases them
+-- _STOP_RENDERING_* - _STOP_SCRIPTED*
+-- min build: 1207
+---@param ped number
+function _StopRunningCoverAnims(ped) end
+
+-- _TASK_AI_SEEK_COVER_TO_COVER_POINT  (0x89783FDDF079C88D)
+-- min build: 1207
+---@return any
+function _TaskAiSeekCoverToCoverPoint() end
+
+-- TASK_ENTER_COVER  (0x4972A022AE6DAFA1)
+-- min build: 1207
+---@param ped number
+function TaskEnterCover(ped) end
+
+-- TASK_EXIT_COVER  (0x2BC4A6D92D140112)
+-- min build: 1207
+---@param ped number
+function TaskExitCover(ped) end

--- a/.luals/redm-natives/AITRANSPORT.lua
+++ b/.luals/redm-natives/AITRANSPORT.lua
@@ -1,0 +1,241 @@
+---@meta
+
+-- RDR3 namespace: AITRANSPORT -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x4B6C9A43F7D9109B  (0x4B6C9A43F7D9109B)
+-- Used for ROWBOAT and ROWBOATSWAMP in R* Scripts
+-- _SET_IS_* - _SET_PED_*
+-- min build: 1207
+---@param transportVehicle number
+---@param p1 boolean
+function N_0x4B6C9A43F7D9109B(transportVehicle, p1) end
+
+-- _CLEAR_ALL_SEAT_PREFERENCE_SLOTS  (0x5639FBEA922788DA)
+-- min build: 1207
+---@param ped number
+function _ClearAllSeatPreferenceSlots(ped) end
+
+-- _CLEAR_TRANSPORT_EXIT_BLEND_RATIO  (0xF8C20282B237E3F7)
+-- Resets the value set by _SET_TRANSPORT_EXIT_BLEND_RATIO to 0.0f
+-- min build: 1207
+---@param ped number
+function _ClearTransportExitBlendRatio(ped) end
+
+-- _GET_PED_IN_TRANSPORT_SEAT  (0xFFEC4B0A1A3ED515)
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param transportEntity number
+---@param seatIndex number
+---@return number
+function _GetPedInTransportSeat(transportEntity, seatIndex) end
+
+-- _GET_TRANSPORT_USAGE_FLAGS  (0xE195C5A82156321D)
+-- See _SET_TRANSPORT_USAGE_FLAGS
+-- min build: 1207
+---@param transportEntity number
+---@return any
+---@return number
+function _GetTransportUsageFlags(transportEntity) end
+
+-- _IS_PED_ON_TRANSPORT_ENTITY  (0x159EF5B6EDCE00E8)
+-- Checks if ped is placed on target transportEntity
+-- min build: 1207
+---@param ped number
+---@param transportEntity number
+---@return boolean
+function _IsPedOnTransportEntity(ped, transportEntity) end
+
+-- _IS_PED_ON_TRANSPORT_SEAT  (0xDC44F405A6B98D03)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _IsPedOnTransportSeat(ped, p1) end
+
+-- _IS_TRANSPORT_SEAT_FREE  (0x43FF27FC1829C202)
+-- Called together with IS_VEHICLE_SEAT_FREE
+-- min build: 1207
+---@param transportEntity number
+---@param seatIndex number
+---@return boolean
+function _IsTransportSeatFree(transportEntity, seatIndex) end
+
+-- _IS_TRANSPORT_SEAT_OCCUPIED  (0x2E2E06023D07631E)
+-- min build: 1207
+---@param transportEntity number
+---@param seatIndex number
+---@return boolean
+function _IsTransportSeatOccupied(transportEntity, seatIndex) end
+
+-- _SET_AI_CAN_USE_TRANSPORT  (0x67F7CEAC2391E114)
+-- min build: 1207
+---@param transportEntity number
+---@param state boolean
+function _SetAiCanUseTransport(transportEntity, state) end
+
+-- _SET_PED_USE_TRANSPORT_SEAT_PREFERENCE  (0xB7079F4C72896756)
+-- min build: 1207
+---@param ped number
+---@param transportEntity number
+---@param preferenceSlot number
+---@param p3 number
+---@param seatIndex number
+function _SetPedUseTransportSeatPreference(ped, transportEntity, preferenceSlot, p3, seatIndex) end
+
+-- _SET_TRANSPORT_EXCLUSIVE_DRIVER  (0x4248AB2EEB3C75AD)
+-- min build: 1207
+---@param transportEntity number
+---@param ped number
+---@param seatIndex number
+function _SetTransportExclusiveDriver(transportEntity, ped, seatIndex) end
+
+-- _SET_TRANSPORT_EXIT_BLEND_RATIO  (0x8C8371EDFAF014A0)
+-- Exit/dismount speed/blend multiplier for the transport user ped.
+-- >0 enables override, 0 = off; only works while ped is a transport user.
+-- R* Script usage: rcm_doctors_opinion1 - immediately after TASK_EXIT_TRANSPORT(...), set to 0.8f.
+-- https://www.youtube.com/watch?v=FMeUNZbhjAc&t=15s
+-- min build: 1207
+---@param ped number
+---@param ratio number
+function _SetTransportExitBlendRatio(ped, ratio) end
+
+-- _SET_TRANSPORT_PRIORITY_SEAT  (0x13F138225C202F66)
+-- min build: 1207
+---@param transportEntity number
+---@param seatIndex number
+function _SetTransportPrioritySeat(transportEntity, seatIndex) end
+
+-- _SET_TRANSPORT_USAGE_FLAGS  (0xE2487779957FE897)
+-- enum eTransportUsageFlags
+-- {
+-- 	TUF_INVALID = 0,
+-- 	TUF_ALLOW_DRIVER_ME = (1 << 0),
+-- 	TUF_ALLOW_DRIVER_GANG = (1 << 1),
+-- 	TUF_ALLOW_DRIVER_CREW = (1 << 2),
+-- 	TUF_ALLOW_DRIVER_FRIENDS = (1 << 3),
+-- 	TUF_ALLOW_DRIVER_ANYONE = (1 << 4),
+-- 	TUF_ALLOW_PASSENGER_ME = (1 << 5),
+-- 	TUF_ALLOW_PASSENGER_GANG = (1 << 6),
+-- 	TUF_ALLOW_PASSENGER_CREW = (1 << 7),
+-- 	TUF_ALLOW_PASSENGER_FRIENDS = (1 << 8),
+-- 	TUF_ALLOW_PASSENGER_ANYONE = (1 << 9),
+-- 	TUF_ALLOW_ACCESS_AI = (1 << 10)
+-- };
+-- min build: 1207
+---@param transportEntity number
+---@param flags number
+function _SetTransportUsageFlags(transportEntity, flags) end
+
+-- GET_TRANSPORT_CONFIG_FLAG  (0xF382C92CCC1CCDBC)
+-- flagId: see SET_TRANSPORT_CONFIG_FLAG
+-- min build: 1207
+---@param transportEntity number
+---@param flagId number
+---@param p2 boolean
+---@return boolean
+function GetTransportConfigFlag(transportEntity, flagId, p2) end
+
+-- IS_PED_ENTERING_TRANSPORT  (0x619E63980BFC0096)
+-- min build: 1207
+---@param ped number
+---@param transportEntity number
+---@param p2 boolean
+---@return boolean
+function IsPedEnteringTransport(ped, transportEntity, p2) end
+
+-- IS_PED_EXITING_TRANSPORT  (0x660639BC60157048)
+-- min build: 1207
+---@param ped number
+---@param transportEntity number
+---@return boolean
+function IsPedExitingTransport(ped, transportEntity) end
+
+-- SET_PED_OFF_TRANSPORT_SEAT  (0x8886D83A430537FD)
+-- min build: 1207
+---@param ped number
+---@param flags number
+function SetPedOffTransportSeat(ped, flags) end
+
+-- SET_PED_ON_TRANSPORT_SEAT  (0xE588B5A8A005CB5E)
+-- seat: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param ped number
+---@param transportEntity number
+---@param seat number
+---@param flags number
+function SetPedOnTransportSeat(ped, transportEntity, seat, flags) end
+
+-- SET_TRANSPORT_ACCESSIBLE_SEAT_FLAGS  (0xDD0660C997DE94FD)
+-- min build: 1207
+---@param transportEntity number
+---@param flags number
+function SetTransportAccessibleSeatFlags(transportEntity, flags) end
+
+-- SET_TRANSPORT_CONFIG_FLAG  (0xBA8818212633500A)
+-- flagId:
+-- enum eTransportConfigFlags
+-- {
+-- 	TCF_NotConsideredForEntryByLocalPlayer,
+-- 	TCF_0xB78D6624,
+-- 	TCF_0xA9700425,
+-- 	TCF_0x8D7E4641,
+-- 	TCF_0xF24BAA1F,
+-- 	TCF_0x63B77935,
+-- 	TCF_NotConsideredForEntryByAllPlayers,
+-- 	TCF_0xD17A2AFD,
+-- 	TCF_0xD4E4FDD5,
+-- 	TCF_0x8227C929,
+-- 	TCF_0x812C1070,
+-- 	TCF_0x0E1AB26F,
+-- 	TCF_0xBF4EC863,
+-- 	TCF_0x75660C36,
+-- 	TCF_0xA2539E20,
+-- 	TCF_0x9162C633,
+-- 	TCF_DisableHonorModifiers,
+-- 	TCF_0xF9E71CB6,
+-- 	TCF_0x933ECD3F,
+-- 	TCF_0x18513A34
+-- };
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/TRANSPORT_CONFIG_FLAGS
+-- min build: 1207
+---@param transportEntity number
+---@param flagId number
+---@param value boolean
+function SetTransportConfigFlag(transportEntity, flagId, value) end
+
+-- TASK_ENTER_TRANSPORT  (0xAEE3ADD08829CB6F)
+-- Request a ped to enter/join a transport seat. args is a script struct<9> (72 bytes); each field is 8-byte (alignas(8)).
+-- 
+-- struct TaskEnterTransportArgs
+-- {
+-- 	alignas(8) Any     p0;        // unused/reserved in observed scripts
+-- 	alignas(8) Any     p1;        // unused/reserved in observed scripts
+-- 	alignas(8) Any     p2;        // unused/reserved in observed scripts
+-- 	alignas(8) Ped     ped;       // performing ped
+-- 	alignas(8) Vehicle vehicle;   // target transport
+-- 	alignas(8) int     seatIndex; // seat to join (scripts use -1 or explicit seat)
+-- 	alignas(8) int     timeoutMs; // time until forced join/teleport (commonly 20000)
+-- 	alignas(8) float   pedSpeed;  // blend/speed
+-- 	alignas(8) int     flags;     // seen values: (1<<30), 1, 16, 1048578 (usage unclear)
+-- };
+-- min build: 1207
+---@return any
+function TaskEnterTransport() end
+
+-- TASK_EXIT_TRANSPORT  (0xC273A5B8488F7838)
+-- Request a ped to exit a transport. args is a script struct<7> (56 bytes); each field is 8-byte (alignas(8)).
+-- 
+-- struct TaskExitTransportArgs
+-- {
+-- 	alignas(8) Any     p0;       // unused/reserved in observed scripts
+-- 	alignas(8) Any     p1;       // unused/reserved in observed scripts
+-- 	alignas(8) Any     p2;       // unused/reserved in observed scripts
+-- 	alignas(8) Ped     ped;      // performing ped (e.g. PLAYER_PED_ID())
+-- 	alignas(8) Vehicle vehicle;  // transport to exit (vehicle or mount entity handle)
+-- 	alignas(8) float   pedSpeed; // blend/speed
+-- 	alignas(8) int     flags;    // seen values: (1<<30) and 1 (usage unclear)
+-- };
+-- min build: 1207
+---@return any
+function TaskExitTransport() end

--- a/.luals/redm-natives/ANIMSCENE.lua
+++ b/.luals/redm-natives/ANIMSCENE.lua
@@ -1,0 +1,704 @@
+---@meta
+
+-- RDR3 namespace: ANIMSCENE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x1407F5115FB9583E  (0x1407F5115FB9583E)
+-- Used in SP R* Scripts only
+-- Params: p1 = 2B-LowHonor, 2A-HighHonor
+-- min build: 1207
+---@param animScene number
+---@param p1 string
+---@return boolean
+function N_0x1407F5115FB9583E(animScene, p1) end
+
+-- _0x1AD896BF43619551  (0x1AD896BF43619551)
+-- Used in braithwaites2 SP R* Scripts only
+-- _A*
+-- min build: 1207
+function N_0x1AD896BF43619551() end
+
+-- _0x1C5D33A4293E6DDE  (0x1C5D33A4293E6DDE)
+-- Used in SP R* Scripts only
+-- _IS_ANIM_SCENE_P*
+-- min build: 1207
+---@param animScene number
+---@param phaseName string
+---@return boolean
+function N_0x1C5D33A4293E6DDE(animScene, phaseName) end
+
+-- _0x2DB524750DC41ED4  (0x2DB524750DC41ED4)
+-- Used in SP R* Scripts only
+-- _IS_PED_* - _IS_SC*
+-- min build: 1207
+---@return boolean
+function N_0x2DB524750DC41ED4() end
+
+-- _0x3641FCD53E59B335  (0x3641FCD53E59B335)
+-- p2: MINIGAME_GET_SECONDARY_VOICE_STRING
+-- _SET_*
+-- min build: 1207
+---@param mgmHandle number
+---@param ped number
+---@param secondaryVoiceString string
+function N_0x3641FCD53E59B335(mgmHandle, ped, secondaryVoiceString) end
+
+-- _0x3B393716C3FD8237  (0x3B393716C3FD8237)
+-- Used in SP R* Scripts only
+-- _IS_*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x3B393716C3FD8237(ped) end
+
+-- _0x4B85B3CF91972222  (0x4B85B3CF91972222)
+-- Used in Script Function CUTSCENE_MANAGE_SKIP
+-- _CHECK_* (?)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function N_0x4B85B3CF91972222(animScene) end
+
+-- _0x5D7BFDA2290B4E39  (0x5D7BFDA2290B4E39)
+-- Used in SP R* Scripts only
+-- _IS_ANIM_SCENE_R* - _IS_ANIM_SCENE_S*
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function N_0x5D7BFDA2290B4E39(p0) end
+
+-- _0x61B2AAEF645DDAF0  (0x61B2AAEF645DDAF0)
+-- Only used in tg_p R* Script
+-- Returns true when mgm event success
+-- _PREPARE_* - _REGISTER_*
+-- min build: 1207
+---@param mgmEventHandle number
+---@param p1 string
+---@param seatId number
+---@param p3 number
+---@param p4 boolean
+---@return boolean
+function N_0x61B2AAEF645DDAF0(mgmEventHandle, p1, seatId, p3, p4) end
+
+-- _0x73616E64696C132E  (0x73616E64696C132E)
+-- Used in SP R* Scripts only
+-- _CO* - _CR*
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function N_0x73616E64696C132E(animScene, p1) end
+
+-- _0x9AAE3C1148A09BCA  (0x9AAE3C1148A09BCA)
+-- Checks if AnimScene is aborted, and an unknown check. Usually used with 0x34A0671BE613D3D0
+-- Used in SP R* Scripts only
+-- _IS_ANIM_SCENE_*
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function N_0x9AAE3C1148A09BCA(animScene) end
+
+-- _0xA96619FE85159ED2  (0xA96619FE85159ED2)
+-- Checks if AnimScene is aborted, and an unknown check.
+-- Used in SP R* Scripts only
+-- _WAS_ANIM_SCENE_*
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function N_0xA96619FE85159ED2(animScene) end
+
+-- _0xAE6DE22DE0ED4554  (0xAE6DE22DE0ED4554)
+-- _UNLOAD_* - _WAS_ANIM_SCENE_*
+-- min build: 1207
+---@param mgmHandle number
+---@param ped number
+function N_0xAE6DE22DE0ED4554(mgmHandle, ped) end
+
+-- _0xB1A196BAFE650402  (0xB1A196BAFE650402)
+-- _PREPARE_* - _REGISTER_*
+-- min build: 1207
+---@param mgmHandle number
+---@param ped number
+function N_0xB1A196BAFE650402(mgmHandle, ped) end
+
+-- _0xC1193521E3B9FADD  (0xC1193521E3B9FADD)
+-- Used in SP R* Scripts only
+-- _RESUME_* - _SET_A*
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+function N_0xC1193521E3B9FADD(entity, p1) end
+
+-- _0xCDCD7B2D49AEE73A  (0xCDCD7B2D49AEE73A)
+-- Used in SP R* Scripts only
+-- _SET_P*
+-- min build: 1207
+---@param p0 boolean
+function N_0xCDCD7B2D49AEE73A(p0) end
+
+-- _0xD70C7A30412F8FA0  (0xD70C7A30412F8FA0)
+-- Checks if AnimScene is NOT aborted, and an unknown check. Usually used with ABORT_ANIM_SCENE
+-- Used in SP R* Scripts only
+-- _IS_ANIM_SCENE_*
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function N_0xD70C7A30412F8FA0(animScene) end
+
+-- _0xE12D7B4B959644CD  (0xE12D7B4B959644CD)
+-- Used in SP R* Scripts only
+-- _SET_B* - _SET_C*
+-- min build: 1207
+function N_0xE12D7B4B959644CD() end
+
+-- _0xEA41D44A8D42057B  (0xEA41D44A8D42057B)
+-- Used in SP R* Scripts only
+-- _PAUSE_* - _PLAY_*
+-- min build: 1207
+---@return boolean
+function N_0xEA41D44A8D42057B() end
+
+-- _CLEAR_ANIM_SCENE_WAS_SKIPPED  (0x8A8208AE92BF87A5)
+-- min build: 1207
+---@param animScene number
+function _ClearAnimSceneWasSkipped(animScene) end
+
+-- _CLEAR_BREAKOUT_ARCHETYPE  (0xBC781D24AA11F179)
+-- min build: 1207
+---@param ped number
+function _ClearBreakoutArchetype(ped) end
+
+-- _CREATE_ANIM_SCENE  (0x1FCA98E33C1437B3)
+-- flags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eAnimSceneFlag
+-- min build: 1207
+---@param animDict string
+---@param flags number
+---@param playbackListName string
+---@param p3 boolean
+---@param p4 boolean
+---@return number
+function _CreateAnimScene(animDict, flags, playbackListName, p3, p4) end
+
+-- _CREATE_MGM_SYSTEM  (0xA1300DE03E5D1973)
+-- Returns mgmHandle
+-- min build: 1207
+---@param mgmFilename string
+---@return number
+function _CreateMgmSystem(mgmFilename) end
+
+-- _DELETE_ANIM_SCENE  (0x84EEDB2C6E650000)
+-- min build: 1207
+---@param animScene number
+function _DeleteAnimScene(animScene) end
+
+-- _DELETE_MGM_SYSTEM  (0x53CB3970BA02E3CC)
+-- min build: 1207
+---@param mgmHandle number
+function _DeleteMgmSystem(mgmHandle) end
+
+-- _DOES_ANIM_SCENE_OWNERSHIP_OF_ENTITY_EXIST  (0x9D1ECA9337BE9FC3)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@return boolean
+function _DoesAnimSceneOwnershipOfEntityExist(animScene, entityName) end
+
+-- _DOES_ANIM_SCENE_PLAY_LIST_EXIST  (0xA9016536015DE29D)
+-- min build: 1207
+---@param animScene number
+---@param playbackListName string
+---@return boolean
+function _DoesAnimScenePlayListExist(animScene, playbackListName) end
+
+-- _DOES_ENTITY_WITH_ID_EXIST_IN_ANIM_SCENE  (0x6F1F0B17109309DA)
+-- min build: 1207
+---@param animScene number
+---@param entityId string
+---@return boolean
+function _DoesEntityWithIdExistInAnimScene(animScene, entityId) end
+
+-- _GET_ANIM_SCENE_DICT  (0xAE5ADA4FE3E21ADC)
+-- min build: 1207
+---@param animScene number
+---@return number
+function _GetAnimSceneDict(animScene) end
+
+-- _GET_ANIM_SCENE_DURATION  (0x49F1D143ADE32656)
+-- min build: 1207
+---@param animScene number
+---@return number
+function _GetAnimSceneDuration(animScene) end
+
+-- _GET_ANIM_SCENE_OBJECT  (0xFB5674687A1B2814)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@param isNetwork boolean
+---@return number
+function _GetAnimSceneObject(animScene, name, isNetwork) end
+
+-- _GET_ANIM_SCENE_PED  (0xE5822422197BBBA3)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@param isNetwork boolean
+---@return number
+function _GetAnimScenePed(animScene, name, isNetwork) end
+
+-- _GET_ANIM_SCENE_PLAYBACK_LIST_PHASE_AUDIO_LOAD_STRESS  (0x9E036D5204FFBBC8)
+-- min build: 1207
+---@param animScene number
+---@param phaseName string
+---@return number
+function _GetAnimScenePlaybackListPhaseAudioLoadStress(animScene, phaseName) end
+
+-- _GET_ANIM_SCENE_RATE  (0x43C21623E42B821B)
+-- min build: 1207
+---@param animScene number
+---@return number
+function _GetAnimSceneRate(animScene) end
+
+-- _GET_ANIM_SCENE_TIME  (0x61BE7D6186260002)
+-- min build: 1207
+---@param animScene number
+---@return number
+function _GetAnimSceneTime(animScene) end
+
+-- _GET_ANIM_SCENE_VEHICLE  (0x430EE0A19BC5A287)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@param isNetwork boolean
+---@return number
+function _GetAnimSceneVehicle(animScene, name, isNetwork) end
+
+-- _HAS_ENTITY_ENTERED_ANIM_SCENE  (0x337F1CC8EE895601)
+-- _HAS_L* (?)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@return boolean
+function _HasEntityEnteredAnimScene(animScene, entityName) end
+
+-- _IS_ANIM_SCENE_ABORTED  (0x34A0671BE613D3D0)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function _IsAnimSceneAborted(animScene) end
+
+-- _IS_ANIM_SCENE_LOADING  (0x59606519FF9D3EC2)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function _IsAnimSceneLoading(animScene, p1) end
+
+-- _IS_ANIM_SCENE_METADATA_ASSET_IN_RANGE_LOADING  (0xF8D1D2DAB6007EEF)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function _IsAnimSceneMetadataAssetInRangeLoading(animScene, p1) end
+
+-- _IS_ANIM_SCENE_PAUSED  (0x4B4038796F0D6566)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function _IsAnimScenePaused(animScene) end
+
+-- _IS_ANIM_SCENE_PLAYBACK_LIST_PHASE_ACTIVE  (0x1F0E401031E20146)
+-- min build: 1207
+---@param animScene number
+---@param phaseName string
+---@return boolean
+function _IsAnimScenePlaybackListPhaseActive(animScene, phaseName) end
+
+-- _IS_ANIM_SCENE_PLAYBACK_LIST_PHASE_LOADED  (0x23E33CB9F4A3F547)
+-- min build: 1207
+---@param animScene number
+---@param phaseName string
+---@return boolean
+function _IsAnimScenePlaybackListPhaseLoaded(animScene, phaseName) end
+
+-- _IS_ANIM_SCENE_PLAYBACK_LIST_PHASE_LOADING  (0x0DF57F86FE71DBE5)
+-- min build: 1207
+---@param animScene number
+---@param phaseName string
+---@return boolean
+function _IsAnimScenePlaybackListPhaseLoading(animScene, phaseName) end
+
+-- _IS_ANIM_SCENE_SKIPPABLE  (0x4CDFFE3189EBDBD0)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function _IsAnimSceneSkippable(animScene) end
+
+-- _IS_MGM_SYSTEM_LOADED  (0xFDFC14799373283F)
+-- MGM stands for MiniGameMoments.
+-- min build: 1207
+---@param mgmFilename string
+---@return boolean
+function _IsMgmSystemLoaded(mgmFilename) end
+
+-- _LOAD_MGM_ASSETS  (0xB727A847862CB00A)
+-- Used to request MiniGameMoments Assets.
+-- 
+-- mgmFilename's:
+-- Poker
+-- PokerArthur
+-- PokerArthurCamp
+-- PokerJohn
+-- PokerJohnCamp
+-- min build: 1207
+---@param mgmFilename string
+---@return boolean
+function _LoadMgmAssets(mgmFilename) end
+
+-- _PAUSE_SCRIPT_THREADS  (0x37C1257849DEF24A)
+-- Pauses all script threads except the one that called it.
+-- min build: 1207
+---@param toggle boolean
+function _PauseScriptThreads(toggle) end
+
+-- _RELEASE_ANIM_SCENE_PLAY_LIST  (0xAE6ADA8FE7E84ACC)
+-- min build: 1207
+---@param animScene number
+---@param playlistName string
+---@return boolean
+function _ReleaseAnimScenePlayList(animScene, playlistName) end
+
+-- _REQUEST_PHOTO_MODE_DEFREEZE  (0x41AFA5F228B0B6B0)
+-- min build: 1207
+function _RequestPhotoModeDefreeze() end
+
+-- _REQUEST_PHOTO_MODE_FREEZE  (0x7C709C01D43D94CD)
+-- min build: 1207
+function _RequestPhotoModeFreeze() end
+
+-- _SET_BREAKOUT_ARCHETYPE  (0x99B2A2E3655DEAF1)
+-- min build: 1207
+---@param ped number
+---@param archetype string
+function _SetBreakoutArchetype(ped, archetype) end
+
+-- _SET_MGM_EVENT  (0x07706C4CC9C6CC9E)
+-- min build: 1207
+---@param mgmEventHandle number
+---@param p1 string
+---@param seatId any
+---@param p3 number
+---@param p4 number
+function _SetMgmEvent(mgmEventHandle, p1, seatId, p3, p4) end
+
+-- ABORT_ANIM_SCENE  (0x718CF1328D20C2B3)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+function AbortAnimScene(animScene, p1) end
+
+-- ATTACH_ANIM_SCENE_TO_ENTITY  (0xDC418495DBA327A1)
+-- min build: 1207
+---@param animScene number
+---@param entity number
+---@param p2 number
+function AttachAnimSceneToEntity(animScene, entity, p2) end
+
+-- ATTACH_ANIM_SCENE_TO_ENTITY_PRESERVING_LOCATION  (0x1C0B105C3F30B88D)
+-- min build: 1207
+---@param animScene number
+---@param entity number
+---@param p2 number
+function AttachAnimSceneToEntityPreservingLocation(animScene, entity, p2) end
+
+-- BLOCK_ANIM_SCENE_FADING_NEXT_FRAME  (0x1B70811D3BF75DB9)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+function BlockAnimSceneFadingNextFrame(p0, p1) end
+
+-- CHECK_OWNERSHIP_OF_ANIM_SCENE  (0x661B8683611B9B97)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function CheckOwnershipOfAnimScene(animScene) end
+
+-- COULD_ANIM_SCENE_ENTITY_REACH_EXIT_NEXT_FRAME  (0x73616E64696C616E)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@param p2 any
+---@param p3 any
+---@return boolean
+function CouldAnimSceneEntityReachExitNextFrame(animScene, entityName, p2, p3) end
+
+-- DETACH_ANIM_SCENE  (0x6843A1AA3A336DFF)
+-- min build: 1207
+---@param animScene number
+function DetachAnimScene(animScene) end
+
+-- DETACH_ANIM_SCENE_PRESERVING_LOCATION  (0xA2507C4948C83D2E)
+-- min build: 1207
+---@param animScene number
+function DetachAnimScenePreservingLocation(animScene) end
+
+-- DOES_ANIM_SCENE_EXIST  (0x25557E324489393C)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function DoesAnimSceneExist(animScene) end
+
+-- FADE_ANIM_SCENE_AUDIO_IN  (0xA41351EA2A18A0AD)
+-- min build: 1207
+---@param animScene number
+---@param p1 number
+function FadeAnimSceneAudioIn(animScene, p1) end
+
+-- FADE_ANIM_SCENE_AUDIO_OUT  (0x323E3AD772BA5D57)
+-- min build: 1207
+---@param animScene number
+---@param p1 number
+function FadeAnimSceneAudioOut(animScene, p1) end
+
+-- GET_ANIM_SCENE_BOOL  (0x07A6F6447ECA9B64)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@return boolean
+function GetAnimSceneBool(animScene, name) end
+
+-- GET_ANIM_SCENE_CURRENT_ACTIVE_CAMERA_COUNT  (0x4822A65D5AF64E69)
+-- min build: 1207
+---@param animScene number
+---@return number
+function GetAnimSceneCurrentActiveCameraCount(animScene) end
+
+-- GET_ANIM_SCENE_ENTITY_LOCATION_DATA  (0x8398438D8F14F56D)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@param p3 boolean
+---@param playbackListName string
+---@param p5 number
+---@return boolean
+---@return vector3
+function GetAnimSceneEntityLocationData(animScene, entityName, p3, playbackListName, p5) end
+
+-- GET_ANIM_SCENE_FLOAT  (0xCC24CB07F60B496E)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@return number
+function GetAnimSceneFloat(animScene, name) end
+
+-- GET_ANIM_SCENE_INT  (0x2B7277484CC095FD)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@return number
+function GetAnimSceneInt(animScene, name) end
+
+-- GET_ANIM_SCENE_ORIGIN  (0xADF1D53F3B1FE0A7)
+-- min build: 1207
+---@param animScene number
+---@param order number
+---@return vector3
+---@return vector3
+function GetAnimSceneOrigin(animScene, order) end
+
+-- GET_ANIM_SCENE_PHASE  (0x3FBC3F51BF12DFBF)
+-- min build: 1207
+---@param animScene number
+---@return number
+function GetAnimScenePhase(animScene) end
+
+-- HAS_ANIM_SCENE_EXITED  (0xF94692EB9DC15D74)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function HasAnimSceneExited(animScene, p1) end
+
+-- HAS_ENTITY_EXITED_ANIM_SCENE  (0xB89FCFF19DAFFF28)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@return boolean
+function HasEntityExitedAnimScene(animScene, entityName) end
+
+-- IS_ANIM_SCENE_EXITING_THIS_FRAME  (0xCDC5512A407CF08D)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function IsAnimSceneExitingThisFrame(animScene) end
+
+-- IS_ANIM_SCENE_FINISHED  (0xD8254CB2C586412B)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function IsAnimSceneFinished(animScene, p1) end
+
+-- IS_ANIM_SCENE_IN_SECTION  (0x8D81E7824B7753F7)
+-- min build: 1207
+---@param animScene number
+---@param sectionName string
+---@param p2 boolean
+---@return boolean
+function IsAnimSceneInSection(animScene, sectionName, p2) end
+
+-- IS_ANIM_SCENE_LOADED  (0x477122B8D05E7968)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@param p2 boolean
+---@return boolean
+function IsAnimSceneLoaded(animScene, p1, p2) end
+
+-- IS_ANIM_SCENE_METADATA_LOADED  (0x95531A4A20CCE7BC)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function IsAnimSceneMetadataLoaded(animScene, p1) end
+
+-- IS_ANIM_SCENE_RUNNING  (0xCBFC7725DE6CE2E0)
+-- min build: 1207
+---@param animScene number
+---@param p1 boolean
+---@return boolean
+function IsAnimSceneRunning(animScene, p1) end
+
+-- IS_ENTITY_EXITING_ANIM_SCENE_THIS_FRAME  (0x005E6F28DD7ED58D)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@return boolean
+function IsEntityExitingAnimSceneThisFrame(animScene, entityName) end
+
+-- IS_ENTITY_PLAYING_ANIM_SCENE  (0x3AB6C7B0BB0DF4B1)
+-- min build: 1207
+---@param entity number
+---@param animScene number
+---@return boolean
+function IsEntityPlayingAnimScene(entity, animScene) end
+
+-- LOAD_ANIM_SCENE  (0xAF068580194D9DC7)
+-- min build: 1207
+---@param animScene number
+function LoadAnimScene(animScene) end
+
+-- REMOVE_ANIM_SCENE_ENTITY  (0x2BF96692C67F3E53)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@param entity number
+function RemoveAnimSceneEntity(animScene, entityName, entity) end
+
+-- REQUEST_ANIM_SCENE_PLAY_LIST  (0xDF7B5144E25CD3FE)
+-- min build: 1207
+---@param animScene number
+---@param playlistName string
+---@return boolean
+function RequestAnimScenePlayList(animScene, playlistName) end
+
+-- RESET_ANIM_SCENE  (0x8FDF221F13537936)
+-- min build: 1207
+---@param animScene number
+---@param playbackListName string
+function ResetAnimScene(animScene, playbackListName) end
+
+-- RESUME_ANIM_SCENE_FROM_LAST_CHECKPOINT  (0x8E1BA705F63C1925)
+-- min build: 1207
+---@param animScene number
+function ResumeAnimSceneFromLastCheckpoint(animScene) end
+
+-- SET_ANIM_SCENE_BOOL  (0x519E96C2C68B404B)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@param value boolean
+---@param p3 boolean
+function SetAnimSceneBool(animScene, name, value, p3) end
+
+-- SET_ANIM_SCENE_ENTITY  (0x8B720AD451CA2AB3)
+-- min build: 1207
+---@param animScene number
+---@param entityName string
+---@param entity number
+---@param flags number
+function SetAnimSceneEntity(animScene, entityName, entity, flags) end
+
+-- SET_ANIM_SCENE_FLOAT  (0x6BC5104E68CBEFE8)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@param value number
+---@param p3 boolean
+---@param p4 boolean
+function SetAnimSceneFloat(animScene, name, value, p3, p4) end
+
+-- SET_ANIM_SCENE_INT  (0x3A379D2166CF5B92)
+-- min build: 1207
+---@param animScene number
+---@param name string
+---@param value number
+---@param p3 boolean
+function SetAnimSceneInt(animScene, name, value, p3) end
+
+-- SET_ANIM_SCENE_ORIGIN  (0x020894BF17A02EF2)
+-- min build: 1207
+---@param animScene number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param order number
+function SetAnimSceneOrigin(animScene, posX, posY, posZ, rotX, rotY, rotZ, order) end
+
+-- SET_ANIM_SCENE_PAUSED  (0xD6824B7D24DC0CE0)
+-- min build: 1207
+---@param animScene number
+---@param toggle boolean
+function SetAnimScenePaused(animScene, toggle) end
+
+-- SET_ANIM_SCENE_PLAY_LIST  (0x15598CFB25F3DC7E)
+-- min build: 1207
+---@param animScene number
+---@param playlistName string
+---@param p2 boolean
+function SetAnimScenePlayList(animScene, playlistName, p2) end
+
+-- SET_ANIM_SCENE_PLAYBACK_LIST  (0xAB5E7CAB074D6B84)
+-- min build: 1207
+---@param animScene number
+---@param playbackListName string
+function SetAnimScenePlaybackList(animScene, playbackListName) end
+
+-- SET_ANIM_SCENE_RATE  (0x75820B801CFF262A)
+-- min build: 1207
+---@param animScene number
+---@param rate number
+function SetAnimSceneRate(animScene, rate) end
+
+-- START_ANIM_SCENE  (0xF4D94AF761768700)
+-- min build: 1207
+---@param animScene number
+function StartAnimScene(animScene) end
+
+-- TAKE_OWNERSHIP_OF_ANIM_SCENE  (0xF7A4C571E572D237)
+-- min build: 1207
+---@param animScene number
+function TakeOwnershipOfAnimScene(animScene) end
+
+-- TRIGGER_ANIM_SCENE_SKIP  (0x4B85B3CF9197AEDF)
+-- min build: 1207
+---@param animScene number
+function TriggerAnimSceneSkip(animScene) end
+
+-- WAS_ANIM_SCENE_SKIPPED  (0xEF324E9550A394D5)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function WasAnimSceneSkipped(animScene) end

--- a/.luals/redm-natives/ANTICHEAT.lua
+++ b/.luals/redm-natives/ANTICHEAT.lua
@@ -1,0 +1,13 @@
+---@meta
+
+-- RDR3 namespace: ANTICHEAT -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _REPORT_PLAYER_BAD_SPORT_BEHAVIOR  (0xC31C44C43B48FDE3)
+-- nullsub, doesn't do anything
+-- however it is being used in tty scripts: [NET_BAD_SPORT_REPORT_PLAYER] Detected bad sport behavior from Player
+-- badSportBehavior: BS_QUITTER = 0, BS_VEHICLE_DESTRUCTION = 1, BS_VOTED_OUT = 2
+-- min build: 1207
+---@param badSportBehaviorType number
+---@return any
+function _ReportPlayerBadSportBehavior(badSportBehaviorType) end

--- a/.luals/redm-natives/ATTRIBUTE.lua
+++ b/.luals/redm-natives/ATTRIBUTE.lua
@@ -1,0 +1,267 @@
+---@meta
+
+-- RDR3 namespace: ATTRIBUTE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _ENABLE_ATTRIBUTE_CORE_OVERPOWER  (0x4AF5A4C7B9157D14)
+-- coreIndex: see _SET_ATTRIBUTE_CORE_VALUE
+-- 
+-- Previously incorrectly named ENABLE_ATTRIBUTE_OVERPOWER
+-- min build: 1207
+---@param ped number
+---@param coreIndex number
+---@param value number
+---@param makeSound boolean
+function _EnableAttributeCoreOverpower(ped, coreIndex, value, makeSound) end
+
+-- _GET_ATTRIBUTE_CORE_OVERPOWER_SECONDS_LEFT  (0xB429F58803D285B1)
+-- min build: 1207
+---@param ped number
+---@param coreIndex number
+---@return number
+function _GetAttributeCoreOverpowerSecondsLeft(ped, coreIndex) end
+
+-- _GET_ATTRIBUTE_CORE_VALUE  (0x36731AC041289BB1)
+-- Gets the ped's core value on a scale of 0 to 100.
+-- coreIndex: see _SET_ATTRIBUTE_CORE_VALUE
+-- min build: 1207
+---@param ped number
+---@param coreIndex number
+---@return number
+function _GetAttributeCoreValue(ped, coreIndex) end
+
+-- _GET_ATTRIBUTE_OVERPOWER_SECONDS_LEFT  (0x4C9F782180712742)
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return number
+function _GetAttributeOverpowerSecondsLeft(ped, attributeIndex) end
+
+-- _IS_ATTRIBUTE_CORE_OVERPOWERED  (0x200373A8DF081F22)
+-- min build: 1207
+---@param ped number
+---@param coreIndex number
+---@return boolean
+function _IsAttributeCoreOverpowered(ped, coreIndex) end
+
+-- _IS_ATTRIBUTE_OVERPOWERED  (0x103C2F885ABEB00B)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return boolean
+function _IsAttributeOverpowered(ped, attributeIndex) end
+
+-- _SET_ATTRIBUTE_CORE_VALUE  (0xC6258F41D86676E0)
+-- coreIndex:
+-- enum eAttributeCore
+-- {
+-- 	ATTRIBUTE_CORE_HEALTH,
+-- 	ATTRIBUTE_CORE_STAMINA,
+-- 	ATTRIBUTE_CORE_DEADEYE
+-- };
+-- min build: 1207
+---@param ped number
+---@param coreIndex number
+---@param value number
+function _SetAttributeCoreValue(ped, coreIndex, value) end
+
+-- _SET_STATUS_EFFECT_CORE_ICON  (0xA4D3A1C008F250DF)
+-- Displays status effects on core icons (includes warnings).
+-- 
+-- enum eUiRpgStatusEffect
+-- {
+-- 	STATUS_NONE,
+-- 	STATUS_COLD,
+-- 	STATUS_HOT,
+-- 	STATUS_OVERFED,
+-- 	STATUS_DIRTY,
+-- 	STATUS_SNAKE_VENOM,
+-- 	STATUS_ARROW_WOUNDED,
+-- 	STATUS_ARROW_DRAINED,
+-- 	STATUS_ARROW_DISORIENTED,
+-- 	STATUS_ARROW_TRACKED,
+-- 	STATUS_ARROW_CONFUSION,
+-- 	STATUS_UNDERWEIGHT,
+-- 	STATUS_OVERWEIGHT,
+-- 	STATUS_SICK_1,
+-- 	STATUS_SICK_2,
+-- 	STATUS_PREDATOR_INVULNERABLE
+-- };
+-- min build: 1207
+---@param statusEffectType number
+function _SetStatusEffectCoreIcon(statusEffectType) end
+
+-- _SET_STATUS_EFFECT_PERIODIC_ICON  (0xFB6E111908502871)
+-- Starts core periodic icon.
+-- statusEffectType: see 0xA4D3A1C008F250DF
+-- min build: 1207
+---@param statusEffectType number
+function _SetStatusEffectPeriodicIcon(statusEffectType) end
+
+-- _START_ITEM_PREVIEW  (0x7E2C766ADB2C5F1A)
+-- Params: p1 is related to satchel_category
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+function _StartItemPreview(p0, p1) end
+
+-- _STOP_STATUS_EFFECT_PERIODIC_ICON  (0x3FC4C027FD0936F4)
+-- Stops periodic icon.
+-- statusEffectType: see 0xA4D3A1C008F250DF
+-- min build: 1207
+---@param statusEffectType number
+function _StopStatusEffectPeriodicIcon(statusEffectType) end
+
+-- ADD_ATTRIBUTE_POINTS  (0x75415EE0CB583760)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param p2 number
+function AddAttributePoints(ped, attributeIndex, p2) end
+
+-- DISABLE_ATTRIBUTE_OVERPOWER  (0xF8DAC3D85636C241)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+function DisableAttributeOverpower(ped, attributeIndex) end
+
+-- ENABLE_ATTRIBUTE_OVERPOWER  (0xF6A7C08DF2E28B28)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- 
+-- Old name: _SET_ATTRIBUTE_OVERPOWER_VALUE
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param value number
+---@param makeSound boolean
+function EnableAttributeOverpower(ped, attributeIndex, value, makeSound) end
+
+-- GET_ATTRIBUTE_BASE_RANK  (0x147149F2E909323C)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return number
+function GetAttributeBaseRank(ped, attributeIndex) end
+
+-- GET_ATTRIBUTE_BONUS_RANK  (0x0EFA71F4B4330E04)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param coreIndex number
+---@return number
+function GetAttributeBonusRank(ped, coreIndex) end
+
+-- GET_ATTRIBUTE_POINTS  (0x219DA04BAA9CB065)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return number
+function GetAttributePoints(ped, attributeIndex) end
+
+-- GET_ATTRIBUTE_RANK  (0xA4C8E23E29040DE0)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return number
+function GetAttributeRank(ped, attributeIndex) end
+
+-- GET_DEFAULT_ATTRIBUTE_POINTS_NEEDED_FOR_RANK  (0x94A7F191DB49A44D)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param modelHash number
+---@param attributeIndex number
+---@param rank number
+---@return number
+function GetDefaultAttributePointsNeededForRank(modelHash, attributeIndex, rank) end
+
+-- GET_DEFAULT_ATTRIBUTE_RANK  (0x958DD43D41F89A47)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param modelHash number
+---@param attributeIndex number
+---@return number
+function GetDefaultAttributeRank(modelHash, attributeIndex) end
+
+-- GET_DEFAULT_MAX_ATTRIBUTE_RANK  (0x7C059C55AD940CB4)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param modelHash number
+---@param attributeIndex number
+---@return number
+function GetDefaultMaxAttributeRank(modelHash, attributeIndex) end
+
+-- GET_MAX_ATTRIBUTE_POINTS  (0x223BF310F854871C)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return number
+function GetMaxAttributePoints(ped, attributeIndex) end
+
+-- GET_MAX_ATTRIBUTE_RANK  (0x704674A0535A471D)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return number
+function GetMaxAttributeRank(ped, attributeIndex) end
+
+-- SET_ATTRIBUTE_BASE_RANK  (0x5DA12E025D47D4E5)
+-- attributeIndex:
+-- enum ePedAttribute
+-- {
+-- 	PA_HEALTH,
+-- 	PA_STAMINA,
+-- 	PA_SPECIALABILITY,
+-- 	PA_COURAGE,
+-- 	PA_AGILITY,
+-- 	PA_SPEED,
+-- 	PA_ACCELERATION,
+-- 	PA_BONDING,
+-- 	SA_HUNGER,
+-- 	SA_FATIGUED,
+-- 	SA_INEBRIATED,
+-- 	SA_POISONED,
+-- 	SA_BODYHEAT,
+-- 	SA_BODYWEIGHT,
+-- 	SA_OVERFED,
+-- 	SA_SICKNESS,
+-- 	SA_DIRTINESS,
+-- 	SA_DIRTINESSHAT,
+-- 	MTR_STRENGTH,
+-- 	MTR_GRIT,
+-- 	MTR_INSTINCT,
+-- 	PA_UNRULINESS,
+-- 	SA_DIRTINESSSKIN
+-- };
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param newValue number
+function SetAttributeBaseRank(ped, attributeIndex, newValue) end
+
+-- SET_ATTRIBUTE_BONUS_RANK  (0x920F9488BD115EFB)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param newValue number
+function SetAttributeBonusRank(ped, attributeIndex, newValue) end
+
+-- SET_ATTRIBUTE_POINTS  (0x09A59688C26D88DF)
+-- attributeIndex: see SET_ATTRIBUTE_BASE_RANK
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param p2 number
+function SetAttributePoints(ped, attributeIndex, p2) end
+
+-- STOP_ITEM_PREVIEW  (0xD962F8579D702DB5)
+-- min build: 1207
+function StopItemPreview() end

--- a/.luals/redm-natives/AUDIO.lua
+++ b/.luals/redm-natives/AUDIO.lua
@@ -1,0 +1,1484 @@
+---@meta
+
+-- RDR3 namespace: AUDIO -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x017492B2201E3428  (0x017492B2201E3428)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x017492B2201E3428(p0, p1, p2, p3) end
+
+-- _0x018ABE833CA64D2A  (0x018ABE833CA64D2A)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+function N_0x018ABE833CA64D2A(p0, p1) end
+
+-- _0x06C5DF5EE444BC6B  (0x06C5DF5EE444BC6B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x06C5DF5EE444BC6B(p0, p1, p2, p3, p4) end
+
+-- _0x078F77FD1A43EAB3  (0x078F77FD1A43EAB3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x078F77FD1A43EAB3(p0, p1) end
+
+-- _0x0CB3D1919E8D7CBA  (0x0CB3D1919E8D7CBA)
+-- min build: 1207
+---@param convoRoot string
+---@return boolean
+function N_0x0CB3D1919E8D7CBA(convoRoot) end
+
+-- _0x0D7FD6A55FD63AEF  (0x0D7FD6A55FD63AEF)
+-- speechEventType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/naSpeechEventType 
+-- p1 is possibly naSpeechAudibility, naSpeechType, or naSpeechEventTypeRequestPriority
+-- SKIP_* - START_*
+-- min build: 1207
+---@param speechEventType number
+---@param p1 number
+---@param p2 boolean
+function N_0x0D7FD6A55FD63AEF(speechEventType, p1, p2) end
+
+-- _0x0FAF7171BF613B80  (0x0FAF7171BF613B80)
+-- min build: 1207
+---@param p0 any
+function N_0x0FAF7171BF613B80(p0) end
+
+-- _0x131EC9247E7A2903  (0x131EC9247E7A2903)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x131EC9247E7A2903(p0) end
+
+-- _0x138ADB94F8B90616  (0x138ADB94F8B90616)
+-- min build: 1207
+function N_0x138ADB94F8B90616() end
+
+-- _0x139A4B9DF2D26CBF  (0x139A4B9DF2D26CBF)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+function N_0x139A4B9DF2D26CBF(p0, p1) end
+
+-- _0x152ED1B56E8F1F50  (0x152ED1B56E8F1F50)
+-- min build: 1207
+---@param p0 string
+---@param currentScriptedConvoLine number
+---@return number
+function N_0x152ED1B56E8F1F50(p0, currentScriptedConvoLine) end
+
+-- _0x1E6F9A9FE1A99F36  (0x1E6F9A9FE1A99F36)
+-- min build: 1207
+---@param audSpeechEvent string
+function N_0x1E6F9A9FE1A99F36(audSpeechEvent) end
+
+-- _0x254B0241E964B450  (0x254B0241E964B450)
+-- min build: 1207
+---@param p0 string
+---@param currentScriptedConvoLine number
+---@return number
+function N_0x254B0241E964B450(p0, currentScriptedConvoLine) end
+
+-- _0x259ACC5B52A2B2D9  (0x259ACC5B52A2B2D9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x259ACC5B52A2B2D9(p0, p1) end
+
+-- _0x2651DDC0EA269073  (0x2651DDC0EA269073)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+function N_0x2651DDC0EA269073(ropeId, p1) end
+
+-- _0x295859EB18F48D82  (0x295859EB18F48D82)
+-- min build: 1207
+---@param p0 string
+---@return number
+function N_0x295859EB18F48D82(p0) end
+
+-- _0x2B101AD9F651243A  (0x2B101AD9F651243A)
+-- min build: 1207
+---@return any
+function N_0x2B101AD9F651243A() end
+
+-- _0x2B9C37C01BF25EDB  (0x2B9C37C01BF25EDB)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2B9C37C01BF25EDB(p0) end
+
+-- _0x2FFF4A78384AFFDF  (0x2FFF4A78384AFFDF)
+-- min build: 1436
+---@param entity number
+---@return any
+function N_0x2FFF4A78384AFFDF(entity) end
+
+-- _0x341CDD17EFC2472E  (0x341CDD17EFC2472E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x341CDD17EFC2472E(p0, p1) end
+
+-- _0x35B8C070E0C16E2F  (0x35B8C070E0C16E2F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x35B8C070E0C16E2F(p0, p1) end
+
+-- _0x380A2E353AD30917  (0x380A2E353AD30917)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x380A2E353AD30917(p0, p1, p2) end
+
+-- _0x3A00D87B20A2A5E4  (0x3A00D87B20A2A5E4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3A00D87B20A2A5E4(p0, p1) end
+
+-- _0x3A3BE6B920525237  (0x3A3BE6B920525237)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3A3BE6B920525237(p0, p1) end
+
+-- _0x3D0BBCCF401B5FDB  (0x3D0BBCCF401B5FDB)
+-- min build: 1207
+function N_0x3D0BBCCF401B5FDB() end
+
+-- _0x3E93DDDCBB6111E4  (0x3E93DDDCBB6111E4)
+-- min build: 1207
+---@param p0 string
+---@param p1 number
+function N_0x3E93DDDCBB6111E4(p0, p1) end
+
+-- _0x3E98AC9D8C56C62C  (0x3E98AC9D8C56C62C)
+-- min build: 1207
+---@param p0 any
+function N_0x3E98AC9D8C56C62C(p0) end
+
+-- _0x40CA665AB9D8D505  (0x40CA665AB9D8D505)
+-- min build: 1207
+---@param convoRoot string
+---@param singleLineIndex number
+function N_0x40CA665AB9D8D505(convoRoot, singleLineIndex) end
+
+-- _0x43037ABFE214A851  (0x43037ABFE214A851)
+-- min build: 1207
+function N_0x43037ABFE214A851() end
+
+-- _0x448F2647DD6F2E27  (0x448F2647DD6F2E27)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x448F2647DD6F2E27(p0, p1, p2, p3, p4) end
+
+-- _0x44A5EEF54F62E823  (0x44A5EEF54F62E823)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x44A5EEF54F62E823(p0) end
+
+-- _0x4A98E228A936DBCC  (0x4A98E228A936DBCC)
+-- Gets the hash for the currently playing speech line.
+-- min build: 1207
+---@param ped number
+---@return number
+function N_0x4A98E228A936DBCC(ped) end
+
+-- _0x4BE3EC91C01F0FE8  (0x4BE3EC91C01F0FE8)
+-- min build: 1207
+function N_0x4BE3EC91C01F0FE8() end
+
+-- _0x569ABC36E28DDEAA  (0x569ABC36E28DDEAA)
+-- min build: 1207
+function N_0x569ABC36E28DDEAA() end
+
+-- _0x580D71DFE0088E34  (0x580D71DFE0088E34)
+-- _IS_SOUND_RUNNING(?)
+-- min build: 1207
+---@param audioName string
+---@param audioRef string
+---@return boolean
+function N_0x580D71DFE0088E34(audioName, audioRef) end
+
+-- _0x5A13586A9447931F  (0x5A13586A9447931F)
+-- min build: 1207
+---@param p0 boolean
+---@return boolean
+function N_0x5A13586A9447931F(p0) end
+
+-- _0x5AE0CB5F35F034FD  (0x5AE0CB5F35F034FD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function N_0x5AE0CB5F35F034FD(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0x5BC885EBD75FAA7D  (0x5BC885EBD75FAA7D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x5BC885EBD75FAA7D(p0, p1) end
+
+-- _0x5E3CCF03995388B5  (0x5E3CCF03995388B5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x5E3CCF03995388B5(p0, p1, p2, p3) end
+
+-- _0x62377977E4F08668  (0x62377977E4F08668)
+-- min build: 1436
+---@param entity number
+---@return number
+function N_0x62377977E4F08668(entity) end
+
+-- _0x64B956F4E761DF5C  (0x64B956F4E761DF5C)
+-- min build: 1207
+---@param p0 any
+function N_0x64B956F4E761DF5C(p0) end
+
+-- _0x660A8F876DF1D4F8  (0x660A8F876DF1D4F8)
+-- speechEventType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/naSpeechEventType 
+-- SKIP_* - START_*
+-- min build: 1207
+---@param speechEventType number
+function N_0x660A8F876DF1D4F8(speechEventType) end
+
+-- _0x6652B0C8F3D414D0  (0x6652B0C8F3D414D0)
+-- min build: 1207
+---@param p0 any
+function N_0x6652B0C8F3D414D0(p0) end
+
+-- _0x6AB944DF68B512D3  (0x6AB944DF68B512D3)
+-- _STOP_AUDIO_*
+-- min build: 1207
+---@param p0 any
+function N_0x6AB944DF68B512D3(p0) end
+
+-- _0x6B7A88A61B41E589  (0x6B7A88A61B41E589)
+-- min build: 1207
+---@param p0 any
+function N_0x6B7A88A61B41E589(p0) end
+
+-- _0x6DA15746D5CC1A92  (0x6DA15746D5CC1A92)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0x6DA15746D5CC1A92(p0, p1, p2, p3, p4, p5) end
+
+-- _0x7455CD705F7E933E  (0x7455CD705F7E933E)
+-- _AUDIO_IS_* - _AUDIO_TRIGGER*
+-- min build: 1207
+function N_0x7455CD705F7E933E() end
+
+-- _0x7678FE0455ED1145  (0x7678FE0455ED1145)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x7678FE0455ED1145(p0, p1, p2) end
+
+-- _0x79F9C57B8D0DFE90  (0x79F9C57B8D0DFE90)
+-- Only used in R* SP Script cv_mus_shared
+-- min build: 1207
+---@param convoRoot string
+---@param animScene number
+---@return boolean
+function N_0x79F9C57B8D0DFE90(convoRoot, animScene) end
+
+-- _0x7E176C676F8652A9  (0x7E176C676F8652A9)
+-- min build: 1207
+---@param p0 any
+function N_0x7E176C676F8652A9(p0) end
+
+-- _0x821C32C728B24477  (0x821C32C728B24477)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x821C32C728B24477(p0, p1, p2) end
+
+-- _0x839C9F124BE74D94  (0x839C9F124BE74D94)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x839C9F124BE74D94(p0, p1, p2, p3, p4) end
+
+-- _0x847748AE5D7B1071  (0x847748AE5D7B1071)
+-- min build: 1207
+---@param p0 boolean
+---@return boolean
+function N_0x847748AE5D7B1071(p0) end
+
+-- _0x864A842B86993851  (0x864A842B86993851)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+function N_0x864A842B86993851(ped) end
+
+-- _0x886657C5B3D8EDE3  (0x886657C5B3D8EDE3)
+-- min build: 1232
+---@param entity number
+---@return any
+function N_0x886657C5B3D8EDE3(entity) end
+
+-- _0x8D29FDF565DED9AE  (0x8D29FDF565DED9AE)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x8D29FDF565DED9AE(p0, p1, p2) end
+
+-- _0x8E901B65206C2D3E  (0x8E901B65206C2D3E)
+-- min build: 1207
+---@param ped number
+function N_0x8E901B65206C2D3E(ped) end
+
+-- _0x935DBD96D4A3DA1F  (0x935DBD96D4A3DA1F)
+-- min build: 1207
+---@param p0 string
+---@param currentScriptedConvoLine number
+---@return number
+function N_0x935DBD96D4A3DA1F(p0, currentScriptedConvoLine) end
+
+-- _0x9D6DEC9791A4E501  (0x9D6DEC9791A4E501)
+-- Returns true or false if the ped can say a specific speech line with PLAY_PED_AMBIENT_SPEECH_NATIVE, similar to DOES_CONTEXT_EXIST_FOR_THIS_PED.
+-- Not reliable on remote clients when used on a player ped.
+-- Params: p2 and p3 are usually false and true, respectively.
+-- min build: 1207
+---@param ped number
+---@param speechName string
+---@param p2 boolean
+---@param p3 boolean
+---@return boolean
+function N_0x9D6DEC9791A4E501(ped, speechName, p2, p3) end
+
+-- _0x9EB779765E68C52E  (0x9EB779765E68C52E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9EB779765E68C52E(p0, p1) end
+
+-- _0xA2323A2EAE32A290  (0xA2323A2EAE32A290)
+-- min build: 1207
+---@param listeningToPed number
+---@param ped number
+---@param listenerName string
+function N_0xA2323A2EAE32A290(listeningToPed, ped, listenerName) end
+
+-- _0xA2B851605748AD0E  (0xA2B851605748AD0E)
+-- min build: 1207
+function N_0xA2B851605748AD0E() end
+
+-- _0xA6847BBA4FCDD13F  (0xA6847BBA4FCDD13F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA6847BBA4FCDD13F(p0, p1) end
+
+-- _0xA6A3A3F96B8B030E  (0xA6A3A3F96B8B030E)
+-- min build: 1207
+---@return any
+function N_0xA6A3A3F96B8B030E() end
+
+-- _0xABDB4863D3D72021  (0xABDB4863D3D72021)
+-- min build: 1207
+---@param entity number
+---@param p1 any
+---@param p2 any
+---@param p3 number
+---@param p4 any
+function N_0xABDB4863D3D72021(entity, p1, p2, p3, p4) end
+
+-- _0xB93A769B8B726950  (0xB93A769B8B726950)
+-- Used in Script Function NET_CAMP_CLIENT_UPDATE_PED_ROLE_STATE_SHOP: hash exists! Playing hash
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0xB93A769B8B726950(ped, p1) end
+
+-- _0xBC07CA8FD710E7FD  (0xBC07CA8FD710E7FD)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+function N_0xBC07CA8FD710E7FD(p0, p1) end
+
+-- _0xBE28DB99556FF8D9  (0xBE28DB99556FF8D9)
+-- Checks for MOONSHINE_BAND
+-- min build: 1207
+---@param entity number
+---@return number
+function N_0xBE28DB99556FF8D9(entity) end
+
+-- _0xC369E2234E34A0CA  (0xC369E2234E34A0CA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC369E2234E34A0CA(p0, p1) end
+
+-- _0xC4CFCE4C656EF480  (0xC4CFCE4C656EF480)
+-- min build: 1207
+---@param ped number
+function N_0xC4CFCE4C656EF480(ped) end
+
+-- _0xC68C02DE259C927C  (0xC68C02DE259C927C)
+-- min build: 1232
+---@param p0 any
+---@return any
+function N_0xC68C02DE259C927C(p0) end
+
+-- _0xC886CD666ADD42E1  (0xC886CD666ADD42E1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xC886CD666ADD42E1(p0, p1) end
+
+-- _0xCBF2BEBB468A34F3  (0xCBF2BEBB468A34F3)
+-- min build: 1207
+---@param p0 any
+function N_0xCBF2BEBB468A34F3(p0) end
+
+-- _0xCFAD2C8CD1054523  (0xCFAD2C8CD1054523)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xCFAD2C8CD1054523(p0, p1, p2, p3) end
+
+-- _0xD05A460328560477  (0xD05A460328560477)
+-- min build: 1232
+---@param p0 any
+---@return any
+function N_0xD05A460328560477(p0) end
+
+-- _0xD0730C1FA40348D9  (0xD0730C1FA40348D9)
+-- _IS_SCRIPTED_CONVERSATION_*
+-- min build: 1207
+---@param convoRoot string
+---@return boolean
+function N_0xD0730C1FA40348D9(convoRoot) end
+
+-- _0xD47D47EFBF103FB8  (0xD47D47EFBF103FB8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xD47D47EFBF103FB8(p0, p1) end
+
+-- _0xD733528B6C35647A  (0xD733528B6C35647A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xD733528B6C35647A(p0, p1) end
+
+-- _0xDAD6CD07CAA4F382  (0xDAD6CD07CAA4F382)
+-- min build: 1207
+function N_0xDAD6CD07CAA4F382() end
+
+-- _0xDC2F83A0612CA34D  (0xDC2F83A0612CA34D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xDC2F83A0612CA34D(p0) end
+
+-- _0xDC93F0948F2C28F4  (0xDC93F0948F2C28F4)
+-- min build: 1207
+---@param p0 any
+function N_0xDC93F0948F2C28F4(p0) end
+
+-- _0xDF947FE0D551684E  (0xDF947FE0D551684E)
+-- min build: 1207
+---@param ped number
+---@param p1 string
+---@return boolean
+function N_0xDF947FE0D551684E(ped, p1) end
+
+-- _0xE600F61F54A444A6  (0xE600F61F54A444A6)
+-- min build: 1207
+---@return any
+function N_0xE600F61F54A444A6() end
+
+-- _0xE7E6CB8B713ED190  (0xE7E6CB8B713ED190)
+-- min build: 1207
+function N_0xE7E6CB8B713ED190() end
+
+-- _0xE891504B2F0E2DBA  (0xE891504B2F0E2DBA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE891504B2F0E2DBA(p0, p1) end
+
+-- _0xE9694B2D6CB87B06  (0xE9694B2D6CB87B06)
+-- min build: 1232
+---@param entity number
+---@param p1 any
+function N_0xE9694B2D6CB87B06(entity, p1) end
+
+-- _0xEA546C31FD45F8CD  (0xEA546C31FD45F8CD)
+-- min build: 1207
+---@param p0 any
+function N_0xEA546C31FD45F8CD(p0) end
+
+-- _0xEB4D592620B8C209  (0xEB4D592620B8C209)
+-- min build: 1207
+---@param p0 any
+function N_0xEB4D592620B8C209(p0) end
+
+-- _0xF092B6030D6FD49C  (0xF092B6030D6FD49C)
+-- Name: ROPE_SETTINGS_DEFAULT
+-- min build: 1207
+---@param ropeId number
+---@param name string
+function N_0xF092B6030D6FD49C(ropeId, name) end
+
+-- _0xF0EE69F500952FA5  (0xF0EE69F500952FA5)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF0EE69F500952FA5(p0) end
+
+-- _0xF232C2C546AC16D0  (0xF232C2C546AC16D0)
+-- min build: 1207
+---@param p0 string
+function N_0xF232C2C546AC16D0(p0) end
+
+-- _0xF336E9F989B3518F  (0xF336E9F989B3518F)
+-- min build: 1207
+---@param p0 string
+---@return number
+function N_0xF336E9F989B3518F(p0) end
+
+-- _0xF64034D533CE8AAC  (0xF64034D533CE8AAC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xF64034D533CE8AAC(p0, p1, p2) end
+
+-- _0xFCDEC42B1C78B7F8  (0xFCDEC42B1C78B7F8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFCDEC42B1C78B7F8(p0, p1) end
+
+-- _0xFD461D0ABA5559B1  (0xFD461D0ABA5559B1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFD461D0ABA5559B1(p0, p1) end
+
+-- _0xFE5C6177064BD390  (0xFE5C6177064BD390)
+-- min build: 1207
+---@param p0 boolean
+---@return boolean
+function N_0xFE5C6177064BD390(p0) end
+
+-- _0xFFE9C53DEEA3DB0B  (0xFFE9C53DEEA3DB0B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param x number
+---@param y number
+---@param z number
+---@param isSrlLoaded boolean
+---@param p6 any
+---@return any
+function N_0xFFE9C53DEEA3DB0B(p0, p1, x, y, z, isSrlLoaded, p6) end
+
+-- _BLOCK_SPEECH_CONTEXT  (0x6378A235374B852F)
+-- min build: 1207
+---@param context string
+---@param block boolean
+function _BlockSpeechContext(context, block) end
+
+-- _CLEAR_CONVERSATION_HISTORY_FOR_SCRIPTED_CONVERSATION  (0xEF51242E35242B47)
+-- min build: 1207
+---@param convoRoot string
+function _ClearConversationHistoryForScriptedConversation(convoRoot) end
+
+-- _CREATE_NEW_SCRIPTED_PED_AMBIENT_SPEECH  (0x72E4D1C4639BC465)
+-- Create a scripted speech to control speech. If handle is less than 0, it's invalid.
+-- params struct for ScriptedSpeechParams see: PLAY_PED_AMBIENT_SPEECH_NATIVE
+-- Returns scriptedSpeech handle.
+-- min build: 1207
+---@param speaker number
+---@return number
+---@return any
+function _CreateNewScriptedPedAmbientSpeech(speaker) end
+
+-- _GET_ENTITY_AUDIO_MIX_GROUP  (0x8B25A18E390F75BF)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetEntityAudioMixGroup(entity) end
+
+-- _GET_LAST_PLAYED_SPEECH_FOR_PED  (0x6BFFB7C276866996)
+-- Gets the hash for the last played speech line.
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLastPlayedSpeechForPed(ped) end
+
+-- _GET_LOADED_STREAM_ID_FROM_CREATION  (0x0556C784FA056628)
+-- Creates stream and returns streamId handle to be used with PLAY_STREAM_* natives
+-- https://github.com/femga/rdr3_discoveries/tree/master/audio/create_stream
+-- min build: 1207
+---@param streamName string
+---@param soundSet string
+---@return number
+function _GetLoadedStreamIdFromCreation(streamName, soundSet) end
+
+-- _GET_PED_SONG_INDEX_HOST  (0x2DBBF0C5E19383EE)
+-- min build: 1232
+---@param ped number
+---@return any
+function _GetPedSongIndexHost(ped) end
+
+-- _HAS_SOUND_AUDIO_NAME_FINISHED  (0x714A0EA7DE1167BE)
+-- min build: 1207
+---@param audioName string
+---@param soundsetName string
+---@return boolean
+function _HasSoundAudioNameFinished(audioName, soundsetName) end
+
+-- _HAS_SOUND_ID_FINISHED  (0x84848E1C0FC67DBB)
+-- min build: 1207
+---@param soundId number
+---@return boolean
+function _HasSoundIdFinished(soundId) end
+
+-- _IS_ANY_CONVERSATION_PLAYING  (0xA2CAC9DEF0195E6F)
+-- min build: 1207
+---@param p0 boolean
+---@return boolean
+function _IsAnyConversationPlaying(p0) end
+
+-- _IS_PED_IN_ANY_CONVERSATION  (0x54B187F111D9C6F8)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _IsPedInAnyConversation(ped, p1) end
+
+-- _IS_SCRIPTED_AUDIO_CUSTOM  (0x6DF942C4179BE5AB)
+-- item: FUSE, value returned from 0x2E1CDC1FF3B8473E
+-- soundSet: HUD_SHOP_SOUNDSET, COMPANIONS_ROBBERIES_SOUNDSET
+-- min build: 1207
+---@param item number
+---@param soundSet number
+---@return boolean
+function _IsScriptedAudioCustom(item, soundSet) end
+
+-- _IS_SCRIPTED_CONVERSATION_CREATED  (0xD89504D9D7D5057D)
+-- min build: 1207
+---@param convoRoot string
+---@return boolean
+function _IsScriptedConversationCreated(convoRoot) end
+
+-- _IS_SCRIPTED_CONVERSION_ONGOING  (0xF01C570E0A0A1E67)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function _IsScriptedConversionOngoing(p0) end
+
+-- _PLAY_ANIMAL_VOCALIZATION_PHEROMONE_VIAL_RESPONSE  (0x0E53530D9B2DB01D)
+-- min build: 1311
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function _PlayAnimalVocalizationPheromoneVialResponse(ped, p1, p2) end
+
+-- _PLAY_SOUND_FROM_ENTITY_WITH_SET  (0xF1C5310FEAA36B48)
+-- Params: p5 seems to be always 0
+-- min build: 1207
+---@param soundId number
+---@param soundName string
+---@param entity number
+---@param soundsetName string
+---@param p4 boolean
+---@param p5 any
+function _PlaySoundFromEntityWithSet(soundId, soundName, entity, soundsetName, p4, p5) end
+
+-- _PLAY_SOUND_FROM_ITEM  (0xE8EAFF7B41EDD291)
+-- item: value returned from 0x2E1CDC1FF3B8473E
+-- soundSet: HUD_SHOP_SOUNDSET, COMPANIONS_ROBBERIES_SOUNDSET
+-- min build: 1207
+---@param item number
+---@param soundSet number
+---@param p2 any
+function _PlaySoundFromItem(item, soundSet, p2) end
+
+-- _PLAY_SOUND_FROM_POSITION  (0xCCE219C922737BFA)
+-- min build: 1207
+---@param audioName string
+---@param x number
+---@param y number
+---@param z number
+---@param audioRef string
+---@param isNetwork boolean
+---@param p6 any
+---@param p7 boolean
+---@param p8 any
+function _PlaySoundFromPosition(audioName, x, y, z, audioRef, isNetwork, p6, p7, p8) end
+
+-- _PLAY_SOUND_FROM_POSITION_WITH_ID  (0xDCF5BA95BBF0FABA)
+-- Starts Audio Loop
+-- _PLAY_SOUND_FROM_ENTITY* - _PLAY_SOUND_FRONTEND*
+-- min build: 1207
+---@param soundId number
+---@param soundName string
+---@param x number
+---@param y number
+---@param z number
+---@param soundsetName string
+---@param p6 boolean
+---@param p7 number
+---@param p8 boolean
+function _PlaySoundFromPositionWithId(soundId, soundName, x, y, z, soundsetName, p6, p7, p8) end
+
+-- _PLAY_SOUND_FROM_SCRIPTED_PED_AMBIENT_SPEECH  (0xB18FEC133C7C6C69)
+-- Play/advance a scripted speech created via _CREATE_NEW_SCRIPTED_PED_AMBIENT_SPEECH and return a status code.
+-- Return values:
+--   0 = not ready/invalid/failed
+--   1 = started/playing
+--   2 = finished/consumed (you can drop the handle)
+-- Typical usage: poll this in a tick after creating the speech; when it returns 2, clear your handle.
+-- min build: 1207
+---@param scriptedSpeech number
+---@return number
+function _PlaySoundFromScriptedPedAmbientSpeech(scriptedSpeech) end
+
+-- _PLAY_SOUND_FRONTEND_WITH_SOUND_ID  (0xCE5D0FFE83939AF1)
+-- min build: 1207
+---@param soundId number
+---@param name string
+---@param soundSet string
+---@param p3 boolean
+function _PlaySoundFrontendWithSoundId(soundId, name, soundSet, p3) end
+
+-- _RELEASE_SHARD_SOUNDS  (0x9D746964E0CF2C5F)
+-- min build: 1207
+---@param soundName string
+---@param soundsetName string
+function _ReleaseShardSounds(soundName, soundsetName) end
+
+-- _RELEASE_SOUNDSET  (0x531A78D6BF27014B)
+-- min build: 1207
+---@param soundsetName string
+function _ReleaseSoundset(soundsetName) end
+
+-- _SET_AMBIENT_ZONE_POSITION  (0x3743CE6948194349)
+-- min build: 1207
+---@param ambientZone string
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+function _SetAmbientZonePosition(ambientZone, x, y, z, heading) end
+
+-- _SET_AUDIO_SCENESET  (0xAC84686C06184B0D)
+-- min build: 1207
+---@param audioName string
+---@param sceneset string
+---@return boolean
+function _SetAudioSceneset(audioName, sceneset) end
+
+-- _SET_SOUND_RELATIONSHIP_ON_PED  (0x2E31ACA7477CF00F)
+-- p1: Entity.Relationship
+-- p2: Player, Enemy, Teammate, Neutral
+-- min build: 1207
+---@param ped number
+---@param p1 string
+---@param p2 string
+function _SetSoundRelationshipOnPed(ped, p1, p2) end
+
+-- _SET_VARIABLE_ON_SOUND_WITH_ID  (0x503703EC1781B7D6)
+-- min build: 1207
+---@param soundId number
+---@param variableName string
+---@param variableValue number
+function _SetVariableOnSoundWithId(soundId, variableName, variableValue) end
+
+-- _SET_VARIABLE_ON_SOUND_WITH_NAME  (0x9821B68CD3E05F2B)
+-- min build: 1207
+---@param variableName string
+---@param variableValue number
+---@param audioName string
+---@param audioRef string
+function _SetVariableOnSoundWithName(variableName, variableValue, audioName, audioRef) end
+
+-- _SET_VOFX_PED_VOICE  (0x2703EFB583F0949A)
+-- Hashes: VOFX_PLAYER_MALE01, VOFX_PLAYER_MALE02, VOFX_PLAYER_MALE03, VOFX_PLAYER_FEMALE01, VOFX_PLAYER_FEMALE02, VOFX_PLAYER_FEMALE03
+-- min build: 1207
+---@param ped number
+---@param voice number
+function _SetVofxPedVoice(ped, voice) end
+
+-- _SET_WHISTLE_CONFIG_FOR_PED  (0x9963681A8BC69BF3)
+-- whistleConfig: Ped.WhistlePitch (0.0 - 1.0), Ped.WhistleClarity (0.0 - 1.0), Ped.WhistleShape (0.0 - 10.0)
+-- min build: 1207
+---@param ped number
+---@param whistleConfig string
+---@param value number
+function _SetWhistleConfigForPed(ped, whistleConfig, value) end
+
+-- _START_AUDIO_SCENESET  (0x6339C1EA3979B5F7)
+-- min build: 1207
+---@param audioName string
+---@param sceneset string
+---@return boolean
+function _StartAudioSceneset(audioName, sceneset) end
+
+-- _STOP_ALL_SCRIPTED_AUDIO_SOUNDS  (0x2E399EAFBEEA74D5)
+-- min build: 1207
+function _StopAllScriptedAudioSounds() end
+
+-- _STOP_ALL_SCRIPTED_CONVERSIONS  (0x36559148B78853B3)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+---@param p2 boolean
+function _StopAllScriptedConversions(p0, p1, p2) end
+
+-- _STOP_AUDIO_SCENESET  (0x9428447DED71FC7E)
+-- min build: 1207
+---@param sceneset string
+function _StopAudioSceneset(sceneset) end
+
+-- _STOP_SOUND_WITH_ID  (0x3210BCB36AF7621B)
+-- min build: 1207
+---@param soundId number
+function _StopSoundWithId(soundId) end
+
+-- _STOP_SOUND_WITH_NAME  (0x0F2A2175734926D8)
+-- min build: 1207
+---@param audioName string
+---@param audioRef string
+function _StopSoundWithName(audioName, audioRef) end
+
+-- _TRIGGER_MUSIC_EVENT_WITH_HASH  (0x05D6195FB4D428F4)
+-- min build: 1207
+---@param eventName number
+---@return any
+function _TriggerMusicEventWithHash(eventName) end
+
+-- _UNLOAD_SPEECH_CONTEXT  (0x87E6302FC61208CC)
+-- _UNLOAD_[A-C]* - USE_*
+-- min build: 1207
+---@param speechContext string
+function _UnloadSpeechContext(speechContext) end
+
+-- _UPDATE_SOUND_POSITION  (0x0286617C8FC50A53)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param soundId number
+---@param x number
+---@param y number
+---@param z number
+function _UpdateSoundPosition(soundId, x, y, z) end
+
+-- ADD_ENTITY_TO_AUDIO_MIX_GROUP  (0x153973AB99FE8980)
+-- min build: 1207
+---@param entity number
+---@param groupName string
+---@param p2 number
+function AddEntityToAudioMixGroup(entity, groupName, p2) end
+
+-- ADD_PED_TO_CONVERSATION  (0x95D9F4BC443956E7)
+-- min build: 1207
+---@param convoRoot string
+---@param ped number
+---@param characterName string
+function AddPedToConversation(convoRoot, ped, characterName) end
+
+-- AUDIO_IS_MUSIC_PLAYING  (0x845FFC3A4FEEFA3E)
+-- Old name: AUDIO_IS_SCRIPTED_MUSIC_PLAYING
+-- min build: 1207
+---@return boolean
+function AudioIsMusicPlaying() end
+
+-- AUDIO_TRIGGER_EXPLOSION  (0x374F0E716BFCDE82)
+-- min build: 1207
+---@param name string
+---@param x number
+---@param y number
+---@param z number
+function AudioTriggerExplosion(name, x, y, z) end
+
+-- CANCEL_MUSIC_EVENT  (0x5B17A90291133DA5)
+-- min build: 1207
+---@param eventName string
+---@return boolean
+function CancelMusicEvent(eventName) end
+
+-- CLEAR_AMBIENT_ZONE_LIST_STATE  (0x120C48C614909FA4)
+-- min build: 1207
+---@param ambientZone string
+---@param p1 boolean
+function ClearAmbientZoneListState(ambientZone, p1) end
+
+-- CLEAR_AMBIENT_ZONE_STATE  (0x218DD44AAAC964FF)
+-- min build: 1207
+---@param zoneName string
+---@param p1 boolean
+function ClearAmbientZoneState(zoneName, p1) end
+
+-- CLEAR_CONVERSATION_HISTORY  (0x33D51F801CB16E4F)
+-- min build: 1207
+function ClearConversationHistory() end
+
+-- CREATE_NEW_SCRIPTED_CONVERSATION  (0xD2C91A0B572AAE56)
+-- min build: 1207
+---@param convoRoot string
+---@return boolean
+function CreateNewScriptedConversation(convoRoot) end
+
+-- DISABLE_PED_PAIN_AUDIO  (0xA9A41C1E940FB0E8)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function DisablePedPainAudio(ped, toggle) end
+
+-- DOES_CONTEXT_EXIST_FOR_THIS_PED  (0x49B99BF3FDA89A7A)
+-- Checks if the ped can play the speech or has the speech file, last parameter is usually false.
+-- min build: 1207
+---@param ped number
+---@param speechName string
+---@param unk boolean
+---@return boolean
+function DoesContextExistForThisPed(ped, speechName, unk) end
+
+-- FORCE_PED_PANIC_WALLA  (0x062D5EAD4DA2FA6A)
+-- min build: 1207
+function ForcePedPanicWalla() end
+
+-- FORCE_USE_AUDIO_GAME_OBJECT  (0x4F0C413926060B38)
+-- Old name: _FORCE_VEHICLE_ENGINE_AUDIO
+-- min build: 1207
+---@param vehicle number
+---@param audioName string
+function ForceUseAudioGameObject(vehicle, audioName) end
+
+-- GET_CURRENT_SCRIPTED_CONVERSATION_LINE  (0x480357EE890C295A)
+-- min build: 1207
+---@param p0 string
+---@return number
+function GetCurrentScriptedConversationLine(p0) end
+
+-- GET_MUSIC_PLAYTIME  (0xE7A0D23DC414507B)
+-- min build: 1207
+---@return number
+function GetMusicPlaytime() end
+
+-- GET_SOUND_ID  (0x430386FE9BF80B45)
+-- min build: 1207
+---@return number
+function GetSoundId() end
+
+-- IS_AMBIENT_SPEECH_DISABLED  (0x932C2D096A2C3FFF)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsAmbientSpeechDisabled(ped) end
+
+-- IS_AMBIENT_SPEECH_PLAYING  (0x9072C8B49907BFAD)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsAmbientSpeechPlaying(ped) end
+
+-- IS_ANIMAL_VOCALIZATION_PLAYING  (0xC265DF9FB44A9FBD)
+-- min build: 1207
+---@param pedHandle number
+---@return boolean
+function IsAnimalVocalizationPlaying(pedHandle) end
+
+-- IS_ANY_SPEECH_PLAYING  (0x729072355FA39EC9)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsAnySpeechPlaying(ped) end
+
+-- IS_AUDIO_SCENE_ACTIVE  (0xB65B60556E2A9225)
+-- min build: 1207
+---@param scene string
+---@return boolean
+function IsAudioSceneActive(scene) end
+
+-- IS_HORN_ACTIVE  (0x9D6BFC12B05C6121)
+-- Checks whether the horn of a vehicle is currently played.
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsHornActive(vehicle) end
+
+-- IS_PED_IN_CURRENT_CONVERSATION  (0x049E937F18F4020C)
+-- min build: 1207
+---@param p0 string
+---@param ped number
+---@param p2 any
+---@return boolean
+function IsPedInCurrentConversation(p0, ped, p2) end
+
+-- IS_SCRIPTED_CONVERSATION_LOADED  (0xDF0D54BE7A776737)
+-- min build: 1207
+---@param convoRoot string
+---@return boolean
+function IsScriptedConversationLoaded(convoRoot) end
+
+-- IS_SCRIPTED_CONVERSATION_PLAYING  (0x1ECC76792F661CF5)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function IsScriptedConversationPlaying(p0) end
+
+-- IS_SCRIPTED_SPEECH_PLAYING  (0xCC9AA18DCC7084F4)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function IsScriptedSpeechPlaying(p0) end
+
+-- IS_STREAM_PLAYING  (0xD11FA52EB849D978)
+-- min build: 1207
+---@param streamId number
+---@return boolean
+function IsStreamPlaying(streamId) end
+
+-- LOAD_STREAM  (0x1F1F957154EC51DF)
+-- min build: 1207
+---@param streamName string
+---@param soundSet string
+---@return boolean
+function LoadStream(streamName, soundSet) end
+
+-- PAUSE_SCRIPTED_CONVERSATION  (0x8530AD776CD72B12)
+-- min build: 1207
+---@param p0 string
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+function PauseScriptedConversation(p0, p1, p2, p3, p4) end
+
+-- PLAY_AMBIENT_SPEECH_FROM_POSITION_NATIVE  (0xED640017ED337E45)
+-- Play a speech from a position.
+-- params struct for ScriptedSpeechParams see: PLAY_PED_AMBIENT_SPEECH_NATIVE
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return any
+function PlayAmbientSpeechFromPositionNative(x, y, z) end
+
+-- PLAY_ANIMAL_VOCALIZATION  (0xEE066C7006C49C0A)
+-- min build: 1207
+---@param ped number
+---@param vocalizationName string
+---@param p2 boolean
+function PlayAnimalVocalization(ped, vocalizationName, p2) end
+
+-- PLAY_END_CREDITS_MUSIC  (0xCD536C4D33DCC900)
+-- min build: 1207
+---@param play boolean
+function PlayEndCreditsMusic(play) end
+
+-- PLAY_PAIN  (0xBC9AE166038A5CEC)
+-- Valid pain IDs: 0..12
+-- min build: 1207
+---@param ped number
+---@param painId number
+---@param p2 number
+---@param p3 boolean
+---@param isNetwork boolean
+function PlayPain(ped, painId, p2, p3, isNetwork) end
+
+-- PLAY_PED_AMBIENT_SPEECH_NATIVE  (0x8E04FEDD28D42462)
+-- struct ScriptedSpeechParams
+-- {
+-- 	const char* speechName;
+-- 	const char* voiceName;
+-- 	alignas(8) int variation;
+-- 	alignas(8) Hash speechParamHash;
+-- 	alignas(8) Ped listenerPed;
+-- 	alignas(8) BOOL syncOverNetwork;
+-- 	alignas(8) int v7;
+-- 	alignas(8) int v8;
+-- };
+-- 
+-- static_assert(sizeof(ScriptedSpeechParams) == 0x40, "incorrect ScriptedSpeechParams size");
+-- 
+-- 
+-- Example:
+-- 
+-- ScriptedSpeechParams params{"RE_PH_RHD_V3_AGGRO", "0405_U_M_M_RhdSheriff_01", 1, joaat("SPEECH_PARAMS_BEAT_SHOUTED_CLEAR"), 0, true, 1, 1};
+-- PLAY_PED_AMBIENT_SPEECH_NATIVE(PLAYER_PED_ID(), (Any*)&params);
+-- 
+-- Old name: _PLAY_AMBIENT_SPEECH1
+-- https://github.com/femga/rdr3_discoveries/tree/master/audio/audio_banks
+-- min build: 1207
+---@param speaker number
+---@return boolean
+---@return any
+function PlayPedAmbientSpeechNative(speaker) end
+
+-- PLAY_SOUND  (0x7FF4944CC209192D)
+-- min build: 1207
+---@param audioName string
+---@param audioRef string
+---@param p2 boolean
+---@param p3 any
+---@param p4 boolean
+---@param p5 any
+function PlaySound(audioName, audioRef, p2, p3, p4, p5) end
+
+-- PLAY_SOUND_FROM_ENTITY  (0x6FB1DA3CA9DA7D90)
+-- min build: 1207
+---@param audioName string
+---@param entity number
+---@param audioRef string
+---@param isNetwork boolean
+---@param p4 any
+---@param p5 any
+function PlaySoundFromEntity(audioName, entity, audioRef, isNetwork, p4, p5) end
+
+-- PLAY_SOUND_FRONTEND  (0x67C540AA08E4A6F5)
+-- https://github.com/femga/rdr3_discoveries/tree/master/audio/frontend_soundsets
+-- min build: 1207
+---@param audioName string
+---@param audioRef string
+---@param p2 boolean
+---@param p3 any
+function PlaySoundFrontend(audioName, audioRef, p2, p3) end
+
+-- PLAY_STREAM_FROM_PED  (0x89049DD63C08B5D1)
+-- min build: 1207
+---@param ped number
+---@param streamId number
+function PlayStreamFromPed(ped, streamId) end
+
+-- PLAY_STREAM_FROM_POSITION  (0x21442F412E8DE56B)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param streamId number
+function PlayStreamFromPosition(x, y, z, streamId) end
+
+-- PLAY_STREAM_FRONTEND  (0x58FCE43488F9F5F4)
+-- min build: 1207
+---@param streamId number
+function PlayStreamFrontend(streamId) end
+
+-- PRELOAD_SCRIPT_CONVERSATION  (0x3B3CAD6166916D87)
+-- min build: 1207
+---@param convoRoot string
+---@param p1 boolean
+---@param p2 boolean
+---@param clone boolean
+function PreloadScriptConversation(convoRoot, p1, p2, clone) end
+
+-- PREPARE_MUSIC_EVENT  (0x1E5185B72EF5158A)
+-- min build: 1207
+---@param eventName string
+---@return boolean
+function PrepareMusicEvent(eventName) end
+
+-- PREPARE_SOUND  (0xE368E8422C860BA7)
+-- min build: 1207
+---@param soundName string
+---@param soundsetName string
+---@param soundId number
+---@return boolean
+function PrepareSound(soundName, soundsetName, soundId) end
+
+-- PREPARE_SOUND_WITH_ENTITY  (0x4AD019591E94C064)
+-- min build: 1207
+---@param soundName string
+---@param entity number
+---@param soundsetName string
+---@param soundId number
+---@return boolean
+function PrepareSoundWithEntity(soundName, entity, soundsetName, soundId) end
+
+-- PREPARE_SOUNDSET  (0xD9130842D7226045)
+-- https://github.com/femga/rdr3_discoveries/tree/master/audio/soundsets
+-- min build: 1207
+---@param soundsetName string
+---@param p1 boolean
+---@return boolean
+function PrepareSoundset(soundsetName, p1) end
+
+-- REGISTER_SCRIPT_WITH_AUDIO  (0xC6ED9D5092438D91)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 boolean
+function RegisterScriptWithAudio(p0) end
+
+-- RELEASE_NAMED_SCRIPT_AUDIO_BANK  (0x77ED170667F50170)
+-- min build: 1207
+---@param audioBank string
+function ReleaseNamedScriptAudioBank(audioBank) end
+
+-- RELEASE_SCRIPT_AUDIO_BANK  (0x7A2D8AD0A9EB9C3F)
+-- min build: 1207
+function ReleaseScriptAudioBank() end
+
+-- RELEASE_SOUND_ID  (0x353FC880830B88FA)
+-- min build: 1207
+---@param soundId number
+function ReleaseSoundId(soundId) end
+
+-- REMOVE_ENTITY_FROM_AUDIO_MIX_GROUP  (0x18EB48CFC41F2EA0)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+function RemoveEntityFromAudioMixGroup(entity, p1) end
+
+-- REMOVE_PORTAL_SETTINGS_OVERRIDE  (0xB4BBFD9CD8B3922B)
+-- min build: 1207
+---@param p0 string
+function RemovePortalSettingsOverride(p0) end
+
+-- REQUEST_SCRIPT_AUDIO_BANK  (0x2F844A8B08D76685)
+-- min build: 1207
+---@param audioBank string
+---@return boolean
+function RequestScriptAudioBank(audioBank) end
+
+-- RESTART_SCRIPTED_CONVERSATION  (0x9AEB285D1818C9AC)
+-- min build: 1207
+---@param p0 string
+function RestartScriptedConversation(p0) end
+
+-- SET_AMBIENT_VOICE_NAME  (0x6C8065A3B780185B)
+-- min build: 1207
+---@param ped number
+---@param name string
+function SetAmbientVoiceName(ped, name) end
+
+-- SET_AMBIENT_ZONE_LIST_STATE  (0x9748FA4DE50CCE3E)
+-- min build: 1207
+---@param ambientZone string
+---@param p1 boolean
+---@param p2 boolean
+function SetAmbientZoneListState(ambientZone, p1, p2) end
+
+-- SET_AMBIENT_ZONE_LIST_STATE_PERSISTENT  (0xF3638DAE8C4045E1)
+-- min build: 1207
+---@param ambientZone string
+---@param p1 boolean
+---@param p2 boolean
+function SetAmbientZoneListStatePersistent(ambientZone, p1, p2) end
+
+-- SET_AMBIENT_ZONE_STATE  (0xBDA07E5950085E46)
+-- min build: 1207
+---@param zoneName string
+---@param isEnabled boolean
+---@param p2 boolean
+function SetAmbientZoneState(zoneName, isEnabled, p2) end
+
+-- SET_AMBIENT_ZONE_STATE_PERSISTENT  (0x1D6650420CEC9D3B)
+-- min build: 1207
+---@param ambientZone string
+---@param p1 boolean
+---@param p2 boolean
+function SetAmbientZoneStatePersistent(ambientZone, p1, p2) end
+
+-- SET_ANIMAL_MOOD  (0xCC97B29285B1DC3B)
+-- Not implemented.
+-- min build: 1207
+---@param animal number
+---@param mood number
+function SetAnimalMood(animal, mood) end
+
+-- SET_AUDIO_FLAG  (0xB9EFD5C25018725A)
+-- Audio flags can be found here: https://pastebin.com/40qPV6EJ
+-- https://github.com/femga/rdr3_discoveries/tree/master/audio/audio_flags
+-- min build: 1207
+---@param flagName string
+---@param toggle boolean
+function SetAudioFlag(flagName, toggle) end
+
+-- SET_AUDIO_ONLINE_TRANSITION_STAGE  (0x9B1FC259187C97C0)
+-- min build: 1207
+---@param p0 string
+function SetAudioOnlineTransitionStage(p0) end
+
+-- SET_AUDIO_SCENE_VARIABLE  (0xEF21A9EF089A2668)
+-- min build: 1207
+---@param scene string
+---@param variable string
+---@param value number
+function SetAudioSceneVariable(scene, variable, value) end
+
+-- SET_AUDIO_VEHICLE_PRIORITY  (0xE5564483E407F914)
+-- min build: 1207
+---@param vehicle number
+---@param p1 any
+function SetAudioVehiclePriority(vehicle, p1) end
+
+-- SET_GPS_ACTIVE  (0x3BD3F52BA9B1E4E8)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param active boolean
+function SetGpsActive(active) end
+
+-- SET_HORN_ENABLED  (0x76D683C108594D0E)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetHornEnabled(vehicle, toggle) end
+
+-- SET_IS_SCRIPTED_SPEECH_DISABLED  (0xB2DE3AEBE31150E2)
+-- min build: 1207
+---@param ped number
+---@param disabled boolean
+---@return any
+function SetIsScriptedSpeechDisabled(ped, disabled) end
+
+-- SET_PED_INTERIOR_WALLA_DENSITY  (0x8BF907833BE275DE)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function SetPedInteriorWallaDensity(p0, p1) end
+
+-- SET_PED_IS_DRUNK  (0x95D2D383D5396B8A)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedIsDrunk(ped, toggle) end
+
+-- SET_PED_WALLA_DENSITY  (0x149AEE66F0CB3A99)
+-- https://en.m.wikipedia.org/wiki/Walla
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function SetPedWallaDensity(p0, p1) end
+
+-- SET_PORTAL_SETTINGS_OVERRIDE  (0x044DBAD7A7FA2BE5)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+function SetPortalSettingsOverride(p0, p1) end
+
+-- SET_STATIC_EMITTER_ENABLED  (0x399D2D3B33F1B8EB)
+-- min build: 1207
+---@param emitterName string
+---@param toggle boolean
+function SetStaticEmitterEnabled(emitterName, toggle) end
+
+-- SKIP_TO_NEXT_SCRIPTED_CONVERSATION_LINE  (0x9663FE6B7A61EB00)
+-- min build: 1207
+---@param p0 string
+function SkipToNextScriptedConversationLine(p0) end
+
+-- START_AUDIO_SCENE  (0x013A80FC08F6E4F2)
+-- min build: 1207
+---@param scene string
+---@return boolean
+function StartAudioScene(scene) end
+
+-- START_PRELOADED_CONVERSATION  (0x23641AFE870AF385)
+-- min build: 1207
+---@param convoRoot string
+function StartPreloadedConversation(convoRoot) end
+
+-- START_SCRIPT_CONVERSATION  (0x6B17C62C9635D2DC)
+-- min build: 1207
+---@param convoRoot string
+---@param p1 boolean
+---@param p2 boolean
+---@param clone boolean
+function StartScriptConversation(convoRoot, p1, p2, clone) end
+
+-- STOP_AUDIO_SCENE  (0xDFE8422B3B94E688)
+-- min build: 1207
+---@param scene string
+function StopAudioScene(scene) end
+
+-- STOP_AUDIO_SCENES  (0xBAC7FC81A75EC1A1)
+-- min build: 1207
+function StopAudioScenes() end
+
+-- STOP_CURRENT_PLAYING_AMBIENT_SPEECH  (0xB8BEC0CA6F0EDB0F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function StopCurrentPlayingAmbientSpeech(ped, p1) end
+
+-- STOP_CURRENT_PLAYING_SPEECH  (0x79D2F0E66F81D90D)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function StopCurrentPlayingSpeech(ped, p1) end
+
+-- STOP_PED_SPEAKING  (0x9D64D7405520E3D3)
+-- min build: 1207
+---@param ped number
+---@param shaking boolean
+function StopPedSpeaking(ped, shaking) end
+
+-- STOP_SCRIPTED_CONVERSATION  (0xD79DEEFB53455EBA)
+-- min build: 1207
+---@param p0 string
+---@param p1 boolean
+---@param p2 boolean
+---@return number
+function StopScriptedConversation(p0, p1, p2) end
+
+-- STOP_STREAM  (0xA4718A1419D18151)
+-- min build: 1207
+---@param streamId number
+function StopStream(streamId) end
+
+-- TRIGGER_MUSIC_EVENT  (0x706D57B0F50DA710)
+-- https://github.com/femga/rdr3_discoveries/blob/master/audio/music_events/music_events.lua
+-- min build: 1207
+---@param eventName string
+---@return boolean
+function TriggerMusicEvent(eventName) end
+
+-- UNREGISTER_SCRIPT_WITH_AUDIO  (0xA8638BE228D4751A)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function UnregisterScriptWithAudio() end
+
+-- USE_FOOTSTEP_SCRIPT_SWEETENERS  (0xBF4DC1784BE94DFA)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param hash number
+function UseFootstepScriptSweeteners(ped, p1, hash) end

--- a/.luals/redm-natives/BOUNTY.lua
+++ b/.luals/redm-natives/BOUNTY.lua
@@ -1,0 +1,220 @@
+---@meta
+
+-- RDR3 namespace: BOUNTY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x27D3A0E1FE090A43  (0x27D3A0E1FE090A43)
+-- _BOUNTY_IS_* or _BOUNTY_REQUEST_*
+-- min build: 1207
+---@return boolean
+---@return any
+function N_0x27D3A0E1FE090A43() end
+
+-- _0x81847C2134039BDC  (0x81847C2134039BDC)
+-- min build: 1207
+---@return boolean
+---@return any
+function N_0x81847C2134039BDC() end
+
+-- _0x86EC5F83867C4B70  (0x86EC5F83867C4B70)
+-- _BOUNTY_C* or _BOUNTY_GET_*
+-- min build: 1436
+---@return boolean
+---@return any
+function N_0x86EC5F83867C4B70() end
+
+-- _0xD6A67E2FF373D0E3  (0xD6A67E2FF373D0E3)
+-- _BOUNTY_GET_*
+-- min build: 1355
+---@param p0 number
+---@return number
+function N_0xD6A67E2FF373D0E3(p0) end
+
+-- _0xF8BCC5ECA33AC9C1  (0xF8BCC5ECA33AC9C1)
+-- _BOUNTY_GET_*
+-- min build: 1207
+---@return number
+function N_0xF8BCC5ECA33AC9C1() end
+
+-- _BOUNTY_CANCEL_LEGENDARY_MISSION  (0x2BA1BCC99826CDA2)
+-- min build: 1207
+function _BountyCancelLegendaryMission() end
+
+-- _BOUNTY_CANCEL_WANTED_POSTER  (0x6A9DF0FCD0C87FF9)
+-- min build: 1207
+function _BountyCancelWantedPoster() end
+
+-- _BOUNTY_CLEAR_BEING_BOUNTY_HUNTER  (0xA59D1997ECD99F0A)
+-- min build: 1207
+function _BountyClearBeingBountyHunter() end
+
+-- _BOUNTY_CLEAR_BEING_TARGET  (0x932DB3C05A7465D1)
+-- min build: 1207
+function _BountyClearBeingTarget() end
+
+-- _BOUNTY_IS_REQUEST_PENDING  (0x03B61CD51097DE60)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyIsRequestPending() end
+
+-- _BOUNTY_REQUEST_BECOME_TARGET_OF_CHARACTER_BOUNTY_HUNT  (0xB096547D61868254)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestBecomeTargetOfCharacterBountyHunt() end
+
+-- _BOUNTY_REQUEST_BEGIN_WANTED_POSTER  (0xFFA13742E43507E3)
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+function _BountyRequestBeginWantedPoster(p1) end
+
+-- _BOUNTY_REQUEST_BRIBE_JAIL_GUARD  (0x28717806D3BDD0D0)
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+function _BountyRequestBribeJailGuard(p1) end
+
+-- _BOUNTY_REQUEST_CLAIM_CHARACTER_BOUNTY  (0xA9C3B0F746375162)
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+---@return any
+function _BountyRequestClaimCharacterBounty(p1) end
+
+-- _BOUNTY_REQUEST_COMPLETE_LEGENDARY_MISSION  (0xA7309AC0DCF6D950)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _BountyRequestCompleteLegendaryMission() end
+
+-- _BOUNTY_REQUEST_COMPLETE_SPLIT_WANTED_POSTER  (0xFBD137BF0EC50FC9)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _BountyRequestCompleteSplitWantedPoster() end
+
+-- _BOUNTY_REQUEST_COMPLETE_WANTED_POSTER  (0x727AB6F008BB9F29)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _BountyRequestCompleteWantedPoster() end
+
+-- _BOUNTY_REQUEST_ESCAPED_CHARACTER_BOUNTY_HUNT  (0x12E981D53B07BF48)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestEscapedCharacterBountyHunt() end
+
+-- _BOUNTY_REQUEST_PAY_OFF_BOUNTY  (0x537CE992BD2D7BCB)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestPayOffBounty() end
+
+-- _BOUNTY_REQUEST_PAY_OFF_BOUNTY_EX  (0x587BCEC31D64F382)
+-- min build: 1232
+---@param p1 number
+---@param costType number
+---@return boolean
+---@return any
+function _BountyRequestPayOffBountyEx(p1, costType) end
+
+-- _BOUNTY_REQUEST_POSSE_LEADER_CLAIM_CHARACTER_BOUNTY  (0x5B53CA0E2AC3FF45)
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+---@return any
+function _BountyRequestPosseLeaderClaimCharacterBounty(p1) end
+
+-- _BOUNTY_REQUEST_POSSE_LEADER_ESCAPED_CHARACTER_BOUNTY_HUNT  (0x2D874BA20E8E1F20)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestPosseLeaderEscapedCharacterBountyHunt() end
+
+-- _BOUNTY_REQUEST_POSSE_MEMBER_CLAIM_CHARACTER_BOUNTY_SHARE  (0x22D3A61CE053270C)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _BountyRequestPosseMemberClaimCharacterBountyShare() end
+
+-- _BOUNTY_REQUEST_POSSE_MEMBER_ESCAPED_CHARACTER_BOUNTY_HUNT  (0x8521C2E235558278)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestPosseMemberEscapedCharacterBountyHunt() end
+
+-- _BOUNTY_REQUEST_SELF_REPORT_CRIME  (0x188B748861B5BA17)
+-- crimeType: see _REPORT_CRIME
+-- min build: 1207
+---@param crimeType number
+---@param p2 boolean
+---@return boolean
+---@return any
+function _BountyRequestSelfReportCrime(crimeType, p2) end
+
+-- _BOUNTY_REQUEST_SELF_REPORT_KILLED_BY_BOUNTY_HUNTER  (0xB462D69D406A2602)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestSelfReportKilledByBountyHunter() end
+
+-- _BOUNTY_REQUEST_SERVED_FULL_JAIL_SENTENCE  (0x3F73AED12A5EF0FF)
+-- min build: 1207
+---@return boolean
+---@return any
+function _BountyRequestServedFullJailSentence() end
+
+-- BOUNTY_GET_BOUNTY_ON_PLAYER  (0x4EF23E04A0C8FF51)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function BountyGetBountyOnPlayer() end
+
+-- BOUNTY_GET_COOLDOWN_COLLECTION  (0x8FAF4D262FABA99C)
+-- min build: 1207
+---@return boolean
+---@return any
+function BountyGetCooldownCollection() end
+
+-- BOUNTY_GET_LEGENDARY_TARGET  (0x85E4D7B225A30ED1)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+---@return any
+function BountyGetLegendaryTarget(p0) end
+
+-- BOUNTY_GET_WANTED_POSTER_SLOT  (0xB395A44A0C7CA615)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return boolean
+---@return any
+function BountyGetWantedPosterSlot(p0, p1) end
+
+-- BOUNTY_REQUEST_BEGIN_LEGENDARY_MISSION  (0xFC81D7C7A151CFAA)
+-- min build: 1207
+---@param p1 number
+---@param p2 number
+---@return boolean
+---@return any
+function BountyRequestBeginLegendaryMission(p1, p2) end
+
+-- BOUNTY_REQUEST_BEGIN_LEGENDARY_MISSION_FOR_POSSE  (0x48E4E23F1739E197)
+-- min build: 1311
+---@param p1 number
+---@param p2 number
+---@return boolean
+---@return any
+function BountyRequestBeginLegendaryMissionForPosse(p1, p2) end

--- a/.luals/redm-natives/BRAIN.lua
+++ b/.luals/redm-natives/BRAIN.lua
@@ -1,0 +1,84 @@
+---@meta
+
+-- RDR3 namespace: BRAIN -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x4AA5EA1EDFB25786  (0x4AA5EA1EDFB25786)
+-- Called with flag 0 before 0xA6AC35DB4A7957A8 in net_entity_brain
+-- _SET_SCRIPT_BRAIN*
+-- min build: 1207
+---@param flag number
+function N_0x4AA5EA1EDFB25786(flag) end
+
+-- _0xA6AC35DB4A7957A8  (0xA6AC35DB4A7957A8)
+-- Common flags: 250, 99999
+-- _SET_SCRIPT_BRAIN*
+-- min build: 1207
+---@param flag number
+function N_0xA6AC35DB4A7957A8(flag) end
+
+-- _GET_SCRIPT_BRAIN_ENTITY  (0x6818D1A194E29983)
+-- min build: 1207
+---@return number
+function _GetScriptBrainEntity() end
+
+-- _REMOVE_SCRIPT_BRAIN_ENTITY  (0x38F1E09224EECA09)
+-- min build: 1311
+---@param entity number
+function _RemoveScriptBrainEntity(entity) end
+
+-- _START_PRELOADED_SCRIPT_BRAIN  (0x4E4507CC5E4DB869)
+-- Returns threadId
+-- min build: 1207
+---@param entity number
+---@param scriptName string
+---@param scriptStackSize number
+---@param p3 boolean
+---@return number
+function _StartPreloadedScriptBrain(entity, scriptName, scriptStackSize, p3) end
+
+-- _START_SCRIPT_BRAIN  (0x6F62FAE266DCFC81)
+-- Returns threadId
+-- min build: 1207
+---@param entity number
+---@param scriptName string
+---@param p2 number
+---@param p4 number
+---@param p5 boolean
+---@return number
+---@return any
+function _StartScriptBrain(entity, scriptName, p2, p4, p5) end
+
+-- DISABLE_SCRIPT_BRAIN_SET  (0x3F44EA613A5B2676)
+-- min build: 1207
+---@param brainSet number
+function DisableScriptBrainSet(brainSet) end
+
+-- ENABLE_SCRIPT_BRAIN_SET  (0x1CF6E5C6750EADBD)
+-- min build: 1207
+---@param brainSet number
+function EnableScriptBrainSet(brainSet) end
+
+-- REACTIVATE_ALL_OBJECT_BRAINS_THAT_ARE_WAITING_TILL_OUT_OF_RANGE  (0xA32B0B05EFF75730)
+-- Called before starting a new thread_monitor script thread in startup_mp/startup_tlg
+-- Alternative name _REGISTER_SCRIPT_BRAIN
+-- 
+-- Old name: _PREPARE_SCRIPT_BRAIN
+-- min build: 1207
+function ReactivateAllObjectBrainsThatAreWaitingTillOutOfRange() end
+
+-- REACTIVATE_NAMED_OBJECT_BRAINS_WAITING_TILL_OUT_OF_RANGE  (0x74C333E34DF74E8A)
+-- min build: 1207
+---@param scriptName string
+function ReactivateNamedObjectBrainsWaitingTillOutOfRange(scriptName) end
+
+-- REGISTER_OBJECT_SCRIPT_BRAIN  (0x16AF9B4EEAC3B305)
+-- Registers a script for any object with a specific model hash.
+-- min build: 1207
+---@param scriptName string
+---@param modelHash number
+---@param p2 number
+---@param activationRange number
+---@param p4 number
+---@param p5 number
+function RegisterObjectScriptBrain(scriptName, modelHash, p2, activationRange, p4, p5) end

--- a/.luals/redm-natives/BUILTIN.lua
+++ b/.luals/redm-natives/BUILTIN.lua
@@ -1,0 +1,161 @@
+---@meta
+
+-- RDR3 namespace: BUILTIN -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- CEIL  (0x11E019C8F43ACC8A)
+-- Rounds a float value up to the next whole number
+-- min build: 1207
+---@param value number
+---@return number
+function Ceil(value) end
+
+-- COS  (0xD0FFB162F40A139C)
+-- min build: 1207
+---@param value number
+---@return number
+function Cos(value) end
+
+-- FLOOR  (0xF34EE736CF047844)
+-- Rounds a float value down to the next whole number
+-- min build: 1207
+---@param value number
+---@return number
+function Floor(value) end
+
+-- LOG10  (0xE816E655DE37FE20)
+-- Old name: _LOG10
+-- min build: 1232
+---@param value number
+---@return number
+function Log10(value) end
+
+-- POW  (0xE3621CC40F31FE2E)
+-- min build: 1207
+---@param base number
+---@param exponent number
+---@return number
+function Pow(base, exponent) end
+
+-- ROUND  (0xF2DB717A73826179)
+-- min build: 1207
+---@param value number
+---@return number
+function Round(value) end
+
+-- SET_THIS_THREAD_PRIORITY  (0x42B65DEEF2EDF2A1)
+-- THREAD_PRIO_HIGHEST = 0
+-- THREAD_PRIO_NORMAL = 1
+-- THREAD_PRIO_LOWEST = 2
+-- THREAD_PRIO_MANUAL_UPDATE = 100
+-- min build: 1207
+---@param priority number
+function SetThisThreadPriority(priority) end
+
+-- SETTIMERA  (0xC1B1E9A034A63A62)
+-- min build: 1207
+---@param value number
+function Settimera(value) end
+
+-- SETTIMERB  (0x5AE11BC36633DE4E)
+-- min build: 1207
+---@param value number
+function Settimerb(value) end
+
+-- SHIFT_LEFT  (0xEDD95A39E5544DE8)
+-- min build: 1207
+---@param value number
+---@param bitShift number
+---@return number
+function ShiftLeft(value, bitShift) end
+
+-- SHIFT_RIGHT  (0x97EF1E5BCE9DC075)
+-- min build: 1207
+---@param value number
+---@param bitShift number
+---@return number
+function ShiftRight(value, bitShift) end
+
+-- SIN  (0x0BADBFA3B172435F)
+-- min build: 1207
+---@param value number
+---@return number
+function Sin(value) end
+
+-- SQRT  (0x71D93B57D07F9804)
+-- min build: 1207
+---@param value number
+---@return number
+function Sqrt(value) end
+
+-- TIMERA  (0x83666F9FB8FEBD4B)
+-- Counts up. Every 1000 is 1 real-time second. Use SETTIMERA(int value) to set the timer (e.g.: SETTIMERA(0)).
+-- min build: 1207
+---@return number
+function Timera() end
+
+-- TIMERB  (0xC9D9444186B5A374)
+-- min build: 1207
+---@return number
+function Timerb() end
+
+-- TIMESTEP  (0x0000000050597EE2)
+-- Gets the current frame time.
+-- min build: 1207
+---@return number
+function Timestep() end
+
+-- TO_FLOAT  (0xBBDA792448DB5A89)
+-- min build: 1207
+---@param value number
+---@return number
+function ToFloat(value) end
+
+-- VDIST  (0x2A488C176D52CCA5)
+-- Calculates distance between vectors.
+-- The value returned will be in meters.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@return number
+function Vdist(x1, y1, z1, x2, y2, z2) end
+
+-- VDIST2  (0xB7A628320EFF8E47)
+-- Calculates distance between vectors but does not perform Sqrt operations. (Its way faster)
+-- The value returned will be in RAGE units.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@return number
+function Vdist2(x1, y1, z1, x2, y2, z2) end
+
+-- VMAG  (0x652D2EEEF1D3E62C)
+-- Calculates the magnitude of a vector.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function Vmag(x, y, z) end
+
+-- VMAG2  (0xA8CEACB4F35AE058)
+-- Calculates the magnitude of a vector but does not perform Sqrt operations. (Its way faster)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function Vmag2(x, y, z) end
+
+-- WAIT  (0x4EDE34FBADD967A6)
+-- min build: 1207
+---@param ms number
+function Wait(ms) end

--- a/.luals/redm-natives/CAMERA.lua
+++ b/.luals/redm-natives/CAMERA.lua
@@ -1,0 +1,1506 @@
+---@meta
+
+-- RDR3 namespace: CAMERA -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0060B31968E60E41  (0x0060B31968E60E41)
+-- shakeNames in script_rel: CORRECTOR_SHAKE, MINIGAME_BOUNTY_SHAKE, POV_DRUNK_SHAKE, DRUNK_SHAKE, MINIGAME_TRAIN_SHAKE
+-- _IS_GAMEPLAY_*
+-- min build: 1207
+---@param shakeName string
+---@return boolean
+function N_0x0060B31968E60E41(shakeName) end
+
+-- _0x04084490CC302CFB  (0x04084490CC302CFB)
+-- min build: 1207
+function N_0x04084490CC302CFB() end
+
+-- _0x06557F6D96C86881  (0x06557F6D96C86881)
+-- min build: 1207
+function N_0x06557F6D96C86881() end
+
+-- _0x0961B089947BA6D0  (0x0961B089947BA6D0)
+-- min build: 1207
+---@param p0 any
+function N_0x0961B089947BA6D0(p0) end
+
+-- _0x0F1FFEF5D54AE832  (0x0F1FFEF5D54AE832)
+-- NPLOI_UPDATE__GUN_SPINNING_PREVIEW - Adjusting Camera / Ped Reset Flags This Frame
+-- _DISABLE_*
+-- min build: 1207
+function N_0x0F1FFEF5D54AE832() end
+
+-- _0x0FF7125F07DEB84F  (0x0FF7125F07DEB84F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0FF7125F07DEB84F(p0, p1) end
+
+-- _0x1204EB53A5FBC63D  (0x1204EB53A5FBC63D)
+-- Used for DUELING_LOCK_CAMERA_CONTROLS_THIS_FRAME: Disabling look/aim controls
+-- _IS_SC(REEN_)* (?)
+-- min build: 1207
+---@return boolean
+function N_0x1204EB53A5FBC63D() end
+
+-- _0x14C4A49E36C29E49  (0x14C4A49E36C29E49)
+-- min build: 1207
+---@return any
+function N_0x14C4A49E36C29E49() end
+
+-- _0x16E9ABDD34DDD931  (0x16E9ABDD34DDD931)
+-- min build: 1207
+function N_0x16E9ABDD34DDD931() end
+
+-- _0x1811A02277A9E49D  (0x1811A02277A9E49D)
+-- min build: 1207
+---@return boolean
+function N_0x1811A02277A9E49D() end
+
+-- _0x18C3DFAC458783BB  (0x18C3DFAC458783BB)
+-- min build: 1207
+function N_0x18C3DFAC458783BB() end
+
+-- _0x190F7DA1AC09A8EF  (0x190F7DA1AC09A8EF)
+-- min build: 1207
+---@return any
+function N_0x190F7DA1AC09A8EF() end
+
+-- _0x1D931B7CC0EE3956  (0x1D931B7CC0EE3956)
+-- min build: 1436
+---@param dictionary string
+---@param shotName string
+---@param cameraName string
+---@return boolean
+function N_0x1D931B7CC0EE3956(dictionary, shotName, cameraName) end
+
+-- _0x1D9F72DD4FD9A9D7  (0x1D9F72DD4FD9A9D7)
+-- min build: 1207
+---@param p0 any
+function N_0x1D9F72DD4FD9A9D7(p0) end
+
+-- _0x1F6EBD94680252CE  (0x1F6EBD94680252CE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1F6EBD94680252CE(p0, p1) end
+
+-- _0x1FC6C727D30FFDDE  (0x1FC6C727D30FFDDE)
+-- min build: 1207
+---@param p0 any
+function N_0x1FC6C727D30FFDDE(p0) end
+
+-- _0x29E6655DF3590B0D  (0x29E6655DF3590B0D)
+-- min build: 1207
+---@param p0 any
+function N_0x29E6655DF3590B0D(p0) end
+
+-- _0x2AB7C81B3F70570C  (0x2AB7C81B3F70570C)
+-- min build: 1207
+---@return any
+function N_0x2AB7C81B3F70570C() end
+
+-- _0x2DD3149DC34A3F4C  (0x2DD3149DC34A3F4C)
+-- min build: 1207
+---@param p0 any
+function N_0x2DD3149DC34A3F4C(p0) end
+
+-- _0x39073DA4EDDBC91D  (0x39073DA4EDDBC91D)
+-- min build: 1207
+---@param p0 any
+function N_0x39073DA4EDDBC91D(p0) end
+
+-- _0x3B8E3AD9677CE12B  (0x3B8E3AD9677CE12B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x3B8E3AD9677CE12B(p0, p1, p2) end
+
+-- _0x3C486E334520579D  (0x3C486E334520579D)
+-- min build: 1207
+function N_0x3C486E334520579D() end
+
+-- _0x3C8F74E8FE751614  (0x3C8F74E8FE751614)
+-- min build: 1207
+function N_0x3C8F74E8FE751614() end
+
+-- _0x4138EE36BC3DC0A7  (0x4138EE36BC3DC0A7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x4138EE36BC3DC0A7(p0, p1) end
+
+-- _0x41E452A3C580D1A7  (0x41E452A3C580D1A7)
+-- min build: 1207
+function N_0x41E452A3C580D1A7() end
+
+-- _0x450769C833D58844  (0x450769C833D58844)
+-- min build: 1207
+---@return any
+function N_0x450769C833D58844() end
+
+-- _0x465F04F68AD38197  (0x465F04F68AD38197)
+-- min build: 1207
+---@param dictionary string
+---@param shotName string
+---@param duration number
+---@return any
+function N_0x465F04F68AD38197(dictionary, shotName, duration) end
+
+-- _0x4D2F46D1B28D90FB  (0x4D2F46D1B28D90FB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x4D2F46D1B28D90FB(p0, p1) end
+
+-- _0x5060FA977CEA4455  (0x5060FA977CEA4455)
+-- min build: 1207
+---@return any
+function N_0x5060FA977CEA4455() end
+
+-- _0x5B637D6F3B67716A  (0x5B637D6F3B67716A)
+-- min build: 1207
+---@param p0 any
+function N_0x5B637D6F3B67716A(p0) end
+
+-- _0x6072B7420A83A03F  (0x6072B7420A83A03F)
+-- min build: 1207
+---@return any
+function N_0x6072B7420A83A03F() end
+
+-- _0x632BE8D84846FA56  (0x632BE8D84846FA56)
+-- Zooms in the gameplay camera to the next zoom level?
+-- USE_* - WAS_*
+-- min build: 1207
+function N_0x632BE8D84846FA56() end
+
+-- _0x63E5841A9264D016  (0x63E5841A9264D016)
+-- Maintains the death camera after respawn
+-- min build: 1207
+---@param toggle boolean
+function N_0x63E5841A9264D016(toggle) end
+
+-- _0x641092322A8852AB  (0x641092322A8852AB)
+-- min build: 1207
+function N_0x641092322A8852AB() end
+
+-- _0x6519238858AF5479  (0x6519238858AF5479)
+-- min build: 1207
+---@param p0 any
+function N_0x6519238858AF5479(p0) end
+
+-- _0x6CAB0BA160B168D2  (0x6CAB0BA160B168D2)
+-- min build: 1207
+function N_0x6CAB0BA160B168D2() end
+
+-- _0x6DFD37E586D4F44F  (0x6DFD37E586D4F44F)
+-- min build: 1207
+---@return any
+function N_0x6DFD37E586D4F44F() end
+
+-- _0x70A6658D476C6187  (0x70A6658D476C6187)
+-- min build: 1207
+function N_0x70A6658D476C6187() end
+
+-- _0x71D71E08A7ED5BD7  (0x71D71E08A7ED5BD7)
+-- Zooms in the third person camera closer to ground level.
+-- Must be called every frame to interpolate.
+-- Pass false to reset.
+-- min build: 1207
+---@param toggle boolean
+function N_0x71D71E08A7ED5BD7(toggle) end
+
+-- _0x728491FB3DFFEF99  (0x728491FB3DFFEF99)
+-- min build: 1207
+---@param p0 any
+function N_0x728491FB3DFFEF99(p0) end
+
+-- _0x73FF6BE63DC18819  (0x73FF6BE63DC18819)
+-- min build: 1207
+---@return any
+function N_0x73FF6BE63DC18819() end
+
+-- _0x796085220ADCC847  (0x796085220ADCC847)
+-- min build: 1207
+---@return any
+function N_0x796085220ADCC847() end
+
+-- _0x7CE9DC58E3E4755F  (0x7CE9DC58E3E4755F)
+-- min build: 1207
+---@return any
+function N_0x7CE9DC58E3E4755F() end
+
+-- _0x7E40A01B11398FCB  (0x7E40A01B11398FCB)
+-- min build: 1207
+function N_0x7E40A01B11398FCB() end
+
+-- _0x80D7A3E39B120BC4  (0x80D7A3E39B120BC4)
+-- min build: 1207
+---@return any
+function N_0x80D7A3E39B120BC4() end
+
+-- _0x8505E05FC8822843  (0x8505E05FC8822843)
+-- min build: 1207
+---@param p0 any
+function N_0x8505E05FC8822843(p0) end
+
+-- _0x88544C0E3291DCAE  (0x88544C0E3291DCAE)
+-- UPDATE_PLAYER_PLAYING_STATE - Releasing Lasso Hint Cam
+-- Return type char in ida
+-- _SET_GAMEPLAY_HINT_*
+-- min build: 1207
+---@param p0 boolean
+function N_0x88544C0E3291DCAE(p0) end
+
+-- _0x8B1A5FE7E41E52B2  (0x8B1A5FE7E41E52B2)
+-- min build: 1311
+---@return any
+function N_0x8B1A5FE7E41E52B2() end
+
+-- _0x8E036B41C37D0E5F  (0x8E036B41C37D0E5F)
+-- min build: 1207
+---@param p0 any
+function N_0x8E036B41C37D0E5F(p0) end
+
+-- _0x975F6EBB62632FE3  (0x975F6EBB62632FE3)
+-- _IS_SCRIPTED_S*
+-- min build: 1207
+---@return boolean
+function N_0x975F6EBB62632FE3() end
+
+-- _0x9AC65A36D3C0C189  (0x9AC65A36D3C0C189)
+-- min build: 1207
+---@param p0 any
+function N_0x9AC65A36D3C0C189(p0) end
+
+-- _0xA54D643D0773EB65  (0xA54D643D0773EB65)
+-- min build: 1207
+---@param dictionary string
+---@param shotName string
+---@param duration number
+function N_0xA54D643D0773EB65(dictionary, shotName, duration) end
+
+-- _0xA8BA2E0204D8486F  (0xA8BA2E0204D8486F)
+-- NPLOI_UPDATE__GUN_SPINNING_PREVIEW - Adjusting Camera / Ped Reset Flags This Frame
+-- _DISABLE_*
+-- min build: 1355
+function N_0xA8BA2E0204D8486F() end
+
+-- _0xAC77757C05DE9E5A  (0xAC77757C05DE9E5A)
+-- min build: 1207
+---@param cameraDictionary string
+function N_0xAC77757C05DE9E5A(cameraDictionary) end
+
+-- _0xB6A80E1E3A5444F1  (0xB6A80E1E3A5444F1)
+-- min build: 1311
+---@return any
+function N_0xB6A80E1E3A5444F1() end
+
+-- _0xB85C13E0BF1F2A1C  (0xB85C13E0BF1F2A1C)
+-- min build: 1207
+---@param p0 any
+function N_0xB85C13E0BF1F2A1C(p0) end
+
+-- _0xC205B3C54C6A4E37  (0xC205B3C54C6A4E37)
+-- min build: 1207
+---@param p0 any
+function N_0xC205B3C54C6A4E37(p0) end
+
+-- _0xC252C0CC969AF79A  (0xC252C0CC969AF79A)
+-- min build: 1207
+---@param p0 any
+function N_0xC252C0CC969AF79A(p0) end
+
+-- _0xC285FD21294A1C49  (0xC285FD21294A1C49)
+-- min build: 1207
+---@param cameraDictionary string
+---@return boolean
+function N_0xC285FD21294A1C49(cameraDictionary) end
+
+-- _0xC3742F1FDF0A6824  (0xC3742F1FDF0A6824)
+-- Camera will be or is running
+-- min build: 1355
+function N_0xC3742F1FDF0A6824() end
+
+-- _0xC3AEBB276825A359  (0xC3AEBB276825A359)
+-- min build: 1436
+---@param dictionary string
+---@param shotName string
+---@param duration number
+---@return boolean
+function N_0xC3AEBB276825A359(dictionary, shotName, duration) end
+
+-- _0xCF69EA05CD9C33C9  (0xCF69EA05CD9C33C9)
+-- min build: 1207
+function N_0xCF69EA05CD9C33C9() end
+
+-- _0xDB382FE20C2DA222  (0xDB382FE20C2DA222)
+-- min build: 1207
+---@param p0 any
+function N_0xDB382FE20C2DA222(p0) end
+
+-- _0xDC62CD70658E7A02  (0xDC62CD70658E7A02)
+-- min build: 1207
+---@return any
+function N_0xDC62CD70658E7A02() end
+
+-- _0xDF7F5BE9150E47E4  (0xDF7F5BE9150E47E4)
+-- min build: 1207
+---@param p0 any
+function N_0xDF7F5BE9150E47E4(p0) end
+
+-- _0xE28F73212A813E82  (0xE28F73212A813E82)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xE28F73212A813E82(p0, p1, p2, p3) end
+
+-- _0xE2BB2D6A9FE2ECDE  (0xE2BB2D6A9FE2ECDE)
+-- min build: 1207
+---@param p0 any
+function N_0xE2BB2D6A9FE2ECDE(p0) end
+
+-- _0xE6F364DE6C2FDEFE  (0xE6F364DE6C2FDEFE)
+-- min build: 1207
+function N_0xE6F364DE6C2FDEFE() end
+
+-- _0xEA113BF9B0C0C5D7  (0xEA113BF9B0C0C5D7)
+-- min build: 1207
+---@param dictionary string
+---@param shotName string
+---@param duration number
+---@return any
+function N_0xEA113BF9B0C0C5D7(dictionary, shotName, duration) end
+
+-- _0xEF9A3132A0AA6B19  (0xEF9A3132A0AA6B19)
+-- min build: 1207
+---@return any
+function N_0xEF9A3132A0AA6B19() end
+
+-- _0xF1A6FEEDF3776EF9  (0xF1A6FEEDF3776EF9)
+-- min build: 1207
+function N_0xF1A6FEEDF3776EF9() end
+
+-- _0xF48664E9C83825E3  (0xF48664E9C83825E3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xF48664E9C83825E3(p0, p1) end
+
+-- _0xF824530B612FE0CE  (0xF824530B612FE0CE)
+-- min build: 1207
+---@return any
+function N_0xF824530B612FE0CE() end
+
+-- _0xFC3F638BE2B6BB02  (0xFC3F638BE2B6BB02)
+-- min build: 1207
+function N_0xFC3F638BE2B6BB02() end
+
+-- _0xFEB8646818294C75  (0xFEB8646818294C75)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFEB8646818294C75(p0, p1) end
+
+-- _0xFEFDDC6E8FDF8A75  (0xFEFDDC6E8FDF8A75)
+-- _SET_GAMEPLAY_P* - _SET_GAMEPLAY_V*
+-- min build: 1207
+---@param shakeName string
+---@param intensity number
+function N_0xFEFDDC6E8FDF8A75(shakeName, intensity) end
+
+-- _CAM_CREATE  (0xB8B207C34285E978)
+-- min build: 1207
+---@param cameraDictionary string
+function _CamCreate(cameraDictionary) end
+
+-- _CAM_CREATE_2  (0x7B0279170961A73F)
+-- min build: 1207
+---@param cameraDictionary string
+function _CamCreate2(cameraDictionary) end
+
+-- _CAM_DESTROY  (0x0A5A4F1979ABB40E)
+-- min build: 1207
+---@param cameraDictionary string
+function _CamDestroy(cameraDictionary) end
+
+-- _CINEMATIC_LOCATION_SET_LOCATION_AND_ROTATION  (0x0E94C95EC3185FA9)
+-- min build: 1207
+---@param name string
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+function _CinematicLocationSetLocationAndRotation(name, x, y, z, rotX, rotY, rotZ) end
+
+-- _CINEMATIC_LOCATION_TRIGGER_SCRIPTED_SHOT_EVENT_2  (0xBC016635D6A73B31)
+-- min build: 1207
+---@param dictionary string
+---@param shotName string
+---@param duration number
+function _CinematicLocationTriggerScriptedShotEvent2(dictionary, shotName, duration) end
+
+-- _CREATE_KILL_CAM  (0x2F994CC29CAA9D22)
+-- Creates Kill Cam for specified Ped Handle
+-- min build: 1207
+---@param ped number
+function _CreateKillCam(ped) end
+
+-- _DISABLE_CINEMATIC_MODE_THIS_FRAME  (0x8910C24B7E0046EC)
+-- min build: 1207
+function _DisableCinematicModeThisFrame() end
+
+-- _DISABLE_ON_FOOT_FIRST_PERSON_VIEW_THIS_UPDATE_2  (0x05AB44D906738426)
+-- Does the same as 0x9C473089A934C930 (DISABLE_ON_FOOT_FIRST_PERSON_VIEW_THIS_UPDATE)
+-- min build: 1207
+function _DisableOnFootFirstPersonViewThisUpdate2() end
+
+-- _FORCE_CINEMATIC_DEATH_CAM_ON_PED  (0xE3639DB78B3B5400)
+-- Used for DUELING_MANAGE_DEATH_CAMERA - Initializing death camera
+-- Params: targetPed = death cam focuses on it
+-- min build: 1207
+---@param targetPed number
+function _ForceCinematicDeathCamOnPed(targetPed) end
+
+-- _FORCE_FIRST_PERSON_CAM_THIS_FRAME  (0x90DA5BA5C2635416)
+-- Returns true if first person camera is active in saloon1.ysc
+-- min build: 1207
+---@return boolean
+function _ForceFirstPersonCamThisFrame() end
+
+-- _FORCE_LETTER_BOX_THIS_UPDATE  (0xC64ABC0676AF262B)
+-- min build: 1207
+function _ForceLetterBoxThisUpdate() end
+
+-- _FORCE_THIRD_PERSON_CAM_FAR_THIS_FRAME  (0x1CFB749AD4317BDE)
+-- Forces camera position to furthest 3rd person
+-- min build: 1207
+function _ForceThirdPersonCamFarThisFrame() end
+
+-- _FORCE_THIRD_PERSON_CAM_THIS_FRAME  (0x8370D34BD2E60B73)
+-- Forces camera position to second furthest 3rd person
+-- min build: 1207
+function _ForceThirdPersonCamThisFrame() end
+
+-- _FORCE_THIRD_PERSON_CLOSE_THIS_FRAME  (0x718C6ECF5E8CBDD4)
+-- Forces camera position to closest 3rd person
+-- min build: 1207
+function _ForceThirdPersonCloseThisFrame() end
+
+-- _FREEZE_GAMEPLAY_CAM_THIS_FRAME  (0x027CAB2C3AF27010)
+-- min build: 1207
+function _FreezeGameplayCamThisFrame() end
+
+-- _GET_PHOTO_MODE_DOF  (0x4653A741D17F2CD0)
+-- min build: 1207
+---@return number
+function _GetPhotoModeDof() end
+
+-- _GET_PHOTO_MODE_FOCAL_LENGTH  (0x2533BAFFBE737E54)
+-- min build: 1207
+---@return number
+function _GetPhotoModeFocalLength() end
+
+-- _GET_PHOTO_MODE_FOCUS_DISTANCE  (0x18FC740FFDCD7454)
+-- min build: 1207
+---@return number
+function _GetPhotoModeFocusDistance() end
+
+-- _IS_ANIM_SCENE_CAM_ACTIVE  (0x20389408F0E93B9A)
+-- Only used in R* Script camera_photomode
+-- min build: 1207
+---@return boolean
+function _IsAnimSceneCamActive() end
+
+-- _IS_CAM_DATA_DICT_LOADED  (0xDD0B7C5AE58F721D)
+-- min build: 1207
+---@param cameraDictionary string
+---@return boolean
+function _IsCamDataDictLoaded(cameraDictionary) end
+
+-- _IS_CAM_PHOTOFX_RUNNING  (0xA14D5FE82BCB1D9E)
+-- min build: 1207
+---@return boolean
+function _IsCamPhotofxRunning() end
+
+-- _IS_CAMERA_AVAILABLE  (0x927B810E43E99932)
+-- min build: 1207
+---@param cameraDictionary string
+---@return boolean
+function _IsCameraAvailable(cameraDictionary) end
+
+-- _IS_CINEMATIC_CAM_LOCATION_LOADED  (0xAA235E2F2C09E952)
+-- min build: 1207
+---@param sLocationDictName string
+---@return boolean
+function _IsCinematicCamLocationLoaded(sLocationDictName) end
+
+-- _IS_CINEMATIC_CAM_LOCATION_LOADED_2  (0x595550376B7EA230)
+-- Checks data related to Cinematic Cam Locations, if the check fails, the location is being loaded using 0x1B3C2D961F5FC0E1.
+-- min build: 1207
+---@param locationDictName string
+---@return boolean
+function _IsCinematicCamLocationLoaded2(locationDictName) end
+
+-- _IS_IN_CINEMATIC_MODE  (0x74F1D22EFA71FAB8)
+-- min build: 1207
+---@return boolean
+function _IsInCinematicMode() end
+
+-- _IS_IN_FULL_FIRST_PERSON_MODE  (0xD1BA66940E94C547)
+-- Returns true if player is in first person
+-- min build: 1207
+---@return boolean
+function _IsInFullFirstPersonMode() end
+
+-- _LOAD_CAMERA_DATA_DICT  (0x6A4D224FC7643941)
+-- min build: 1207
+---@param cameraDictionary string
+function _LoadCameraDataDict(cameraDictionary) end
+
+-- _LOAD_CINEMATIC_CAM_LOCATION  (0x1B3C2D961F5FC0E1)
+-- min build: 1207
+---@param locationDictName string
+function _LoadCinematicCamLocation(locationDictName) end
+
+-- _PAUSE_CAMERA_FOCUS  (0x9F97E85EC142255E)
+-- min build: 1207
+---@param cam number
+---@param pause boolean
+function _PauseCameraFocus(cam, pause) end
+
+-- _REACTIVATE_PED_HEADSHOT_EXECUTE_SLOWCAM  (0x986F7A51EE3E1F92)
+-- Used to enable headshot kill replay when you headshot set ped.
+-- Params: p1 seems to be 0 or 1 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _ReactivatePedHeadshotExecuteSlowcam(ped, p1) end
+
+-- _REQUEST_LETTER_BOX_NOW  (0x69D65E89FFD72313)
+-- Creates Cinematic Black Bars (at top and bottom)
+-- Disable instantly: false/false, Enable instantly: true/true
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+function _RequestLetterBoxNow(p0, p1) end
+
+-- _REQUEST_LETTER_BOX_OVERTIME  (0xE296208C273BD7F0)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 boolean
+---@param p3 number
+---@param p4 boolean
+---@param p5 boolean
+function _RequestLetterBoxOvertime(p0, p1, p2, p3, p4, p5) end
+
+-- _RESTART_GAMEPLAY_CAM_SHAKE_WITH_NAME  (0xC3E9E5D4F413B773)
+-- Starts or restarts a predefined gameplay camera shake by name and sets its intensity.
+-- If the named shake is already active, the existing shake instance is restarted and its intensity is updated; otherwise the shake is created from camBaseShakeMetadata.
+-- Observed script usage pairs this with _STOP_GAMEPLAY_CAM_SHAKING_WITH_NAME("REINFORCED_LASSO_STRUGGLE_SHAKE", false). Confirmed shakeName values include DRUNK_SHAKE, REINFORCED_LASSO_STRUGGLE_SHAKE, and HAND_SHAKE.
+-- min build: 1207
+---@param shakeName string
+---@param intensity number
+function _RestartGameplayCamShakeWithName(shakeName, intensity) end
+
+-- _SET_CAM_DOF_PARAMS  (0xE4B7945EF4F1BFB2)
+-- min build: 1207
+---@param cam number
+---@return any
+function _SetCamDofParams(cam) end
+
+-- _SET_CAM_FOCUS_DISTANCE  (0x11F32BB61B756732)
+-- min build: 1207
+---@param cam number
+---@param distance number
+function _SetCamFocusDistance(cam, distance) end
+
+-- _SET_GAMEPLAY_CAM_INITIAL_HEADING  (0x6C1053C433A573CF)
+-- min build: 1207
+---@param camInitialHeading number
+function _SetGameplayCamInitialHeading(camInitialHeading) end
+
+-- _SET_GAMEPLAY_CAM_INITIAL_PITCH  (0x449995EA846D3FC2)
+-- min build: 1207
+---@param camInitialPitch number
+function _SetGameplayCamInitialPitch(camInitialPitch) end
+
+-- _SET_GAMEPLAY_CAM_INITIAL_ZOOM  (0xBCDA0BA8762FACB9)
+-- Used in Script Function SHOP_CAMERA_SUPPORT_START_NEW_ORBIT
+-- min build: 1207
+---@param camInitialZoom number
+function _SetGameplayCamInitialZoom(camInitialZoom) end
+
+-- _SET_GAMEPLAY_CAM_PARAMS_THIS_UPDATE  (0x066167C63111D8CF)
+-- Sets the third person gameplay camera zoom level and blends in.
+-- Must be called every frame to interpolate.
+-- Offset and distance permanently affects subtle zoom in weapon wheel and possibly in menus too.
+-- 
+-- Params: p1 and p3 are usually true.
+-- min build: 1207
+---@param speed number
+---@param respectHorizontalOffset boolean
+---@param horizontalOffset number
+---@param respectDistance boolean
+---@param distance number
+function _SetGameplayCamParamsThisUpdate(speed, respectHorizontalOffset, horizontalOffset, respectDistance, distance) end
+
+-- _SET_START_CINEMATIC_DEATH_CAM  (0x6E969927CF632608)
+-- Used for DUELING_MANAGE_DEATH_CAMERA - Initializing death camera
+-- _SET_P* - _SET_S*
+-- min build: 1207
+---@param p0 boolean
+function _SetStartCinematicDeathCam(p0) end
+
+-- _START_CAMERA_ORBIT  (0x65B205BF30C13DDB)
+-- [SHOP_CAMERA_SUPPORT_START_NEW_ORBIT]
+-- p0: struct<32> /*256*/
+-- min build: 1207
+---@return any
+function _StartCameraOrbit() end
+
+-- _STOP_GAMEPLAY_CAM_SHAKING_WITH_NAME  (0x4285804FD65D8066)
+-- script_rel: DRUNK_SHAKE, REINFORCED_LASSO_STRUGGLE_SHAKE, CORRECTOR_SHAKE, MINIGAME_BOUNTY_SHAKE, HAND_SHAKE, MINIGAME_TRAIN_SHAKE
+-- script_mp_rel: DRUNK_SHAKE, REINFORCED_LASSO_STRUGGLE_SHAKE
+-- _STOP_GAMEPLAY_CAM* - _STOP_I*
+-- min build: 1207
+---@param shakeName string
+---@param p1 boolean
+function _StopGameplayCamShakingWithName(shakeName, p1) end
+
+-- _TRIGGER_MISSION_FAILED_CAM  (0x9A92C06ACBAF9731)
+-- min build: 1207
+function _TriggerMissionFailedCam() end
+
+-- _UNLOAD_CAMERA_DATA_DICT  (0x798BE43C9393632B)
+-- min build: 1207
+---@param cameraDictionary string
+function _UnloadCameraDataDict(cameraDictionary) end
+
+-- _UNLOAD_CINEMATIC_CAMERA_LOCATION  (0x2412216FCC7B4E3E)
+-- min build: 1207
+---@param dictionaryName string
+function _UnloadCinematicCameraLocation(dictionaryName) end
+
+-- ADD_CAM_SPLINE_NODE  (0xF1F57F9D230F9CD1)
+-- p7 (length) determines the length of the spline, affects camera path and duration of transition between previous node and this one
+-- 
+-- p8 big values ~100 will slow down the camera movement before reaching this node
+-- 
+-- p9 != 0 seems to override the rotation/pitch (bool?)
+-- min build: 1207
+---@param camera number
+---@param x number
+---@param y number
+---@param z number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param length number
+---@param p8 number
+---@param p9 number
+function AddCamSplineNode(camera, x, y, z, xRot, yRot, zRot, length, p8, p9) end
+
+-- ALLOW_MOTION_BLUR_DECAY  (0x42ED56B02E05D109)
+-- min build: 1207
+---@param cam number
+---@param p1 boolean
+function AllowMotionBlurDecay(cam, p1) end
+
+-- ATTACH_CAM_TO_ENTITY  (0xFDC0DF7F6FB0A592)
+-- Last param determines if its relative to the Entity
+-- min build: 1207
+---@param cam number
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param isRelative boolean
+function AttachCamToEntity(cam, entity, xOffset, yOffset, zOffset, isRelative) end
+
+-- ATTACH_CAM_TO_PED_BONE  (0xDFC1E4A44C0324CA)
+-- boneIndex: https://github.com/femga/rdr3_discoveries/tree/master/boneNames
+-- min build: 1207
+---@param cam number
+---@param ped number
+---@param boneIndex number
+---@param x number
+---@param y number
+---@param z number
+---@param heading boolean
+function AttachCamToPedBone(cam, ped, boneIndex, x, y, z, heading) end
+
+-- CINEMATIC_LOCATION_OVERRIDE_TARGET_ENTITY_THIS_UPDATE  (0x0B0F914459731F60)
+-- Only used in R* Script fm_mission_controller
+-- min build: 1311
+---@param name string
+---@param entity number
+function CinematicLocationOverrideTargetEntityThisUpdate(name, entity) end
+
+-- CINEMATIC_LOCATION_STOP_SCRIPTED_SHOT_EVENT  (0x6D4D25C2137FF511)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function CinematicLocationStopScriptedShotEvent(p0, p1, p2) end
+
+-- CINEMATIC_LOCATION_TRIGGER_SCRIPTED_SHOT_EVENT  (0x02389579A53C3276)
+-- min build: 1207
+---@param dictionary string
+---@param shotName string
+---@param cameraName string
+---@param p3 any
+function CinematicLocationTriggerScriptedShotEvent(dictionary, shotName, cameraName, p3) end
+
+-- CREATE_CAM  (0xE72CDBA7F0A02DD6)
+-- min build: 1207
+---@param camName string
+---@param p1 boolean
+---@return number
+function CreateCam(camName, p1) end
+
+-- CREATE_CAM_WITH_PARAMS  (0x40C23491CE83708E)
+-- min build: 1207
+---@param camName string
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param fov number
+---@param p8 boolean
+---@param p9 number
+---@return number
+function CreateCamWithParams(camName, posX, posY, posZ, rotX, rotY, rotZ, fov, p8, p9) end
+
+-- CREATE_CAMERA  (0x57CDF879EA466C46)
+-- min build: 1207
+---@param camHash number
+---@param p1 boolean
+---@return number
+function CreateCamera(camHash, p1) end
+
+-- CREATE_CAMERA_WITH_PARAMS  (0x98B99B9F27E2D60B)
+-- min build: 1207
+---@param camHash number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param fov number
+---@param p8 boolean
+---@param p9 any
+---@return number
+function CreateCameraWithParams(camHash, posX, posY, posZ, rotX, rotY, rotZ, fov, p8, p9) end
+
+-- DESTROY_ALL_CAMS  (0x163600D6E136C9F8)
+-- BOOL param indicates whether the cam should be destroyed if it belongs to the calling script.
+-- min build: 1207
+---@param p0 boolean
+function DestroyAllCams(p0) end
+
+-- DESTROY_CAM  (0x4E67E0B6D7FD5145)
+-- BOOL param indicates whether the cam should be destroyed if it belongs to the calling script.
+-- min build: 1207
+---@param cam number
+---@param p1 boolean
+function DestroyCam(cam, p1) end
+
+-- DETACH_CAM  (0x05B41DDBEB559556)
+-- min build: 1207
+---@param cam number
+function DetachCam(cam) end
+
+-- DISABLE_CAM_COLLISION_FOR_OBJECT  (0x7E3F546ACFE6C8D9)
+-- min build: 1207
+---@param entity number
+function DisableCamCollisionForObject(entity) end
+
+-- DISABLE_CINEMATIC_BONNET_CAMERA_THIS_UPDATE  (0xA5929C2E57AC90D1)
+-- Old name: _DISABLE_VEHICLE_FIRST_PERSON_CAM_THIS_FRAME
+-- min build: 1207
+function DisableCinematicBonnetCameraThisUpdate() end
+
+-- DISABLE_FIRST_PERSON_FLASH_EFFECT_THIS_UPDATE  (0x77D65669A05D1A1A)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function DisableFirstPersonFlashEffectThisUpdate() end
+
+-- DISABLE_ON_FOOT_FIRST_PERSON_VIEW_THIS_UPDATE  (0x9C473089A934C930)
+-- Old name: _DISABLE_FIRST_PERSON_CAM_THIS_FRAME
+-- min build: 1207
+function DisableOnFootFirstPersonViewThisUpdate() end
+
+-- DO_SCREEN_FADE_IN  (0x6A053CF596F67DF7)
+-- Fades the screen in.
+-- 
+-- duration: The time the fade should take, in milliseconds.
+-- min build: 1207
+---@param duration number
+function DoScreenFadeIn(duration) end
+
+-- DO_SCREEN_FADE_OUT  (0x40C719A5E410B9E4)
+-- Fades the screen out.
+-- 
+-- duration: The time the fade should take, in milliseconds.
+-- min build: 1207
+---@param duration number
+function DoScreenFadeOut(duration) end
+
+-- DOES_CAM_EXIST  (0x153AD457764FD704)
+-- Returns whether or not the passed camera handle exists.
+-- min build: 1207
+---@param cam number
+---@return boolean
+function DoesCamExist(cam) end
+
+-- FORCE_CINEMATIC_RENDERING_THIS_UPDATE  (0x702B75DC9D3EDE56)
+-- min build: 1207
+---@param p0 boolean
+function ForceCinematicRenderingThisUpdate(p0) end
+
+-- GET_CAM_COORD  (0x6B12F11C2A9F0344)
+-- min build: 1207
+---@param cam number
+---@return vector3
+function GetCamCoord(cam) end
+
+-- GET_CAM_FOV  (0x8101D32A0A6B0F60)
+-- min build: 1207
+---@param cam number
+---@return number
+function GetCamFov(cam) end
+
+-- GET_CAM_ROT  (0x9BF96B57254E7889)
+-- rotationOrder: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eEulerRotationOrder
+-- min build: 1207
+---@param cam number
+---@param rotationOrder number
+---@return vector3
+function GetCamRot(cam, rotationOrder) end
+
+-- GET_CAM_SPLINE_PHASE  (0x095EDCD24D90033A)
+-- Can use this with SET_CAM_SPLINE_PHASE to set the float it this native returns.
+-- 
+-- (returns 1.0f when no nodes has been added, reached end of non existing spline)
+-- min build: 1207
+---@param cam number
+---@return number
+function GetCamSplinePhase(cam) end
+
+-- GET_FINAL_RENDERED_CAM_COORD  (0x5352E025EC2B416F)
+-- min build: 1207
+---@return vector3
+function GetFinalRenderedCamCoord() end
+
+-- GET_FINAL_RENDERED_CAM_FOV  (0x04AF77971E508F6A)
+-- min build: 1207
+---@return number
+function GetFinalRenderedCamFov() end
+
+-- GET_FINAL_RENDERED_CAM_ROT  (0x602685BD85DD26CA)
+-- min build: 1207
+---@param rotationOrder number
+---@return vector3
+function GetFinalRenderedCamRot(rotationOrder) end
+
+-- GET_FIRST_PERSON_AIM_CAM_ZOOM_FACTOR  (0xB4132CA1B0EE1365)
+-- min build: 1207
+---@return number
+function GetFirstPersonAimCamZoomFactor() end
+
+-- GET_GAMEPLAY_CAM_COORD  (0x595320200B98596E)
+-- min build: 1207
+---@return vector3
+function GetGameplayCamCoord() end
+
+-- GET_GAMEPLAY_CAM_FOV  (0xF6A96E5ACEEC6E50)
+-- min build: 1207
+---@return number
+function GetGameplayCamFov() end
+
+-- GET_GAMEPLAY_CAM_RELATIVE_HEADING  (0xC4ABF536048998AA)
+-- min build: 1207
+---@return number
+function GetGameplayCamRelativeHeading() end
+
+-- GET_GAMEPLAY_CAM_RELATIVE_PITCH  (0x99AADEBBA803F827)
+-- min build: 1207
+---@return number
+function GetGameplayCamRelativePitch() end
+
+-- GET_GAMEPLAY_CAM_ROT  (0x0252D2B5582957A6)
+-- min build: 1207
+---@param rotationOrder number
+---@return vector3
+function GetGameplayCamRot(rotationOrder) end
+
+-- GET_LETTER_BOX_RATIO  (0xA2B1C7EF759A63CE)
+-- More info: see HAS_LETTER_BOX
+-- min build: 1207
+---@return number
+function GetLetterBoxRatio() end
+
+-- GET_RENDERING_CAM  (0x03A8931ECC8015D6)
+-- min build: 1207
+---@return number
+function GetRenderingCam() end
+
+-- HAS_LETTER_BOX  (0x81DCFD13CF39920E)
+-- More info: https://en.wikipedia.org/wiki/Letterboxing_(filming)
+-- min build: 1207
+---@return boolean
+function HasLetterBox() end
+
+-- INVALIDATE_CINEMATIC_VEHICLE_IDLE_MODE  (0x634F4A0562CF19B8)
+-- Old name: _INVALIDATE_VEHICLE_IDLE_CAM
+-- min build: 1207
+function InvalidateCinematicVehicleIdleMode() end
+
+-- IS_AIM_CAM_ACTIVE  (0x698F456FB909E077)
+-- min build: 1232
+---@return boolean
+function IsAimCamActive() end
+
+-- IS_CAM_ACTIVE  (0x63EFCC7E1810B8E6)
+-- Returns whether or not the passed camera handle is active.
+-- min build: 1207
+---@param cam number
+---@return boolean
+function IsCamActive(cam) end
+
+-- IS_CAM_INTERPOLATING  (0x578F8F1CAA17BD2B)
+-- min build: 1207
+---@param cam number
+---@return boolean
+function IsCamInterpolating(cam) end
+
+-- IS_CAM_RENDERING  (0x4415F8A6C536D39F)
+-- min build: 1207
+---@param cam number
+---@return boolean
+function IsCamRendering(cam) end
+
+-- IS_CAM_SHAKING  (0x2EEB402BD7320159)
+-- min build: 1207
+---@param cam number
+---@return boolean
+function IsCamShaking(cam) end
+
+-- IS_CINEMATIC_CAM_RENDERING  (0xBF7C780731AADBF8)
+-- min build: 1207
+---@return boolean
+function IsCinematicCamRendering() end
+
+-- IS_DEATH_FAIL_CAMERA_RUNNING  (0x139EFB0A71DD9011)
+-- min build: 1207
+---@return boolean
+function IsDeathFailCameraRunning() end
+
+-- IS_FIRST_PERSON_AIM_CAM_ACTIVE  (0xF63134C54B6EC212)
+-- min build: 1207
+---@return boolean
+function IsFirstPersonAimCamActive() end
+
+-- IS_FIRST_PERSON_CAMERA_ACTIVE  (0xA24C1D341C6E0D53)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return boolean
+function IsFirstPersonCameraActive(p0, p1, p2) end
+
+-- IS_FOLLOW_VEHICLE_CAM_ACTIVE  (0xA40C2F51FB589E9A)
+-- min build: 1207
+---@return boolean
+function IsFollowVehicleCamActive() end
+
+-- IS_GAMEPLAY_CAM_LOOKING_BEHIND  (0x8FE0D24FFD04D5A2)
+-- min build: 1207
+---@return boolean
+function IsGameplayCamLookingBehind() end
+
+-- IS_GAMEPLAY_CAM_RENDERING  (0x8660EA714834E412)
+-- min build: 1207
+---@return boolean
+function IsGameplayCamRendering() end
+
+-- IS_GAMEPLAY_CAM_SHAKING  (0xEA4C5F4AA0A4DBEF)
+-- min build: 1207
+---@return boolean
+function IsGameplayCamShaking() end
+
+-- IS_GAMEPLAY_HINT_ACTIVE  (0x2E04AB5FEE042D4A)
+-- min build: 1207
+---@return boolean
+function IsGameplayHintActive() end
+
+-- IS_INTERPOLATING_FROM_SCRIPT_CAMS  (0x251241CAEC707106)
+-- min build: 1207
+---@return boolean
+function IsInterpolatingFromScriptCams() end
+
+-- IS_INTERPOLATING_TO_SCRIPT_CAMS  (0x43AB9D5A7D415478)
+-- min build: 1207
+---@return boolean
+function IsInterpolatingToScriptCams() end
+
+-- IS_SCREEN_FADED_IN  (0x37F9A426FBCF4AF2)
+-- min build: 1207
+---@return boolean
+function IsScreenFadedIn() end
+
+-- IS_SCREEN_FADED_OUT  (0xF5472C80DF2FF847)
+-- min build: 1207
+---@return boolean
+function IsScreenFadedOut() end
+
+-- IS_SCREEN_FADING_IN  (0x0CECCC63FFA2EF24)
+-- min build: 1207
+---@return boolean
+function IsScreenFadingIn() end
+
+-- IS_SCREEN_FADING_OUT  (0x02F39BEFE7B88D00)
+-- min build: 1207
+---@return boolean
+function IsScreenFadingOut() end
+
+-- IS_SPHERE_VISIBLE  (0x2E941B5FFA2989C6)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function IsSphereVisible(x, y, z, radius) end
+
+-- PLAY_CAM_ANIM  (0xA263DDF694D563F6)
+-- min build: 1207
+---@param cam number
+---@param animName string
+---@param animDictionary string
+---@param x number
+---@param y number
+---@param z number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param animFlags number
+---@param rotOrder number
+---@return boolean
+function PlayCamAnim(cam, animName, animDictionary, x, y, z, xRot, yRot, zRot, animFlags, rotOrder) end
+
+-- POINT_CAM_AT_COORD  (0x948B39341C3A40C2)
+-- min build: 1207
+---@param cam number
+---@param x number
+---@param y number
+---@param z number
+function PointCamAtCoord(cam, x, y, z) end
+
+-- POINT_CAM_AT_ENTITY  (0xFC2867E6074D3A61)
+-- min build: 1207
+---@param cam number
+---@param entity number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 boolean
+function PointCamAtEntity(cam, entity, p2, p3, p4, p5) end
+
+-- RENDER_SCRIPT_CAMS  (0x33281167E4942E4F)
+-- ease - smooth transition between the camera's positions
+-- easeTime - Time in milliseconds for the transition to happen
+-- 
+-- If you have created a script (rendering) camera, and want to go back to the 
+-- character (gameplay) camera, call this native with render set to FALSE.
+-- Setting ease to TRUE will smooth the transition.
+-- min build: 1207
+---@param render boolean
+---@param ease boolean
+---@param easeTime number
+---@param p3 boolean
+---@param p4 boolean
+---@param renderingFlags number
+function RenderScriptCams(render, ease, easeTime, p3, p4, renderingFlags) end
+
+-- SET_CAM_ACTIVE  (0x87295BCA613800C8)
+-- Set camera as active/inactive.
+-- min build: 1207
+---@param cam number
+---@param active boolean
+function SetCamActive(cam, active) end
+
+-- SET_CAM_ACTIVE_WITH_INTERP  (0x8B15AE2987C1AC8F)
+-- min build: 1207
+---@param camTo number
+---@param camFrom number
+---@param duration number
+---@param easeLocation number
+---@param easeRotation number
+function SetCamActiveWithInterp(camTo, camFrom, duration, easeLocation, easeRotation) end
+
+-- SET_CAM_AFFECTS_AIMING  (0x3CB9E8BDE5E76F33)
+-- Allows you to aim and shoot at the direction the camera is facing.
+-- min build: 1207
+---@param cam number
+---@param toggle boolean
+function SetCamAffectsAiming(cam, toggle) end
+
+-- SET_CAM_CONTROLS_MINI_MAP_HEADING  (0x1B8F3CE5A6001298)
+-- min build: 1207
+---@param cam number
+---@param p1 boolean
+function SetCamControlsMiniMapHeading(cam, p1) end
+
+-- SET_CAM_COORD  (0xF9EE7D419EE49DE6)
+-- Sets the position of the cam.
+-- min build: 1207
+---@param cam number
+---@param posX number
+---@param posY number
+---@param posZ number
+function SetCamCoord(cam, posX, posY, posZ) end
+
+-- SET_CAM_FAR_CLIP  (0x5E32817BF6302111)
+-- min build: 1207
+---@param cam number
+---@param farClip number
+function SetCamFarClip(cam, farClip) end
+
+-- SET_CAM_FOV  (0x27666E5988D9D429)
+-- Sets the field of view of the cam.
+-- 
+-- Min: 1.0f
+-- Max: 130.0f
+-- min build: 1207
+---@param cam number
+---@param fieldOfView number
+function SetCamFov(cam, fieldOfView) end
+
+-- SET_CAM_MOTION_BLUR_STRENGTH  (0x45FD891364181F9E)
+-- min build: 1207
+---@param cam number
+---@param strength number
+function SetCamMotionBlurStrength(cam, strength) end
+
+-- SET_CAM_NEAR_CLIP  (0xA924028272A61364)
+-- min build: 1207
+---@param cam number
+---@param nearClip number
+function SetCamNearClip(cam, nearClip) end
+
+-- SET_CAM_PARAMS  (0xA47BBFFFB83D4D0A)
+-- min build: 1207
+---@param cam number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param fieldOfView number
+---@param p8 any
+---@param graphType1 number
+---@param graphType2 number
+---@param rotationOrder number
+---@param p12 any
+---@param p13 any
+function SetCamParams(cam, posX, posY, posZ, rotX, rotY, rotZ, fieldOfView, p8, graphType1, graphType2, rotationOrder, p12, p13) end
+
+-- SET_CAM_ROT  (0x63DFA6810AD78719)
+-- Sets the rotation of the cam.
+-- min build: 1207
+---@param cam number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param rotationOrder number
+function SetCamRot(cam, rotX, rotY, rotZ, rotationOrder) end
+
+-- SET_CAM_SPLINE_DURATION  (0xFF6311652CA91015)
+-- min build: 1207
+---@param cam number
+---@param timeDuration number
+function SetCamSplineDuration(cam, timeDuration) end
+
+-- SET_CAM_SPLINE_PHASE  (0xF1898A68E7C15636)
+-- min build: 1207
+---@param cam number
+---@param p1 number
+function SetCamSplinePhase(cam, p1) end
+
+-- SET_CAM_SPLINE_SMOOTHING_STYLE  (0x84B3645618E726B0)
+-- min build: 1207
+---@param cam number
+---@param smoothingStyle number
+function SetCamSplineSmoothingStyle(cam, smoothingStyle) end
+
+-- SET_CINEMATIC_BUTTON_ACTIVE  (0xB90411F480457A6C)
+-- min build: 1207
+---@param p0 boolean
+function SetCinematicButtonActive(p0) end
+
+-- SET_CINEMATIC_MODE_ACTIVE  (0xCE7A90B160F75046)
+-- min build: 1207
+---@param p0 boolean
+function SetCinematicModeActive(p0) end
+
+-- SET_FIRST_PERSON_AIM_CAM_RELATIVE_HEADING_LIMITS_THIS_UPDATE  (0x05BD5E4088B30A66)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function SetFirstPersonAimCamRelativeHeadingLimitsThisUpdate(p0, p1) end
+
+-- SET_FIRST_PERSON_AIM_CAM_RELATIVE_PITCH_LIMITS_THIS_UPDATE  (0x715B7F5E8BED32A2)
+-- Old name: _SET_FIRST_PERSON_CAM_PITCH_RANGE
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function SetFirstPersonAimCamRelativePitchLimitsThisUpdate(p0, p1) end
+
+-- SET_GAMEPLAY_CAM_FOLLOW_PED_THIS_UPDATE  (0x82E41D6ADE924FCA)
+-- Forces gameplay cam to specified ped as if you were the ped or spectating it
+-- min build: 1207
+---@param ped number
+function SetGameplayCamFollowPedThisUpdate(ped) end
+
+-- SET_GAMEPLAY_CAM_IGNORE_ENTITY_COLLISION_THIS_UPDATE  (0xD904F75DBD7AB865)
+-- Old name: _DISABLE_CAM_COLLISION_FOR_ENTITY
+-- min build: 1207
+---@param entity number
+function SetGameplayCamIgnoreEntityCollisionThisUpdate(entity) end
+
+-- SET_GAMEPLAY_CAM_MAX_MOTION_BLUR_STRENGTH_THIS_UPDATE  (0x8459B3E64257B21D)
+-- min build: 1207
+---@param p0 number
+function SetGameplayCamMaxMotionBlurStrengthThisUpdate(p0) end
+
+-- SET_GAMEPLAY_CAM_RELATIVE_HEADING  (0x5D1EB123EAC5D071)
+-- Sets the camera position relative to heading in float from -360 to +360.
+-- 
+-- Heading is always 0 in aiming camera.
+-- min build: 1207
+---@param heading number
+---@param p1 number
+function SetGameplayCamRelativeHeading(heading, p1) end
+
+-- SET_GAMEPLAY_CAM_RELATIVE_PITCH  (0xFB760AF4F537B8BF)
+-- Sets the camera pitch.
+-- 
+-- Parameters:
+-- x = pitches the camera on the x axis.
+-- Value2 = always seems to be hex 0x3F800000 (1.000000 float).
+-- min build: 1207
+---@param x number
+---@param Value2 number
+function SetGameplayCamRelativePitch(x, Value2) end
+
+-- SET_GAMEPLAY_CAM_SHAKE_AMPLITUDE  (0x570E35F5C4A44838)
+-- Sets the amplitude for the gameplay (i.e. 3rd or 1st) camera to shake.
+-- min build: 1207
+---@param amplitude number
+function SetGameplayCamShakeAmplitude(amplitude) end
+
+-- SET_GAMEPLAY_COORD_HINT  (0xFA33B8C69A4A6A0F)
+-- Hash used in finale1.ysc: 1726668277
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param duration number
+---@param blendOutDuration number
+---@param blendInDuration number
+---@param p6 number
+function SetGameplayCoordHint(x, y, z, duration, blendOutDuration, blendInDuration, p6) end
+
+-- SET_GAMEPLAY_ENTITY_HINT  (0xD1F7F32640ADFD12)
+-- p6 & p7 - possibly length or time
+-- min build: 1207
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param p4 boolean
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 any
+function SetGameplayEntityHint(entity, xOffset, yOffset, zOffset, p4, p5, p6, p7, p8) end
+
+-- SET_GAMEPLAY_HINT_BASE_ORBIT_PITCH_OFFSET  (0x421192A2DA48FD01)
+-- min build: 1207
+---@param p0 number
+function SetGameplayHintBaseOrbitPitchOffset(p0) end
+
+-- SET_GAMEPLAY_HINT_CAMERA_RELATIVE_SIDE_OFFSET  (0xF86B6F93727C59C9)
+-- Old name: _SET_GAMEPLAY_HINT_ANIM_OFFSETX
+-- min build: 1207
+---@param p0 number
+function SetGameplayHintCameraRelativeSideOffset(p0) end
+
+-- SET_GAMEPLAY_HINT_CAMERA_RELATIVE_VERTICAL_OFFSET  (0x29E74F819150CC32)
+-- Old name: _SET_GAMEPLAY_HINT_ANIM_OFFSETY
+-- min build: 1207
+---@param p0 number
+function SetGameplayHintCameraRelativeVerticalOffset(p0) end
+
+-- SET_GAMEPLAY_HINT_FOLLOW_DISTANCE_SCALAR  (0xDDDC54181868F81F)
+-- min build: 1207
+---@param p0 number
+function SetGameplayHintFollowDistanceScalar(p0) end
+
+-- SET_GAMEPLAY_HINT_FOV  (0x661E58BC6F00A49A)
+-- min build: 1207
+---@param FOV number
+function SetGameplayHintFov(FOV) end
+
+-- SET_GAMEPLAY_OBJECT_HINT  (0xC40551D65F2BF297)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function SetGameplayObjectHint(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- SET_GAMEPLAY_PED_HINT  (0x90FB951648851733)
+-- min build: 1207
+---@param p0 number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param p4 boolean
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function SetGameplayPedHint(p0, x1, y1, z1, p4, p5, p6, p7) end
+
+-- SET_GAMEPLAY_VEHICLE_HINT  (0xE2B2BB7DAC280515)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function SetGameplayVehicleHint(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- SET_IN_VEHICLE_CAM_STATE_THIS_UPDATE  (0xFA1D5E8D1C3CCD67)
+-- Forces gameplay cam to specified vehicle as if you were in it
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+function SetInVehicleCamStateThisUpdate(vehicle, p1) end
+
+-- SET_SCRIPTED_CAMERA_IS_FIRST_PERSON_THIS_FRAME  (0x1DD95A8D6B24A0C9)
+-- min build: 1207
+---@param p0 boolean
+function SetScriptedCameraIsFirstPersonThisFrame(p0) end
+
+-- SET_THIRD_PERSON_CAM_ORBIT_DISTANCE_LIMITS_THIS_UPDATE  (0x2126C740A4AC370B)
+-- Old name: _ANIMATE_GAMEPLAY_CAM_ZOOM
+-- min build: 1207
+---@param p0 number
+---@param distance number
+function SetThirdPersonCamOrbitDistanceLimitsThisUpdate(p0, distance) end
+
+-- SET_THIRD_PERSON_CAM_RELATIVE_HEADING_LIMITS_THIS_UPDATE  (0x14F3947318CA8AD2)
+-- minimum: Degrees between -180f and 180f.
+-- maximum: Degrees between -180f and 180f.
+-- 
+-- Clamps the gameplay camera's current yaw.
+-- 
+-- Eg. _CLAMP_GAMEPLAY_CAM_YAW(0.0f, 0.0f) will set the horizontal angle directly behind the player.
+-- 
+-- Old name: _CLAMP_GAMEPLAY_CAM_YAW
+-- min build: 1207
+---@param minimum number
+---@param maximum number
+function SetThirdPersonCamRelativeHeadingLimitsThisUpdate(minimum, maximum) end
+
+-- SET_THIRD_PERSON_CAM_RELATIVE_PITCH_LIMITS_THIS_UPDATE  (0x326C7AA308F3DF6A)
+-- minimum: Degrees between -90f and 90f.
+-- maximum: Degrees between -90f and 90f.
+-- 
+-- Clamps the gameplay camera's current pitch.
+-- 
+-- Eg. _CLAMP_GAMEPLAY_CAM_PITCH(0.0f, 0.0f) will set the vertical angle directly behind the player.
+-- 
+-- Old name: _CLAMP_GAMEPLAY_CAM_PITCH
+-- min build: 1207
+---@param minimum number
+---@param maximum number
+function SetThirdPersonCamRelativePitchLimitsThisUpdate(minimum, maximum) end
+
+-- SET_WIDESCREEN_BORDERS  (0xD7F4D54CF80AFA34)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 number
+function SetWidescreenBorders(p0, p1) end
+
+-- SHAKE_CAM  (0xF9A7BCF5D050D4E7)
+-- min build: 1207
+---@param cam number
+---@param type string
+---@param amplitude number
+function ShakeCam(cam, type, amplitude) end
+
+-- SHAKE_GAMEPLAY_CAM  (0xD9B31B4650520529)
+-- min build: 1207
+---@param shakeName string
+---@param intensity number
+function ShakeGameplayCam(shakeName, intensity) end
+
+-- STOP_CAM_POINTING  (0xCA1B30A3357C71F1)
+-- min build: 1207
+---@param cam number
+function StopCamPointing(cam) end
+
+-- STOP_CAM_SHAKING  (0xB78CC4B4706614B0)
+-- min build: 1207
+---@param cam number
+---@param p1 boolean
+function StopCamShaking(cam, p1) end
+
+-- STOP_CODE_GAMEPLAY_HINT  (0x93759A83D0D844E7)
+-- min build: 1207
+---@param p0 boolean
+function StopCodeGameplayHint(p0) end
+
+-- STOP_GAMEPLAY_CAM_SHAKING  (0xE0DE43D290FB65F9)
+-- min build: 1207
+---@param p0 boolean
+function StopGameplayCamShaking(p0) end
+
+-- STOP_GAMEPLAY_HINT  (0x1BCEC33D54CFCA8A)
+-- min build: 1207
+---@param p0 boolean
+function StopGameplayHint(p0) end
+
+-- STOP_RENDERING_SCRIPT_CAMS_USING_CATCH_UP  (0x8C7C7FF7CF0E5153)
+-- This native makes the gameplay camera zoom into first person/third person with a special effect.
+-- blendBackSmoothingType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eBlendBackSmoothing
+-- min build: 1207
+---@param render boolean
+---@param distance number
+---@param blendBackSmoothingType number
+---@param p3 boolean
+---@param p4 boolean
+---@param p5 boolean
+function StopRenderingScriptCamsUsingCatchUp(render, distance, blendBackSmoothingType, p3, p4, p5) end

--- a/.luals/redm-natives/CLOCK.lua
+++ b/.luals/redm-natives/CLOCK.lua
@@ -1,0 +1,130 @@
+---@meta
+
+-- RDR3 namespace: CLOCK -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _ADD_TIME_TO_DATE_TIME  (0x28EEACE9B43D9597)
+-- min build: 1207
+---@return any
+---@return any
+---@return any
+function _AddTimeToDateTime() end
+
+-- _GET_POSIX_TIME_STRUCT  (0x86A68E84E5884951)
+-- Same as GET_POSIX_TIME except that it takes a single pointer to a struct.
+-- min build: 1207
+---@return any
+function _GetPosixTimeStruct() end
+
+-- _GET_SECONDS_SINCE_BASE_YEAR  (0x78FD8BE812E436B2)
+-- Base year is 1898.
+-- min build: 1207
+---@return number
+function _GetSecondsSinceBaseYear() end
+
+-- _PAUSE_CLOCK_THIS_FRAME  (0x568D998A9FF96774)
+-- min build: 1207
+---@param toggle boolean
+function _PauseClockThisFrame(toggle) end
+
+-- _SET_MILLISECONDS_PER_GAME_MINUTE  (0x04EEDB3848DACF68)
+-- min build: 1207
+---@param ms number
+function _SetMillisecondsPerGameMinute(ms) end
+
+-- ADD_TO_CLOCK_TIME  (0xAB7C251C7701D336)
+-- min build: 1207
+---@param hours number
+---@param minutes number
+---@param seconds number
+function AddToClockTime(hours, minutes, seconds) end
+
+-- ADVANCE_CLOCK_TIME_TO  (0x0184750AE88D0B1D)
+-- min build: 1207
+---@param hour number
+---@param minute number
+---@param second number
+function AdvanceClockTimeTo(hour, minute, second) end
+
+-- GET_CLOCK_DAY_OF_MONTH  (0xDF2FD796C54480A5)
+-- min build: 1207
+---@return number
+function GetClockDayOfMonth() end
+
+-- GET_CLOCK_DAY_OF_WEEK  (0x4DD02D4C7FB30076)
+-- Gets the current day of the week.
+-- 
+-- 0: Sunday
+-- 1: Monday
+-- 2: Tuesday
+-- 3: Wednesday
+-- 4: Thursday
+-- 5: Friday
+-- 6: Saturday
+-- min build: 1207
+---@return number
+function GetClockDayOfWeek() end
+
+-- GET_CLOCK_HOURS  (0xC82CF208C2B19199)
+-- Gets the current ingame hour, expressed without zeros. (09:34 will be represented as 9)
+-- min build: 1207
+---@return number
+function GetClockHours() end
+
+-- GET_CLOCK_MINUTES  (0x4E162231B823DBBF)
+-- Gets the current ingame clock minute.
+-- min build: 1207
+---@return number
+function GetClockMinutes() end
+
+-- GET_CLOCK_MONTH  (0x2D44E8FC79EAB1AC)
+-- min build: 1207
+---@return number
+function GetClockMonth() end
+
+-- GET_CLOCK_SECONDS  (0xB6101ABE62B5F080)
+-- Gets the current ingame clock second. Note that ingame clock seconds change really fast since a day in RDR is only 48 minutes in real life.
+-- min build: 1207
+---@return number
+function GetClockSeconds() end
+
+-- GET_CLOCK_YEAR  (0xE136DCA28C4A48BA)
+-- min build: 1207
+---@return number
+function GetClockYear() end
+
+-- GET_MILLISECONDS_PER_GAME_MINUTE  (0xE4CB8D126501EC52)
+-- min build: 1207
+---@return number
+function GetMillisecondsPerGameMinute() end
+
+-- GET_POSIX_TIME  (0x90338AD4A784E455)
+-- min build: 1207
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+function GetPosixTime() end
+
+-- PAUSE_CLOCK  (0x4D1A590C92BF377E)
+-- min build: 1207
+---@param toggle boolean
+---@param unused any
+function PauseClock(toggle, unused) end
+
+-- SET_CLOCK_DATE  (0x02AD3092562941E2)
+-- min build: 1207
+---@param day number
+---@param month number
+---@param year number
+function SetClockDate(day, month, year) end
+
+-- SET_CLOCK_TIME  (0x3A52C59FFB2DEED8)
+-- SET_CLOCK_TIME(12, 34, 56);
+-- min build: 1207
+---@param hour number
+---@param minute number
+---@param second number
+function SetClockTime(hour, minute, second) end

--- a/.luals/redm-natives/COLLECTABLE.lua
+++ b/.luals/redm-natives/COLLECTABLE.lua
@@ -1,0 +1,224 @@
+---@meta
+
+-- RDR3 namespace: COLLECTABLE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x33825A7388A6B9F6  (0x33825A7388A6B9F6)
+-- min build: 1207
+---@param collectableCategory number
+---@param p1 number
+---@return number
+function N_0x33825A7388A6B9F6(collectableCategory, p1) end
+
+-- _0x3FD91F1A148A0468  (0x3FD91F1A148A0468)
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 number
+---@return any
+function N_0x3FD91F1A148A0468(collectableCategory, p1) end
+
+-- _0x61BEFBA3CE7A3BC8  (0x61BEFBA3CE7A3BC8)
+-- Params: collectableCategory = WEEKLY_COLLECTABLES
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 number
+---@return boolean
+function N_0x61BEFBA3CE7A3BC8(collectableCategory, p1) end
+
+-- _0x6BAB7ACED1017204  (0x6BAB7ACED1017204)
+-- Params: collectableCategory = WEEKLY_COLLECTABLES
+-- min build: 1207
+---@param collectableCategory number
+---@param p1 number
+---@return boolean
+function N_0x6BAB7ACED1017204(collectableCategory, p1) end
+
+-- _0x755901C7598B97BC  (0x755901C7598B97BC)
+-- Returns p2 (index?) for 0xB9020EC89C07DF04
+-- min build: 1207
+---@param collectableCategory number
+---@param p1 number
+---@return number
+function N_0x755901C7598B97BC(collectableCategory, p1) end
+
+-- _0x775FA1FC87666847  (0x775FA1FC87666847)
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 number
+---@return any
+function N_0x775FA1FC87666847(collectableCategory, p1) end
+
+-- _0x93F2E7B5DB85657B  (0x93F2E7B5DB85657B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x93F2E7B5DB85657B(p0, p1) end
+
+-- _0x9ADEE485726025D4  (0x9ADEE485726025D4)
+-- Params: collectableCategory = WEEKLY_COLLECTABLES
+-- min build: 1207
+---@param collectableCategory number
+---@return number
+function N_0x9ADEE485726025D4(collectableCategory) end
+
+-- _0xB9020EC89C07DF04  (0xB9020EC89C07DF04)
+-- Accepts more hashes than 0xCC644BC1DD655269
+-- Such as: CAROLINA_PARAKEETS, DINO_BONES, EGRET_FEATHERS, ...
+-- min build: 1207
+---@param collectableCategory number
+---@param p1 number
+---@param index number
+---@return any
+function N_0xB9020EC89C07DF04(collectableCategory, p1, index) end
+
+-- _0xC3CA424E1F12ED0C  (0xC3CA424E1F12ED0C)
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 number
+---@return any
+function N_0xC3CA424E1F12ED0C(collectableCategory, p1) end
+
+-- _0xC4AC39719C1BB559  (0xC4AC39719C1BB559)
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 any
+---@return any
+function N_0xC4AC39719C1BB559(collectableCategory, p1) end
+
+-- _0xD1806FB3EDED6D11  (0xD1806FB3EDED6D11)
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 number
+---@return any
+function N_0xD1806FB3EDED6D11(collectableCategory, p1) end
+
+-- _0xD297F68928A58130  (0xD297F68928A58130)
+-- min build: 1232
+---@param collectableCategory number
+---@param p1 number
+---@return any
+function N_0xD297F68928A58130(collectableCategory, p1) end
+
+-- _0xFC832B06127D8E99  (0xFC832B06127D8E99)
+-- min build: 1207
+---@param collectableCategory number
+---@param p1 number
+---@return boolean
+function N_0xFC832B06127D8E99(collectableCategory, p1) end
+
+-- _COLLECTABLE_CATEGORY_GET_NUM_COLLECTABLES  (0x62CAB7DB62EAD434)
+-- min build: 1207
+---@param collectableCategory number
+---@param collectableSubcategory number
+---@return number
+function _CollectableCategoryGetNumCollectables(collectableCategory, collectableSubcategory) end
+
+-- _COLLECTABLE_CATEGORY_GET_NUM_FOUND  (0x5461C821D00FE15A)
+-- min build: 1207
+---@param collectableCategory number
+---@param collectableSubcategory number
+---@return number
+function _CollectableCategoryGetNumFound(collectableCategory, collectableSubcategory) end
+
+-- _COLLECTABLE_CATEGORY_GET_NUM_TURNED_IN  (0x3A65F4844913A047)
+-- min build: 1207
+---@param collectableCategory number
+---@param collectableSubcategory number
+---@return number
+function _CollectableCategoryGetNumTurnedIn(collectableCategory, collectableSubcategory) end
+
+-- _COLLECTABLE_CATEGORY_GET_TOAST_TEXTURE_DICTIONARY  (0x13AAECDA43318BFE)
+-- min build: 1207
+---@param collectableCategory number
+---@param collectableSubcategory number
+---@return number
+function _CollectableCategoryGetToastTextureDictionary(collectableCategory, collectableSubcategory) end
+
+-- _COLLECTABLE_CATEGORY_GET_TOAST_TEXTURE_NAME  (0xD52D20B0C76BB26D)
+-- min build: 1207
+---@param collectableCategory number
+---@param collectableSubcategory number
+---@return number
+function _CollectableCategoryGetToastTextureName(collectableCategory, collectableSubcategory) end
+
+-- _COLLECTABLE_GET_CATEGORY  (0x725D52F21A5E9EF6)
+-- Used in Script Function NET_COLLECTABLES_HANDLE_ITEM_ADDED
+-- Returns collectableCategory Hash
+-- min build: 1207
+---@param collectableItem number
+---@return number
+function _CollectableGetCategory(collectableItem) end
+
+-- _COLLECTABLE_GET_COLLECTABLE_ITEM_HASH  (0x126CBEBBA46693CF)
+-- min build: 1207
+---@param index number
+---@param collectableCategory number
+---@param collectableSubcategory number
+---@return number
+function _CollectableGetCollectableItemHash(index, collectableCategory, collectableSubcategory) end
+
+-- _COLLECTABLE_GET_IPL  (0x922A79CD4A033B8B)
+-- min build: 1207
+---@param collectableItem number
+---@return number
+function _CollectableGetIpl(collectableItem) end
+
+-- _COLLECTABLE_GET_NUM_FOUND  (0xF83D3DDA4D3C8169)
+-- min build: 1207
+---@param collectableItem number
+---@return number
+function _CollectableGetNumFound(collectableItem) end
+
+-- _COLLECTABLE_GET_NUM_TURNED_IN  (0x9A03F22AD446EEAC)
+-- min build: 1207
+---@param collectableItem number
+---@return number
+function _CollectableGetNumTurnedIn(collectableItem) end
+
+-- _COLLECTABLE_GET_PLACEMENT_LOCATION  (0x1F1DD794908C2BFA)
+-- min build: 1207
+---@param collectableItem number
+---@return vector3
+function _CollectableGetPlacementLocation(collectableItem) end
+
+-- _COLLECTABLE_GET_SUBCATEGORY  (0x6052B4DE6657684F)
+-- min build: 1207
+---@param collectableItem number
+---@return number
+function _CollectableGetSubcategory(collectableItem) end
+
+-- _COLLECTABLE_INCREMENT_NUM_FOUND  (0x3EA62E56F386C997)
+-- min build: 1207
+---@param collectableItem number
+---@param amount number
+function _CollectableIncrementNumFound(collectableItem, amount) end
+
+-- _COLLECTABLE_INCREMENT_NUM_TURNED_IN  (0x398FAB9C96A81924)
+-- min build: 1207
+---@param collectableItem number
+---@param amount number
+function _CollectableIncrementNumTurnedIn(collectableItem, amount) end
+
+-- _COLLECTABLE_SET_ITEM_HASH_DISCOVERED  (0xEC3959E9950BF56B)
+-- Returns discoveredItemHash
+-- _COLLECTABLE_C* - _COLLECTABLE_G*
+-- min build: 1207
+---@param collectableItem number
+---@return number
+function _CollectableSetItemHashDiscovered(collectableItem) end
+
+-- COLLECTABLE_CATEGORY_SET_HAS_RECEIVED_LIST  (0x0B6D275D2F242E17)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function CollectableCategorySetHasReceivedList(p0, p1, p2) end
+
+-- COLLECTABLE_GET_CATEGORY_ITEM_SET_BUY_AWARD  (0xCC644BC1DD655269)
+-- collectableCategory: ANTIQUE_BOTTLES, BIRD_EGGS, ARROWHEADS, FAMILY_HEIRLOOMS, WILD_FLOWERS, COINS, LOST_JEWELRY_RINGS, LOST_JEWELRY_BRACELETS, LOST_JEWELRY_EARRINGS, LOST_JEWELRY_NECKLACES, TAROT_CARDS_CUPS, TAROT_CARDS_PENTACLES, TAROT_CARDS_SWORDS, TAROT_CARDS_WANDS, FOSSILS_COMMON, FOSSILS_UNCOMMON, FOSSILS_RARE
+-- min build: 1207
+---@param collectableCategory number
+---@param p1 number
+---@return number
+function CollectableGetCategoryItemSetBuyAward(collectableCategory, p1) end

--- a/.luals/redm-natives/COMPANION.lua
+++ b/.luals/redm-natives/COMPANION.lua
@@ -1,0 +1,164 @@
+---@meta
+
+-- RDR3 namespace: COMPANION -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0A8FD91EDE7B328A  (0x0A8FD91EDE7B328A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0A8FD91EDE7B328A(p0, p1) end
+
+-- _0x0C6A00DAE896614C  (0x0C6A00DAE896614C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0C6A00DAE896614C(p0, p1) end
+
+-- _0x0DE02DA3C0F66955  (0x0DE02DA3C0F66955)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x0DE02DA3C0F66955(ped, p1) end
+
+-- _0x2917E634206B9E17  (0x2917E634206B9E17)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x2917E634206B9E17(ped, p1) end
+
+-- _0x3CAAD93FA5B9579A  (0x3CAAD93FA5B9579A)
+-- min build: 1207
+---@param volume number
+---@param p1 number
+---@param p2 number
+function N_0x3CAAD93FA5B9579A(volume, p1, p2) end
+
+-- _0x61BDA07407754A5C  (0x61BDA07407754A5C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x61BDA07407754A5C(p0, p1, p2, p3) end
+
+-- _0x722FBE08EF5B87BD  (0x722FBE08EF5B87BD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0x722FBE08EF5B87BD(p0, p1, p2, p3, p4) end
+
+-- _0x7274F84B1501B523  (0x7274F84B1501B523)
+-- min build: 1207
+---@param p0 any
+function N_0x7274F84B1501B523(p0) end
+
+-- _0x8FB98B719AA0075A  (0x8FB98B719AA0075A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x8FB98B719AA0075A(p0, p1, p2, p3, p4) end
+
+-- _0x991E3346D788F20F  (0x991E3346D788F20F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x991E3346D788F20F(p0, p1) end
+
+-- _0x9C902084F48D2E6C  (0x9C902084F48D2E6C)
+-- min build: 1207
+---@param p0 any
+function N_0x9C902084F48D2E6C(p0) end
+
+-- _0xA079FF7CFB9AC8BD  (0xA079FF7CFB9AC8BD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA079FF7CFB9AC8BD(p0, p1) end
+
+-- _0xBF6583E926D13890  (0xBF6583E926D13890)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBF6583E926D13890(p0, p1) end
+
+-- _0xCE27824B5968B79A  (0xCE27824B5968B79A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCE27824B5968B79A(p0, p1) end
+
+-- _0xD428C3F92FC3F6F8  (0xD428C3F92FC3F6F8)
+-- min build: 1207
+---@param ped number
+---@param p1 string
+function N_0xD428C3F92FC3F6F8(ped, p1) end
+
+-- _0xD55A871E1CE3481B  (0xD55A871E1CE3481B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xD55A871E1CE3481B(p0, p1, p2, p3) end
+
+-- _0xD730281E496621FB  (0xD730281E496621FB)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0xD730281E496621FB(ped, p1) end
+
+-- _0xD747979C053EFA7A  (0xD747979C053EFA7A)
+-- min build: 1207
+---@param p0 any
+function N_0xD747979C053EFA7A(p0) end
+
+-- _0xF06CBB8CCCA823C0  (0xF06CBB8CCCA823C0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xF06CBB8CCCA823C0(p0, p1) end
+
+-- _ACTIVATE_COMPANION_ANALYSIS  (0xCBD9EC60495C728C)
+-- min build: 1207
+---@param groupId number
+function _ActivateCompanionAnalysis(groupId) end
+
+-- _ADD_COMPANION_FLAG  (0xDEB369F6AD168C58)
+-- Used for Script Function NET_FETCH_CLIENT_ACTIVATE_COMAPNION_ANALYSIS: Hiding! Ped
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _AddCompanionFlag(ped, p1) end
+
+-- _DEACTIVATE_COMPANION_ANALYSIS  (0x72B7F65F11FC8896)
+-- min build: 1207
+---@param groupId number
+function _DeactivateCompanionAnalysis(groupId) end
+
+-- _GET_COMPANION_ACTIVITY  (0xB7E0590C86E1711F)
+-- enum _0x18F77396
+-- min build: 1207
+---@param groupId number
+---@return number
+function _GetCompanionActivity(groupId) end
+
+-- _REMOVE_COMPANION_FLAG  (0x1740E3DEE0AE4D27)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _RemoveCompanionFlag(ped, p1) end
+
+-- _SET_COMPANION_ACTIVITY  (0x0F1CD8CA9E65D5F6)
+-- enum _0x18F77396
+-- min build: 1207
+---@param groupId number
+---@param activity number
+function _SetCompanionActivity(groupId, activity) end

--- a/.luals/redm-natives/COMPAPP.lua
+++ b/.luals/redm-natives/COMPAPP.lua
@@ -1,0 +1,36 @@
+---@meta
+
+-- RDR3 namespace: COMPAPP -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x29C733459A9011EB  (0x29C733459A9011EB)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 number
+---@param p1 string
+function N_0x29C733459A9011EB(p0, p1) end
+
+-- _0x74BCCEB233AD95B2  (0x74BCCEB233AD95B2)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function N_0x74BCCEB233AD95B2(p0, p1) end
+
+-- _0x7AF1BB4504EA5ED9  (0x7AF1BB4504EA5ED9)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function N_0x7AF1BB4504EA5ED9() end
+
+-- _0xB6FD96420C0126A1  (0xB6FD96420C0126A1)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 number
+---@param p1 boolean
+function N_0xB6FD96420C0126A1(p0, p1) end
+
+-- _0xCCB4635A071FB62D  (0xCCB4635A071FB62D)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0xCCB4635A071FB62D() end

--- a/.luals/redm-natives/COMPENDIUM.lua
+++ b/.luals/redm-natives/COMPENDIUM.lua
@@ -1,0 +1,227 @@
+---@meta
+
+-- RDR3 namespace: COMPENDIUM -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x725D52F21A5E9E22  (0x725D52F21A5E9E22)
+-- Only used in R* SP Scripts, category = GANGS
+-- _COMPENDIUM_GET_*
+-- min build: 1207
+---@param category number
+---@return number
+function N_0x725D52F21A5E9E22(category) end
+
+-- _0x729D52461AEA9E22  (0x729D52461AEA9E22)
+-- Only used in R* SP Scripts, category = GANGS
+-- _COMPENDIUM_GET_NUM_OF_ENTRIES_IN_*
+-- min build: 1207
+---@param category number
+---@return number
+function N_0x729D52461AEA9E22(category) end
+
+-- _COMPENDIUM_GET_NUM_OF_ENTRIES_IN_CATEGORY  (0x729D52F61A5A9E22)
+-- min build: 1207
+---@param category number
+---@return number
+function _CompendiumGetNumOfEntriesInCategory(category) end
+
+-- _COMPENDIUM_GET_SUBCATEGORY_HASH_FROM_ANIMAL_TYPE  (0xCD278B6BFBDBDC22)
+-- min build: 1355
+---@param category number
+---@param animalType number
+---@return number
+function _CompendiumGetSubcategoryHashFromAnimalType(category, animalType) end
+
+-- COMPENDIUM_ANIMAL_GET_SAMPLE_INVENTORY_ITEM  (0x4E4ACAE1C671A9DA)
+-- min build: 1311
+---@param compendiumEntry number
+---@return any
+function CompendiumAnimalGetSampleInventoryItem(compendiumEntry) end
+
+-- COMPENDIUM_ANIMAL_HAS_SAMPLE  (0x6FC24625E4FCAC27)
+-- min build: 1311
+---@param compendiumEntry number
+---@return boolean
+function CompendiumAnimalHasSample(compendiumEntry) end
+
+-- COMPENDIUM_ANIMAL_HAS_STAMP  (0xBCF569FC32FFF456)
+-- min build: 1311
+---@param compendiumEntry number
+---@return boolean
+function CompendiumAnimalHasStamp(compendiumEntry) end
+
+-- COMPENDIUM_ANIMAL_OBSERVED_BY_STAT_NAME  (0x725D52F26A5E9E10)
+-- min build: 1207
+---@param animalType number
+---@param disableCompendiumToast boolean
+function CompendiumAnimalObservedByStatName(animalType, disableCompendiumToast) end
+
+-- COMPENDIUM_ANIMAL_SET_DISCOVERED  (0x67F35C7C9F2BDCFE)
+-- min build: 1311
+---@param compendiumEntry number
+function CompendiumAnimalSetDiscovered(compendiumEntry) end
+
+-- COMPENDIUM_FISH_CAUGHT  (0x725D52F21A5E9E00)
+-- min build: 1207
+---@param ped number
+---@param category number
+function CompendiumFishCaught(ped, category) end
+
+-- COMPENDIUM_FISH_GET_LURE_SUITABILITY_BY_STAT_ITEM  (0x725D52F21A5E9E81)
+-- min build: 1207
+---@param animalType number
+---@param baitType number
+---@return number
+function CompendiumFishGetLureSuitabilityByStatItem(animalType, baitType) end
+
+-- COMPENDIUM_GANG_AMBUSH_SURVIVED  (0x725D52F21A5E9E04)
+-- min build: 1207
+---@param p0 any
+function CompendiumGangAmbushSurvived(p0) end
+
+-- COMPENDIUM_GANG_BOUNTY_CAPTURED  (0x725D52F21A5E9E06)
+-- min build: 1207
+---@param p0 any
+function CompendiumGangBountyCaptured(p0) end
+
+-- COMPENDIUM_GANG_CAMP_FOUND  (0x725D52F21A5E9E03)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function CompendiumGangCampFound(p0, p1) end
+
+-- COMPENDIUM_GANG_ENCOUNTERED  (0x725D52F21A5E9E05)
+-- min build: 1207
+---@param p0 any
+function CompendiumGangEncountered(p0) end
+
+-- COMPENDIUM_GANG_HIDEOUT_FOUND  (0x725D52F21A5E9E08)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function CompendiumGangHideoutFound(p0, p1) end
+
+-- COMPENDIUM_GANG_MEMBER_KILLED  (0x725D52F21A5E9E07)
+-- min build: 1207
+---@param p0 any
+function CompendiumGangMemberKilled(p0) end
+
+-- COMPENDIUM_GET_ENTRY_BY_INDEX_IN_SUBCATEGORY  (0x5CEB63B2E3D9895F)
+-- min build: 1311
+---@param category number
+---@param subcategory number
+---@param count number
+---@return number
+function CompendiumGetEntryByIndexInSubcategory(category, subcategory, count) end
+
+-- COMPENDIUM_GET_ENTRY_BY_PED_INDEX  (0x1CFA0219D8E1CF25)
+-- min build: 1311
+---@param category number
+---@param ped number
+---@return number
+function CompendiumGetEntryByPedIndex(category, ped) end
+
+-- COMPENDIUM_GET_ENTRY_BY_STAT_ITEM  (0x66EC938394D76C85)
+-- min build: 1355
+---@param category number
+---@param animalType number
+---@return number
+function CompendiumGetEntryByStatItem(category, animalType) end
+
+-- COMPENDIUM_GET_MAP_DISCOVERABLE_FROM_STAT_ITEM  (0x729D54121A5E9E20)
+-- min build: 1207
+---@param animalStatItem number
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function CompendiumGetMapDiscoverableFromStatItem(animalStatItem, x, y, z) end
+
+-- COMPENDIUM_GET_NUM_ENTRIES_IN_SUBCATEGORY  (0xF58A0C0E086E8E36)
+-- min build: 1311
+---@param category number
+---@param subcategory number
+---@return number
+function CompendiumGetNumEntriesInSubcategory(category, subcategory) end
+
+-- COMPENDIUM_GET_SHORT_DESCRIPTION_FROM_PED  (0x6C5E5D48E48B4C65)
+-- min build: 1207
+---@param ped number
+---@return number
+function CompendiumGetShortDescriptionFromPed(ped) end
+
+-- COMPENDIUM_GET_STUDY_AWARD_ID  (0x9F678782720349E4)
+-- min build: 1311
+---@param ped number
+---@return any
+function CompendiumGetStudyAwardId(ped) end
+
+-- COMPENDIUM_GET_SUBCATEGORY_PED_IS_IN  (0x9B657550DF55EC96)
+-- min build: 1311
+---@param category number
+---@param ped number
+---@return number
+function CompendiumGetSubcategoryPedIsIn(category, ped) end
+
+-- COMPENDIUM_GET_SUBCATEGORY_SAMPLE_TOAST_DESC_COMPLETE  (0x59D4D68CDB82427C)
+-- min build: 1311
+---@param category number
+---@param subcategory number
+---@return string
+function CompendiumGetSubcategorySampleToastDescComplete(category, subcategory) end
+
+-- COMPENDIUM_GET_SUBCATEGORY_SAMPLE_TOAST_DESC_PROGRESS  (0x82BFB5B367957699)
+-- min build: 1311
+---@param category number
+---@param subcategory number
+---@return string
+function CompendiumGetSubcategorySampleToastDescProgress(category, subcategory) end
+
+-- COMPENDIUM_GET_SUBCATEGORY_SAMPLE_TOAST_TITLE  (0x5E50C67EB60951E6)
+-- min build: 1311
+---@param category number
+---@param subcategory number
+---@return string
+function CompendiumGetSubcategorySampleToastTitle(category, subcategory) end
+
+-- COMPENDIUM_GET_SUBCATEGORY_TOAST_APP_ID  (0x2BF30D9D4D680112)
+-- min build: 1311
+---@param category number
+---@param subcategory number
+---@return any
+function CompendiumGetSubcategoryToastAppId(category, subcategory) end
+
+-- COMPENDIUM_HERB_PICKED  (0x725D52F21A5E9E09)
+-- herbType: https://alloc8or.re/rdr3/doc/enums/eHerbType.txt
+-- Vector3: Player Location
+-- min build: 1207
+---@param herbType number
+---@param x number
+---@param y number
+---@param z number
+function CompendiumHerbPicked(herbType, x, y, z) end
+
+-- COMPENDIUM_HORSE_BONDING  (0x725D52F21A5E9E50)
+-- min build: 1207
+---@param ped number
+---@param bondingLevel number
+function CompendiumHorseBonding(ped, bondingLevel) end
+
+-- COMPENDIUM_HORSE_OBSERVED  (0x725D58F2125E5E50)
+-- Only gets called if bSetObserved is true and animalType is matching
+-- min build: 1207
+---@param ped number
+---@param disableCompendiumToast boolean
+function CompendiumHorseObserved(ped, disableCompendiumToast) end
+
+-- COMPENDIUM_HORSE_WILD_BROKEN  (0x725852D21A2E9E50)
+-- NET_PLAYER_HORSE_PROCESS_EVENT_HORSE_BREAKING
+-- min build: 1207
+---@param ped number
+function CompendiumHorseWildBroken(ped) end
+
+-- COMPENDIUM_WAS_ANIMAL_OBSERVED  (0x23B5E9C5160BC04F)
+-- min build: 1311
+---@param ped number
+---@return boolean
+function CompendiumWasAnimalObserved(ped) end

--- a/.luals/redm-natives/CRASHLOG.lua
+++ b/.luals/redm-natives/CRASHLOG.lua
@@ -1,0 +1,79 @@
+---@meta
+
+-- RDR3 namespace: CRASHLOG -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0FD3ECF9D0C8655F  (0x0FD3ECF9D0C8655F)
+-- min build: 1207
+---@param p0 string
+function N_0x0FD3ECF9D0C8655F(p0) end
+
+-- _0x23CCAB8F40B9CBEE  (0x23CCAB8F40B9CBEE)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function N_0x23CCAB8F40B9CBEE(x, y, z) end
+
+-- _0x33C1D63E55FA4284  (0x33C1D63E55FA4284)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function N_0x33C1D63E55FA4284(p0) end
+
+-- _0x3A66F1963B223F61  (0x3A66F1963B223F61)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function N_0x3A66F1963B223F61(p0) end
+
+-- _0x4E42CA5BCD45444A  (0x4E42CA5BCD45444A)
+-- min build: 1207
+function N_0x4E42CA5BCD45444A() end
+
+-- _0x7C680FF55617F82F  (0x7C680FF55617F82F)
+-- min build: 1207
+---@return boolean
+function N_0x7C680FF55617F82F() end
+
+-- _0x87F005C969EF1563  (0x87F005C969EF1563)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0x87F005C969EF1563(p0) end
+
+-- _0xA67F0B039D9CD513  (0xA67F0B039D9CD513)
+-- min build: 1207
+---@param p0 boolean
+---@return boolean
+function N_0xA67F0B039D9CD513(p0) end
+
+-- _0xCA0BAC376C541978  (0xCA0BAC376C541978)
+-- min build: 1207
+---@param p0 string
+function N_0xCA0BAC376C541978(p0) end
+
+-- _0xD8E3D22AA4F0E0A5  (0xD8E3D22AA4F0E0A5)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function N_0xD8E3D22AA4F0E0A5(p0) end
+
+-- _0xDA05310EA94DC8C6  (0xDA05310EA94DC8C6)
+-- unused = true
+-- min build: 1436
+---@param p0 string
+---@param p1 string
+function N_0xDA05310EA94DC8C6(p0, p1) end
+
+-- _0xE72E234B30DA7B7A  (0xE72E234B30DA7B7A)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0xE72E234B30DA7B7A(p0) end
+
+-- _0xF0D545C1EEAD614A  (0xF0D545C1EEAD614A)
+-- min build: 1207
+---@return boolean
+function N_0xF0D545C1EEAD614A() end

--- a/.luals/redm-natives/CREW.lua
+++ b/.luals/redm-natives/CREW.lua
@@ -1,0 +1,112 @@
+---@meta
+
+-- RDR3 namespace: CREW -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x58D378AF2C8765B7  (0x58D378AF2C8765B7)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function N_0x58D378AF2C8765B7(p0) end
+
+-- _NETWORK_ACCEPT_CLAN_INVITE  (0x8E2143144B8E188D)
+-- min build: 1207
+---@param crewInviteIndex number
+---@return boolean
+function _NetworkAcceptClanInvite(crewInviteIndex) end
+
+-- _NETWORK_CLAN_INVITE_PLAYER  (0xC685B014CE3D988B)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function _NetworkClanInvitePlayer(p0) end
+
+-- _NETWORK_CLAN_SET_ACTIVE  (0xC080FF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _NetworkClanSetActive(p0) end
+
+-- NETWORK_CLAN_GET_LOCAL_MEMBERSHIPS_COUNT  (0x1F471B79ACC90BEF)
+-- min build: 1207
+---@return number
+function NetworkClanGetLocalMembershipsCount() end
+
+-- NETWORK_CLAN_GET_MEMBERSHIP_DESC  (0x48DE78AF2C8885B8)
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+function NetworkClanGetMembershipDesc(p1) end
+
+-- NETWORK_CLAN_IS_EMBLEM_READY  (0xA134777FF7F33331)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+---@return any
+function NetworkClanIsEmblemReady(p0) end
+
+-- NETWORK_CLAN_PLAYER_GET_DESC  (0xEEE6EACBE8874FBA)
+-- min build: 1207
+---@param bufferSize number
+---@return boolean
+---@return any
+---@return any
+function NetworkClanPlayerGetDesc(bufferSize) end
+
+-- NETWORK_CLAN_PLAYER_IS_ACTIVE  (0xB124B57F571D8F18)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkClanPlayerIsActive() end
+
+-- NETWORK_CLAN_RELEASE_EMBLEM  (0x113E6E3E50E286B0)
+-- min build: 1207
+---@param p0 any
+function NetworkClanReleaseEmblem(p0) end
+
+-- NETWORK_CLAN_REQUEST_EMBLEM  (0x13518FF1C6B28938)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function NetworkClanRequestEmblem(p0) end
+
+-- NETWORK_CLAN_SERVICE_IS_VALID  (0x579CCED0265D4896)
+-- min build: 1207
+---@return boolean
+function NetworkClanServiceIsValid() end
+
+-- NETWORK_FIND_GAMERS_IN_CREW  (0xE532D6811B3A4D2A)
+-- min build: 1207
+---@param crewId number
+---@return boolean
+function NetworkFindGamersInCrew(crewId) end
+
+-- NETWORK_GET_PRIMARY_CLAN_DATA_CLEAR  (0x9AA46BADAD0E27ED)
+-- min build: 1207
+---@return any
+function NetworkGetPrimaryClanDataClear() end
+
+-- NETWORK_GET_PRIMARY_CLAN_DATA_NEW  (0xC080FF658B2E41DA)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function NetworkGetPrimaryClanDataNew() end
+
+-- NETWORK_GET_PRIMARY_CLAN_DATA_PENDING  (0xB5074DB804E28CE7)
+-- min build: 1207
+---@return boolean
+function NetworkGetPrimaryClanDataPending() end
+
+-- NETWORK_GET_PRIMARY_CLAN_DATA_START  (0xCE86D8191B762107)
+-- min build: 1207
+---@param p1 any
+---@return boolean
+---@return any
+function NetworkGetPrimaryClanDataStart(p1) end
+
+-- NETWORK_GET_PRIMARY_CLAN_DATA_SUCCESS  (0x5B4F04F19376A0BA)
+-- min build: 1207
+---@return boolean
+function NetworkGetPrimaryClanDataSuccess() end

--- a/.luals/redm-natives/DATABINDING.lua
+++ b/.luals/redm-natives/DATABINDING.lua
@@ -1,0 +1,580 @@
+---@meta
+
+-- RDR3 namespace: DATABINDING -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x02B21B6BEEDD83CC  (0x02B21B6BEEDD83CC)
+-- min build: 1207
+---@param entryId number
+---@param p1 number
+---@return any
+function N_0x02B21B6BEEDD83CC(entryId, p1) end
+
+-- _0x05AC9E1E02975AFB  (0x05AC9E1E02975AFB)
+-- _DATABINDING_WRITE_DATA_*
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+function N_0x05AC9E1E02975AFB(p0, p1, p2) end
+
+-- _0x1919D59E60FD516E  (0x1919D59E60FD516E)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+function N_0x1919D59E60FD516E(p0, p1, p2) end
+
+-- _0x294AF5323F44B053  (0x294AF5323F44B053)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 any
+---@return any
+function N_0x294AF5323F44B053(p0, p1, p2) end
+
+-- _0x3BF0767CF33FCC88  (0x3BF0767CF33FCC88)
+-- min build: 1207
+---@param entryId number
+function N_0x3BF0767CF33FCC88(entryId) end
+
+-- _0x422179C7F6AD9304  (0x422179C7F6AD9304)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x422179C7F6AD9304(p0) end
+
+-- _0x6329C34BEE5BFF4B  (0x6329C34BEE5BFF4B)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function N_0x6329C34BEE5BFF4B(p0, p1) end
+
+-- _0x7FC60C94C83C5CD7  (0x7FC60C94C83C5CD7)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+function N_0x7FC60C94C83C5CD7(p0, p1, p2) end
+
+-- _0xB138CA787F3DD858  (0xB138CA787F3DD858)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 any
+function N_0xB138CA787F3DD858(p0, p1, p2) end
+
+-- _0xBFC83DA249BEFCC9  (0xBFC83DA249BEFCC9)
+-- _DATABINDING_WRITE_DATA_*
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 any
+function N_0xBFC83DA249BEFCC9(p0, p1, p2) end
+
+-- _0xC900CEC8A172375B  (0xC900CEC8A172375B)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+function N_0xC900CEC8A172375B(p0, p1, p2) end
+
+-- _0xD48993A61938C64D  (0xD48993A61938C64D)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function N_0xD48993A61938C64D(p0, p1) end
+
+-- _0xE6AAB897120492D6  (0xE6AAB897120492D6)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function N_0xE6AAB897120492D6(p0, p1) end
+
+-- _0xE6AAB897120492D7  (0xE6AAB897120492D7)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 any
+function N_0xE6AAB897120492D7(p0, p1, p2) end
+
+-- _0xF47E33F8D2523825  (0xF47E33F8D2523825)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function N_0xF47E33F8D2523825(p0, p1) end
+
+-- _DATABINDING_ADD_DATA_BOOL  (0x58BAA5F635DA2FF4)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 boolean
+---@return any
+function _DatabindingAddDataBool(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_BOOL_BY_HASH  (0xBC95D3AE2ECA70D6)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 boolean
+---@return any
+function _DatabindingAddDataBoolByHash(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_BOOL_FROM_PATH  (0x37BB86A751148A6A)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@param p2 boolean
+---@return any
+function _DatabindingAddDataBoolFromPath(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_CONTAINER  (0xEB4F9A3537EEABCD)
+-- Returns entryId Hash
+-- min build: 1207
+---@param entryId number
+---@param p1 string
+---@return number
+function _DatabindingAddDataContainer(entryId, p1) end
+
+-- _DATABINDING_ADD_DATA_CONTAINER_BY_HASH  (0x98BB14345BB68257)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function _DatabindingAddDataContainerByHash(p0, p1) end
+
+-- _DATABINDING_ADD_DATA_CONTAINER_FROM_PATH  (0x0C827D175F1292F4)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@return number
+function _DatabindingAddDataContainerFromPath(p0, p1) end
+
+-- _DATABINDING_ADD_DATA_CONTAINER_FROM_PATH_BY_HASH  (0xD7DB94AB78E8EBE4)
+-- min build: 1207
+---@param p0 string
+---@param p1 number
+---@return any
+function _DatabindingAddDataContainerFromPathByHash(p0, p1) end
+
+-- _DATABINDING_ADD_DATA_FLOAT  (0x5154228273ADB9A6)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+---@return any
+function _DatabindingAddDataFloat(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_GANG_ID  (0x7D0F2014DB28DD00)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param gangId any
+---@return any
+function _DatabindingAddDataGangId(p0, p1, gangId) end
+
+-- _DATABINDING_ADD_DATA_HASH  (0x8538F1205D60ECA6)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+---@return any
+function _DatabindingAddDataHash(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_HASH_BY_HASH  (0x8E173DFB041993C6)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+---@return any
+function _DatabindingAddDataHashByHash(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_INT  (0x307A3247C5457BDE)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+---@return any
+function _DatabindingAddDataInt(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_INT_BY_HASH  (0x267F9527F4350ADE)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+---@return any
+function _DatabindingAddDataIntByHash(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_POSSE_ID  (0x7D0F2014DB28DD01)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param posseId any
+---@return any
+function _DatabindingAddDataPosseId(p0, p1, posseId) end
+
+-- _DATABINDING_ADD_DATA_STRING  (0x617FCA1C5652BBAD)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 string
+---@return any
+function _DatabindingAddDataString(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_STRING_BY_HASH  (0xEAD09E76E22630C3)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 string
+---@return any
+function _DatabindingAddDataStringByHash(p0, p1, p2) end
+
+-- _DATABINDING_ADD_DATA_STRING_FROM_PATH  (0xA381DE86EE170C4A)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@param p2 string
+---@return any
+function _DatabindingAddDataStringFromPath(p0, p1, p2) end
+
+-- _DATABINDING_ADD_HASH_ARRAY  (0x52F5F08278EA5D75)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingAddHashArray(p0, p1) end
+
+-- _DATABINDING_ADD_STRING_ARRAY  (0x1B23E0627BDBFE85)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingAddStringArray(p0, p1) end
+
+-- _DATABINDING_ADD_UI_ITEM_LIST  (0xFE74FA57E0CE6824)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingAddUiItemList(p0, p1) end
+
+-- _DATABINDING_ADD_UI_ITEM_LIST_BY_HASH  (0x3C7799283325181B)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function _DatabindingAddUiItemListByHash(p0, p1) end
+
+-- _DATABINDING_ADD_UI_ITEM_LIST_FROM_PATH  (0xDB5B9A474148F699)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@return any
+function _DatabindingAddUiItemListFromPath(p0, p1) end
+
+-- _DATABINDING_CLEAR_BINDING_ARRAY  (0xA1F15C1D03DF802D)
+-- min build: 1207
+---@param entryId number
+function _DatabindingClearBindingArray(entryId) end
+
+-- _DATABINDING_GET_ARRAY_COUNT  (0xD23F5DE04FE717E2)
+-- min build: 1207
+---@param entryId number
+---@return any
+function _DatabindingGetArrayCount(entryId) end
+
+-- _DATABINDING_GET_DATA_CONTAINER_FROM_CHILD_INDEX  (0x0C827D175F1292F3)
+-- min build: 1207
+---@param entryId number
+---@param p1 number
+---@return any
+function _DatabindingGetDataContainerFromChildIndex(entryId, p1) end
+
+-- _DATABINDING_GET_DATA_CONTAINER_FROM_PATH  (0x0C827D175F1292F2)
+-- min build: 1207
+---@param p0 string
+---@return any
+function _DatabindingGetDataContainerFromPath(p0) end
+
+-- _DATABINDING_GET_ITEM_CONTEXT_BY_INDEX  (0xE96D7F9FEFCC105F)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return any
+function _DatabindingGetItemContextByIndex(p0, index) end
+
+-- _DATABINDING_INSERT_UI_ITEM_TO_LIST_FROM_CONTEXT_HASH_ALIAS  (0xEE97A05C05F16E41)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@param p2 number
+---@param p3 any
+function _DatabindingInsertUiItemToListFromContextHashAlias(p0, index, p2, p3) end
+
+-- _DATABINDING_INSERT_UI_ITEM_TO_LIST_FROM_CONTEXT_STRING_ALIAS  (0x5859E970794D92F3)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@param p2 string
+---@param p3 any
+function _DatabindingInsertUiItemToListFromContextStringAlias(p0, index, p2, p3) end
+
+-- _DATABINDING_INSERT_UI_ITEM_TO_LIST_FROM_PATH_STRING_ALIAS  (0x5740774F608E4FC8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 string
+---@param p3 any
+function _DatabindingInsertUiItemToListFromPathStringAlias(p0, p1, p2, p3) end
+
+-- _DATABINDING_READ_DATA_BOOL  (0x5EEFBD4B6D7CD6EB)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _DatabindingReadDataBool(p0) end
+
+-- _DATABINDING_READ_DATA_BOOL_FROM_PARENT  (0xA8EDE09FE07BD77F)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingReadDataBoolFromParent(p0, p1) end
+
+-- _DATABINDING_READ_DATA_BOOL_FROM_PARENT_BY_HASH  (0x4CDC3FDDFAE07EB3)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function _DatabindingReadDataBoolFromParentByHash(p0, p1) end
+
+-- _DATABINDING_READ_DATA_HASH_STRING_FROM_PARENT  (0x9B535990B01B62DE)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingReadDataHashStringFromParent(p0, p1) end
+
+-- _DATABINDING_READ_DATA_HASH_STRING_FROM_PARENT_BY_HASH  (0x1F43BC25A119B252)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function _DatabindingReadDataHashStringFromParentByHash(p0, p1) end
+
+-- _DATABINDING_READ_DATA_INT_FROM_PARENT  (0xFFC566A4801F6B40)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingReadDataIntFromParent(p0, p1) end
+
+-- _DATABINDING_READ_DATA_INT_FROM_PARENT_BY_HASH  (0xB5F668B648EC0970)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return any
+function _DatabindingReadDataIntFromParentByHash(p0, p1) end
+
+-- _DATABINDING_READ_DATA_STRING  (0x3D290B5FFA7C5151)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _DatabindingReadDataString(p0) end
+
+-- _DATABINDING_READ_DATA_STRING_FROM_PARENT  (0x6323AD277C4A2AFB)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@return any
+function _DatabindingReadDataStringFromParent(p0, p1) end
+
+-- _DATABINDING_READ_FLOAT  (0x5FE444EB67C70AD4)
+-- min build: 1207
+---@param entryId number
+---@return number
+function _DatabindingReadFloat(entryId) end
+
+-- _DATABINDING_READ_HASH  (0x81D7183E7A8ECA72)
+-- min build: 1207
+---@param entryId number
+---@return number
+function _DatabindingReadHash(entryId) end
+
+-- _DATABINDING_REMOVE_BINDING_ARRAY_ITEM_BY_DATA_CONTEXT_ID  (0xF68B1726EAF7B285)
+-- min build: 1207
+---@param p0 any
+---@param entryId number
+function _DatabindingRemoveBindingArrayItemByDataContextId(p0, entryId) end
+
+-- _DATABINDING_REMOVE_DATA_ENTRY  (0x0AE9938D0541F2DA)
+-- min build: 1207
+---@param entryId number
+function _DatabindingRemoveDataEntry(entryId) end
+
+-- _DATABINDING_REMOVE_UI_ITEM_FROM_LIST_BY_INDEX  (0x6318FB3BE37E11B3)
+-- Remove a UI item from its list by index.
+-- Video: https://imgur.com/a/LDAUVkh
+-- min build: 1207
+---@param entryId number
+---@param index number
+function _DatabindingRemoveUiItemFromListByIndex(entryId, index) end
+
+-- _DATABINDING_SET_TEMPLATED_UI_ITEM_HASH_ALIAS  (0x0AE7138D0541F2DE)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+function _DatabindingSetTemplatedUiItemHashAlias(p0, p1, p2) end
+
+-- _DATABINDING_SET_TEMPLATED_UI_ITEM_LIST_SIZE  (0xFE74FA57E0CE6825)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+function _DatabindingSetTemplatedUiItemListSize(p0, p1) end
+
+-- _DATABINDING_WRITE_DATA_BOOL  (0xAB888B4B91046770)
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+function _DatabindingWriteDataBool(p0, p1) end
+
+-- _DATABINDING_WRITE_DATA_BOOL_FROM_PARENT  (0xBDFE546E4C2D0E21)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 boolean
+function _DatabindingWriteDataBoolFromParent(p0, p1, p2) end
+
+-- _DATABINDING_WRITE_DATA_FLOAT  (0xDF504BECEB15DA93)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+function _DatabindingWriteDataFloat(p0, p1) end
+
+-- _DATABINDING_WRITE_DATA_GANG_ID  (0xC70041408E16BE2D)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param gangId any
+function _DatabindingWriteDataGangId(p0, p1, gangId) end
+
+-- _DATABINDING_WRITE_DATA_HASH_STRING  (0xACDEF586BD71B1FD)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+function _DatabindingWriteDataHashString(p0, p1) end
+
+-- _DATABINDING_WRITE_DATA_HASH_STRING_FROM_PARENT  (0x0971F04E1EAA7AE8)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+function _DatabindingWriteDataHashStringFromParent(p0, p1, p2) end
+
+-- _DATABINDING_WRITE_DATA_HASH_STRING_FROM_PARENT_BY_HASH  (0x20209529689E0953)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 any
+function _DatabindingWriteDataHashStringFromParentByHash(p0, p1, p2) end
+
+-- _DATABINDING_WRITE_DATA_INT  (0x335C3F6B3766B8D9)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+function _DatabindingWriteDataInt(p0, p1) end
+
+-- _DATABINDING_WRITE_DATA_INT_FROM_PARENT  (0x9EFA98238BA08FC4)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 number
+function _DatabindingWriteDataIntFromParent(p0, p1, p2) end
+
+-- _DATABINDING_WRITE_DATA_INT_FROM_PARENT_BY_HASH  (0x9D6E10A41D6ED6EC)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 any
+function _DatabindingWriteDataIntFromParentByHash(p0, p1, p2) end
+
+-- _DATABINDING_WRITE_DATA_POSSE_ID  (0xC70041408E16BE2E)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param posseId any
+function _DatabindingWriteDataPosseId(p0, p1, posseId) end
+
+-- _DATABINDING_WRITE_DATA_SCRIPT_VARIABLES  (0xAB888B4B91046771)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param ___ any
+function _DatabindingWriteDataScriptVariables(p0, p1, ___) end
+
+-- _DATABINDING_WRITE_DATA_STRING  (0xE1BD342F2872AEE9)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+function _DatabindingWriteDataString(p0, p1) end
+
+-- _DATABINDING_WRITE_STRING_FROM_HASH  (0xA3BD6FF95E713EE5)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 string
+function _DatabindingWriteStringFromHash(p0, p1, p2) end
+
+-- _VIRTUAL_COLLECTION_EXISTS  (0x37963B56755BFB35)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _VirtualCollectionExists(p0) end
+
+-- _VIRTUAL_COLLECTION_ITEM_ADD  (0x6DCBF187221CF73D)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@param p2 number
+---@param p3 any
+function _VirtualCollectionItemAdd(p0, index, p2, p3) end
+
+-- _VIRTUAL_COLLECTION_RESET  (0x09D95666ED2B5F60)
+-- min build: 1207
+---@param p0 any
+function _VirtualCollectionReset(p0) end
+
+-- _VIRTUAL_COLLECTION_SET_INTEREST_INDEX  (0x49A8447533308BCF)
+-- min build: 1207
+---@param p0 any
+---@param interestIndex number
+function _VirtualCollectionSetInterestIndex(p0, interestIndex) end
+
+-- _VIRTUAL_COLLECTION_SET_SIZE  (0x9DCE9B01A93B58BC)
+-- min build: 1207
+---@param p0 any
+---@param size number
+function _VirtualCollectionSetSize(p0, size) end
+
+-- DATABINDING_IS_ENTRY_VALID  (0x1E7130793AAAAB8D)
+-- min build: 1207
+---@param entryId number
+---@return boolean
+function DatabindingIsEntryValid(entryId) end
+
+-- DATABINDING_READ_INT  (0x570784D782597512)
+-- min build: 1207
+---@param p0 any
+---@return number
+function DatabindingReadInt(p0) end
+
+-- DATABINDING_WRITE_STRING_FROM_PARENT  (0x4FF713B2F17A391E)
+-- min build: 1207
+---@param p0 any
+---@param p1 string
+---@param p2 string
+function DatabindingWriteStringFromParent(p0, p1, p2) end

--- a/.luals/redm-natives/DATAFILE.lua
+++ b/.luals/redm-natives/DATAFILE.lua
@@ -1,0 +1,430 @@
+---@meta
+
+-- RDR3 namespace: DATAFILE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x1C65CC931C0F946F  (0x1C65CC931C0F946F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x1C65CC931C0F946F(p0, p1, p2) end
+
+-- _0x277251C161B4C3F4  (0x277251C161B4C3F4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x277251C161B4C3F4(p0, p1, p2) end
+
+-- _0x3168BA5D6DECE323  (0x3168BA5D6DECE323)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0x3168BA5D6DECE323() end
+
+-- _0x4F9E3ED7617123AC  (0x4F9E3ED7617123AC)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x4F9E3ED7617123AC(p0) end
+
+-- _0x7681B677400C7071  (0x7681B677400C7071)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x7681B677400C7071(p0, p1, p2, p3, p4) end
+
+-- _0x9F130129EBC31B34  (0x9F130129EBC31B34)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x9F130129EBC31B34(p0, p1, p2) end
+
+-- _0xBC0DF006A4952C68  (0xBC0DF006A4952C68)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xBC0DF006A4952C68(p0, p1, p2) end
+
+-- _0xCA56DD6AB7A39F64  (0xCA56DD6AB7A39F64)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xCA56DD6AB7A39F64(p0) end
+
+-- _0xE13634BB6BAF0734  (0xE13634BB6BAF0734)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return number
+function N_0xE13634BB6BAF0734(p0, p1) end
+
+-- _PARSEDDATA_GET_BOOL  (0xA63CD20F19B961AB)
+-- min build: 1207
+---@param p2 number
+---@return boolean
+---@return boolean
+---@return any
+function _ParseddataGetBool(p2) end
+
+-- _PARSEDDATA_GET_ENTRIES  (0xED4413CEE1BF142C)
+-- Returns false when there are no entries.
+-- min build: 1207
+---@return boolean
+---@return any
+function _ParseddataGetEntries() end
+
+-- _PARSEDDATA_GET_FILE  (0x91DED5DD64BB2691)
+-- Opens file.
+-- min build: 1207
+---@return any
+function _ParseddataGetFile() end
+
+-- _PARSEDDATA_GET_FLOAT  (0xB2B42607F7867576)
+-- min build: 1207
+---@param p2 number
+---@return boolean
+---@return any
+---@return any
+function _ParseddataGetFloat(p2) end
+
+-- _PARSEDDATA_GET_INT  (0x52FC26D2D2FC2987)
+-- min build: 1207
+---@param p2 number
+---@return boolean
+---@return any
+---@return any
+function _ParseddataGetInt(p2) end
+
+-- _PARSEDDATA_GET_NUM_CHILDREN  (0x6BEB168D5195E7AB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _ParseddataGetNumChildren(p0, p1) end
+
+-- _PARSEDDATA_GET_SECTION  (0x44B3A36933AC009C)
+-- min build: 1207
+---@param section number
+---@return boolean
+---@return number
+---@return any
+function _ParseddataGetSection(section) end
+
+-- _PARSEDDATA_LOAD_FILE_HASH  (0xD97D8D905F1562F2)
+-- LOAD_PARSEDDATA_FILE_FAILSAFE_HASH
+-- Returns parseddata script fileHandle
+-- min build: 1207
+---@param p0 number
+---@return number
+function _ParseddataLoadFileHash(p0) end
+
+-- _PARSEDDATA_REGISTER_QUERY  (0xAE156A747C39A741)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function _ParseddataRegisterQuery(p0, p1, p2) end
+
+-- _PARSEDDATA_RQ_FILLOUT_BOOL  (0x0D9138F3F8261DF7)
+-- Old name: _DATAFILE_GET_BOOL
+-- min build: 1207
+---@return boolean
+---@return boolean
+---@return any
+function _ParseddataRqFilloutBool() end
+
+-- _PARSEDDATA_RQ_FILLOUT_FLOAT  (0x7F034FC3E891B57A)
+-- Old name: _DATAFILE_GET_FLOAT
+-- min build: 1207
+---@return boolean
+---@return number
+---@return any
+function _ParseddataRqFilloutFloat() end
+
+-- _PARSEDDATA_RQ_FILLOUT_INT  (0xEF44ACC657352A35)
+-- Old name: _DATAFILE_GET_INT
+-- min build: 1207
+---@return boolean
+---@return number
+---@return any
+function _ParseddataRqFilloutInt() end
+
+-- _PARSEDDATA_RQ_FILLOUT_STRING_63  (0x08EAF8E9F2EB7B2E)
+-- Old name: _DATAFILE_GET_STRING
+-- min build: 1207
+---@param p0 string
+---@return boolean
+---@return any
+function _ParseddataRqFilloutString63(p0) end
+
+-- _PARSEDDATA_RQ_FILLOUT_VECTOR  (0x06FBF89B12DA279C)
+-- Old name: _DATAFILE_GET_VECTOR
+-- min build: 1207
+---@return boolean
+---@return vector3
+---@return any
+function _ParseddataRqFilloutVector() end
+
+-- _PARSEDDATA_RQ_GET_NUM_NODES  (0xDF01B1F7A886B42D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _ParseddataRqGetNumNodes(p0) end
+
+-- _PARSEDDATA_UNLOAD_FILE  (0x129567F0C05F81B9)
+-- min build: 1207
+---@param fileHandle number
+function _ParseddataUnloadFile(fileHandle) end
+
+-- DATAARRAY_GET_BOOL  (0xAB1231D2DE52F2D3)
+-- min build: 1207
+---@param arrayIndex number
+---@return boolean
+---@return any
+function DataarrayGetBool(arrayIndex) end
+
+-- DATAARRAY_GET_COUNT  (0x6A885BF69239E539)
+-- min build: 1207
+---@return number
+---@return any
+function DataarrayGetCount() end
+
+-- DATAARRAY_GET_DICT  (0xA010655985853485)
+-- min build: 1207
+---@param arrayIndex number
+---@return any
+---@return any
+function DataarrayGetDict(arrayIndex) end
+
+-- DATAARRAY_GET_FLOAT  (0xA9D003CF419CB81E)
+-- min build: 1207
+---@param arrayIndex number
+---@return number
+---@return any
+function DataarrayGetFloat(arrayIndex) end
+
+-- DATAARRAY_GET_INT  (0x96DEA500B6EBBE53)
+-- min build: 1207
+---@param arrayIndex number
+---@return number
+---@return any
+function DataarrayGetInt(arrayIndex) end
+
+-- DATAARRAY_GET_STRING  (0xB6790A8FF80F889F)
+-- min build: 1207
+---@param arrayIndex number
+---@return string
+---@return any
+function DataarrayGetString(arrayIndex) end
+
+-- DATAARRAY_GET_TYPE  (0x151DAFE6B3B9888F)
+-- Types:
+-- 1 = Boolean
+-- 2 = Integer
+-- 3 = Float
+-- 4 = String
+-- 5 = Vector3
+-- 6 = Object
+-- 7 = Array
+-- min build: 1207
+---@param arrayIndex number
+---@return number
+---@return any
+function DataarrayGetType(arrayIndex) end
+
+-- DATAARRAY_GET_VECTOR  (0x850DA2750DA14E9A)
+-- min build: 1207
+---@param arrayIndex number
+---@return vector3
+---@return any
+function DataarrayGetVector(arrayIndex) end
+
+-- DATADICT_GET_ARRAY  (0x1B5447CF18544B18)
+-- min build: 1207
+---@param key string
+---@return any
+---@return any
+function DatadictGetArray(key) end
+
+-- DATADICT_GET_BOOL  (0x175E915A486EE548)
+-- min build: 1207
+---@param key string
+---@return boolean
+---@return any
+function DatadictGetBool(key) end
+
+-- DATADICT_GET_DICT  (0x4D7A30130F46AC9C)
+-- min build: 1207
+---@param key string
+---@return any
+---@return any
+function DatadictGetDict(key) end
+
+-- DATADICT_GET_FLOAT  (0x814643ECA258ADF5)
+-- min build: 1207
+---@param key string
+---@return number
+---@return any
+function DatadictGetFloat(key) end
+
+-- DATADICT_GET_INT  (0x9D896A3B87D96E2B)
+-- min build: 1207
+---@param key string
+---@return number
+---@return any
+function DatadictGetInt(key) end
+
+-- DATADICT_GET_STRING  (0xE37B38C0B4E95DFA)
+-- min build: 1207
+---@param key string
+---@return string
+---@return any
+function DatadictGetString(key) end
+
+-- DATADICT_GET_TYPE  (0x92E11E3CA4C7CDF0)
+-- Types:
+-- 1 = Boolean
+-- 2 = Integer
+-- 3 = Float
+-- 4 = String
+-- 5 = Vector3
+-- 6 = Object
+-- 7 = Array
+-- min build: 1207
+---@param key string
+---@return number
+---@return any
+function DatadictGetType(key) end
+
+-- DATADICT_GET_VECTOR  (0xE459C941431E0FFA)
+-- min build: 1207
+---@param key string
+---@return vector3
+---@return any
+function DatadictGetVector(key) end
+
+-- DATADICT_IS_ARRAY_VALID  (0xB04B69CF277D15C0)
+-- min build: 1207
+---@return boolean
+---@return any
+function DatadictIsArrayValid() end
+
+-- DATADICT_IS_DICT_VALID  (0x4607D57C5F7D332A)
+-- min build: 1207
+---@return boolean
+---@return any
+function DatadictIsDictValid() end
+
+-- DATADICT_SET_INT  (0x26FDF5E99AA2F3E9)
+-- min build: 1207
+---@param key string
+---@param value number
+---@return any
+function DatadictSetInt(key, value) end
+
+-- DATAFILE_CREATE  (0x56B7291FB953DD51)
+-- min build: 1207
+---@param index number
+function DatafileCreate(index) end
+
+-- DATAFILE_DELETE  (0x9FB90EEDEA9F2D5C)
+-- min build: 1207
+---@param index number
+function DatafileDelete(index) end
+
+-- DATAFILE_DELETE_REQUESTED_FILE  (0x604B8ED1A482F9DF)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function DatafileDeleteRequestedFile(p0) end
+
+-- DATAFILE_GET_FILE_DICT  (0xBBD8CF823CAE557C)
+-- min build: 1207
+---@param index number
+---@return any
+function DatafileGetFileDict(index) end
+
+-- DATAFILE_HAS_LOADED_FILE_DATA  (0x17279C820464CEE0)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function DatafileHasLoadedFileData(p0) end
+
+-- DATAFILE_HAS_VALID_FILE_DATA  (0xE60100389E50EADE)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function DatafileHasValidFileData(p0) end
+
+-- DATAFILE_SELECT_ACTIVE_FILE  (0x46102A0989AD80B5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return boolean
+function DatafileSelectActiveFile(p0, p1) end
+
+-- DATAFILE_UGC_SELECT_DATA  (0x790EC421078F5C4E)
+-- Reloops value returned by UGC_QUERY_GET_CONTENT_NUM
+-- min build: 1207
+---@param ugcRequestId any
+---@param index number
+---@param p2 any
+---@return any
+function DatafileUgcSelectData(ugcRequestId, index, p2) end
+
+-- DATAFILE_WATCH_REQUEST_ID  (0xA5834834CA8FD7FC)
+-- Adds the given request ID to the watch list.
+-- min build: 1207
+---@param id number
+function DatafileWatchRequestId(id) end
+
+-- PARSEDDATA_IS_FILE_LOADED  (0x603AC35FD4602C76)
+-- min build: 1207
+---@param fileHandle number
+---@return boolean
+function ParseddataIsFileLoaded(fileHandle) end
+
+-- PARSEDDATA_IS_FILE_VALID  (0x7907969497EA92F5)
+-- min build: 1207
+---@param fileHandle number
+---@return boolean
+function ParseddataIsFileValid(fileHandle) end
+
+-- PARSEDDATA_RQ_FILLOUT_HASH  (0xFBFF3FF2F5E80C0B)
+-- Old name: _DATAFILE_GET_HASH
+-- min build: 1207
+---@return boolean
+---@return number
+---@return any
+function ParseddataRqFilloutHash() end
+
+-- PARSEDDATA_RQ_FILLOUT_NODE  (0x83C3ED532B6E5D07)
+-- Old name: _DATAFILE_GET_DATA_NODE_INDEX
+-- min build: 1207
+---@return boolean
+---@return number
+---@return any
+function ParseddataRqFilloutNode() end
+
+-- PARSEDDATA_RQ_FILLOUT_STRING_127  (0x951327435DC5164B)
+-- min build: 1232
+---@param p0 string
+---@return boolean
+---@return any
+function ParseddataRqFilloutString127(p0) end
+
+-- UGC2_SET_PLAYER_DATA  (0xE79C70E77E0973C7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function Ugc2SetPlayerData(p0, p1, p2, p3) end

--- a/.luals/redm-natives/DEBUG.lua
+++ b/.luals/redm-natives/DEBUG.lua
@@ -1,0 +1,24 @@
+---@meta
+
+-- RDR3 namespace: DEBUG -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0xA8D970D8A72640A6  (0xA8D970D8A72640A6)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@return any
+function N_0xA8D970D8A72640A6() end
+
+-- _0xACF9CB705BEFA8CB  (0xACF9CB705BEFA8CB)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@return any
+function N_0xACF9CB705BEFA8CB() end
+
+-- GET_GAME_VERSION_NAME  (0x05A5F662AD35C573)
+-- Return example: 1207.69_dev_pc, 1436.28_dev_live_tu
+-- 
+-- Old name: _GET_GAME_BUILD_STRING
+-- min build: 1207
+---@return string
+function GetGameVersionName() end

--- a/.luals/redm-natives/DECORATOR.lua
+++ b/.luals/redm-natives/DECORATOR.lua
@@ -1,0 +1,128 @@
+---@meta
+
+-- RDR3 namespace: DECORATOR -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _DECOR_GET_PLAYER_INDEX  (0xB1682B2443F0540B)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@return number
+function _DecorGetPlayerIndex(entity, propertyName) end
+
+-- _DECOR_REGISTER_NETWORKED  (0x4587374F88B7F6C2)
+-- type: see DECOR_REGISTER
+-- min build: 1207
+---@param propertyName string
+---@param type number
+---@param isNetworked boolean
+function _DecorRegisterNetworked(propertyName, type, isNetworked) end
+
+-- _DECOR_SET_PLAYER_INDEX  (0x4BDC83150D43772D)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@param value number
+---@return boolean
+function _DecorSetPlayerIndex(entity, propertyName, value) end
+
+-- DECOR_EXIST_ON  (0xD9D1CDBF3464DCDF)
+-- Returns whether or not the specified property is set for the entity.
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@return boolean
+function DecorExistOn(entity, propertyName) end
+
+-- DECOR_GET_BOOL  (0xDEF3F1B071ABB197)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@return boolean
+function DecorGetBool(entity, propertyName) end
+
+-- DECOR_GET_FLOAT  (0xE5FF70CD842CA9D4)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@return number
+function DecorGetFloat(entity, propertyName) end
+
+-- DECOR_GET_INT  (0x44DB62727762FD9B)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@return number
+function DecorGetInt(entity, propertyName) end
+
+-- DECOR_IS_REGISTERED_AS_TYPE  (0x72355278C069F272)
+-- type: see DECOR_REGISTER
+-- min build: 1207
+---@param propertyName string
+---@param type number
+---@return boolean
+function DecorIsRegisteredAsType(propertyName, type) end
+
+-- DECOR_REGISTER  (0x0B253D644E3C36B3)
+-- type:
+-- enum eDecorType
+-- {
+-- 	DECOR_TYPE_UNKNOWN,
+-- 	DECOR_TYPE_FLOAT,
+-- 	DECOR_TYPE_BOOL,
+-- 	DECOR_TYPE_INT,
+-- 	DECOR_TYPE_STRING,
+-- 	DECOR_TYPE_TIME,
+-- 	DECOR_TYPE_PLAYER_INDEX
+-- };
+-- min build: 1207
+---@param propertyName string
+---@param type number
+function DecorRegister(propertyName, type) end
+
+-- DECOR_REMOVE  (0x2BA7F5877A088A1D)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@return boolean
+function DecorRemove(entity, propertyName) end
+
+-- DECOR_REMOVE_ALL  (0x88942780E0ADEA42)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function DecorRemoveAll(entity) end
+
+-- DECOR_SET_BOOL  (0xFE26E4609B1C3772)
+-- This function sets metadata of type bool to specified entity.
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@param value boolean
+---@return boolean
+function DecorSetBool(entity, propertyName, value) end
+
+-- DECOR_SET_FLOAT  (0x238F8B0C1C7FE834)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@param value number
+---@return boolean
+function DecorSetFloat(entity, propertyName, value) end
+
+-- DECOR_SET_INT  (0xE88F4D7F52A6090F)
+-- Sets property to int.
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@param value number
+---@return boolean
+function DecorSetInt(entity, propertyName, value) end
+
+-- DECOR_SET_STRING  (0x0671C1A3FF7AFDFC)
+-- min build: 1207
+---@param entity number
+---@param propertyName string
+---@param value string
+---@return boolean
+function DecorSetString(entity, propertyName, value) end

--- a/.luals/redm-natives/DLC.lua
+++ b/.luals/redm-natives/DLC.lua
@@ -1,0 +1,25 @@
+---@meta
+
+-- RDR3 namespace: DLC -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _GET_SPECIAL_EDITION_CASH_CAMP_BONUS_ENABLED  (0x1DB9D61E505AE3FC)
+-- min build: 1207
+---@return boolean
+function _GetSpecialEditionCashCampBonusEnabled() end
+
+-- _GET_SPECIAL_EDITION_CORE_STATS_BONUS_ENABLED  (0xA16B4FBA7887D7BA)
+-- min build: 1207
+---@return boolean
+function _GetSpecialEditionCoreStatsBonusEnabled() end
+
+-- GET_IS_LOADING_SCREEN_ACTIVE  (0x71D4BF5890659B0C)
+-- min build: 1207
+---@return boolean
+function GetIsLoadingScreenActive() end
+
+-- IS_DLC_PRESENT  (0x2763DC12BBE2BB6F)
+-- min build: 1207
+---@param dlcHash number
+---@return boolean
+function IsDlcPresent(dlcHash) end

--- a/.luals/redm-natives/ENTITY.lua
+++ b/.luals/redm-natives/ENTITY.lua
@@ -1,0 +1,2201 @@
+---@meta
+
+-- RDR3 namespace: ENTITY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x002AAC783ED323ED  (0x002AAC783ED323ED)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x002AAC783ED323ED(p0, p1) end
+
+-- _0x007AAC783ED323ED  (0x007AAC783ED323ED)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x007AAC783ED323ED(p0, p1, p2) end
+
+-- _0x0939E773925C4719  (0x0939E773925C4719)
+-- min build: 1207
+function N_0x0939E773925C4719() end
+
+-- _0x0CCEFC6C2C95DA2A  (0x0CCEFC6C2C95DA2A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0x0CCEFC6C2C95DA2A(p0, p1, p2, p3) end
+
+-- _0x0DB41D59E0F1502B  (0x0DB41D59E0F1502B)
+-- min build: 1207
+---@param p0 any
+function N_0x0DB41D59E0F1502B(p0) end
+
+-- _0x0FD7D7C232876E72  (0x0FD7D7C232876E72)
+-- min build: 1207
+---@param p0 any
+function N_0x0FD7D7C232876E72(p0) end
+
+-- _0x188736456D1DEDE6  (0x188736456D1DEDE6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x188736456D1DEDE6(p0, p1) end
+
+-- _0x20FAEE47427A4497  (0x20FAEE47427A4497)
+-- min build: 1207
+function N_0x20FAEE47427A4497() end
+
+-- _0x350E9211074955AF  (0x350E9211074955AF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x350E9211074955AF(p0, p1) end
+
+-- _0x371D179701D9C082  (0x371D179701D9C082)
+-- Called if entity is in water and submerged level is larger than 1f. If CARRYING_FLAG_FORCE_ALLOW_WARP_TO_SAFE_GROUND_LOCATION is true, it gets disabled as well.
+-- min build: 1436
+---@param entity number
+function N_0x371D179701D9C082(entity) end
+
+-- _0x37B01666BAE8F7EF  (0x37B01666BAE8F7EF)
+-- Seems to return true if entity is burned / scorched
+-- _GET_ENTITY_*
+-- min build: 1207
+---@param entity number
+---@return any
+function N_0x37B01666BAE8F7EF(entity) end
+
+-- _0x383F64263F946E45  (0x383F64263F946E45)
+-- Used when checking if ped is in water
+-- min build: 1207
+---@param entity number
+---@param p2 number
+---@param ped number
+---@param p4 any
+---@param p5 number
+---@return boolean
+---@return number
+function N_0x383F64263F946E45(entity, p2, ped, p4, p5) end
+
+-- _0x3EC28DA1FFAC9DDD  (0x3EC28DA1FFAC9DDD)
+-- Used in Script Function DUELING_DID_PLAYER_DISARM_OPPONENT
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param p2 any
+---@param p3 any
+---@return boolean
+function N_0x3EC28DA1FFAC9DDD(entity1, entity2, p2, p3) end
+
+-- _0x5744562E973E33CD  (0x5744562E973E33CD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0x5744562E973E33CD(p0, p1, p2, p3, p4) end
+
+-- _0x5826EFD6D73C4DE5  (0x5826EFD6D73C4DE5)
+-- _REMOVE_DECALS_* - _REMOVE_FORCED*
+-- min build: 1207
+---@param entity number
+function N_0x5826EFD6D73C4DE5(entity) end
+
+-- _0x582F73ACFE969571  (0x582F73ACFE969571)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x582F73ACFE969571(p0, p1, p2) end
+
+-- _0x5E214112806591EA  (0x5E214112806591EA)
+-- Attaches scenario to bone with an offset
+-- _GET_I* - _GET_M*
+-- min build: 1207
+---@param entity number
+---@param boneIndex number
+---@return vector3
+function N_0x5E214112806591EA(entity, boneIndex) end
+
+-- _0x7A49D40DE437BC8D  (0x7A49D40DE437BC8D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x7A49D40DE437BC8D(p0, p1) end
+
+-- _0x7F20092547B4DDEA  (0x7F20092547B4DDEA)
+-- min build: 1207
+---@param p0 any
+function N_0x7F20092547B4DDEA(p0) end
+
+-- _0x80FDEB3A9E9AA578  (0x80FDEB3A9E9AA578)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+function N_0x80FDEB3A9E9AA578(entity, p1) end
+
+-- _0x898586729DB5221D  (0x898586729DB5221D)
+-- min build: 1207
+---@param ped number
+function N_0x898586729DB5221D(ped) end
+
+-- _0x8E10DF0FFA63FB65  (0x8E10DF0FFA63FB65)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0x8E10DF0FFA63FB65(p0, p1, p2, p3, p4) end
+
+-- _0x8E46E18AA828334F  (0x8E46E18AA828334F)
+-- Used in Script Function GENERIC_ITEM_HAS_ANIM_COMPLETED
+-- _GET_ENTITY_*
+-- min build: 1207
+---@param entity number
+---@param animDict string
+---@param animClip string
+---@return number
+function N_0x8E46E18AA828334F(entity, animDict, animClip) end
+
+-- _0x978AA2323ED32209  (0x978AA2323ED32209)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x978AA2323ED32209(p0, p1) end
+
+-- _0x9C6906EF8CB20C5F  (0x9C6906EF8CB20C5F)
+-- min build: 1436
+---@param entity number
+function N_0x9C6906EF8CB20C5F(entity) end
+
+-- _0xA9E6D8F2DDFC4DB9  (0xA9E6D8F2DDFC4DB9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA9E6D8F2DDFC4DB9(p0, p1) end
+
+-- _0xB16C780C51E51E2B  (0xB16C780C51E51E2B)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xB16C780C51E51E2B(p0) end
+
+-- _0xB38A29CCD5447783  (0xB38A29CCD5447783)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xB38A29CCD5447783(p0, p1, p2) end
+
+-- _0xBA2A089E60ED1163  (0xBA2A089E60ED1163)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0xBA2A089E60ED1163(p0, p1, p2, p3, p4) end
+
+-- _0xC3ABCFBC7D74AFA5  (0xC3ABCFBC7D74AFA5)
+-- Returns BOOL in ida
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0xC3ABCFBC7D74AFA5(ped, p1, p2) end
+
+-- _0xC6A1A3D63F122DE7  (0xC6A1A3D63F122DE7)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+function N_0xC6A1A3D63F122DE7(p0, p1) end
+
+-- _0xC76E94A78127412B  (0xC76E94A78127412B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xC76E94A78127412B(p0, p1, p2) end
+
+-- _0xCDB682BB47C02F0A  (0xCDB682BB47C02F0A)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+function N_0xCDB682BB47C02F0A(entity, p1) end
+
+-- _0xD21C7418C590BB40  (0xD21C7418C590BB40)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xD21C7418C590BB40(p0) end
+
+-- _0xD46BF94C4C66FAB0  (0xD46BF94C4C66FAB0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xD46BF94C4C66FAB0(p0, p1, p2, p3) end
+
+-- _0xDF8E49EA89A01DB1  (0xDF8E49EA89A01DB1)
+-- Hardcoded to return zero/false.
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xDF8E49EA89A01DB1(p0, p1, p2) end
+
+-- _0xE19035EB65AB2932  (0xE19035EB65AB2932)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE19035EB65AB2932(p0, p1) end
+
+-- _0xE31FC20319874CB3  (0xE31FC20319874CB3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xE31FC20319874CB3(p0, p1, p2) end
+
+-- _0xE75EEA8DB59A9F39  (0xE75EEA8DB59A9F39)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0xE75EEA8DB59A9F39(p0, p1, p2, p3, p4, p5) end
+
+-- _0xE9E7A0BAC7F57746  (0xE9E7A0BAC7F57746)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE9E7A0BAC7F57746(p0, p1) end
+
+-- _0xEF259AA1E097E0AD  (0xEF259AA1E097E0AD)
+-- min build: 1207
+---@param entity number
+---@param p1 any
+function N_0xEF259AA1E097E0AD(entity, p1) end
+
+-- _0xF41E2979D5BC5370  (0xF41E2979D5BC5370)
+-- min build: 1207
+---@param p0 any
+function N_0xF41E2979D5BC5370(p0) end
+
+-- _0xF59FDE7B4D31A630  (0xF59FDE7B4D31A630)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF59FDE7B4D31A630(p0) end
+
+-- _0xFF83AF534156B399  (0xFF83AF534156B399)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFF83AF534156B399(p0, p1) end
+
+-- _0xFF9965C47FA404DA  (0xFF9965C47FA404DA)
+-- SET_ENTITY_LO*
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function N_0xFF9965C47FA404DA(entity, toggle) end
+
+-- _ADD_ENTITY_TRACKING_TRAILS  (0x1AD922AB5038DEF3)
+-- min build: 1207
+---@param entity number
+function _AddEntityTrackingTrails(entity) end
+
+-- _ATTACH_ENTITY_TO_COORDS_PHYSICALLY  (0x445D7D8EA66E373E)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@param x number
+---@param y number
+---@param z number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param timer number
+---@param p9 boolean
+---@param p10 number
+---@param p11 number
+---@param p12 number
+---@param p13 number
+---@param p14 number
+---@param p15 number
+function _AttachEntityToCoordsPhysically(entity, p1, x, y, z, offsetX, offsetY, offsetZ, timer, p9, p10, p11, p12, p13, p14, p15) end
+
+-- _CHANGE_ENTITY_HEALTH  (0x835F131E7DC8F97A)
+-- Alters entity's health by 'amount'. Can be negative (to drain health).
+-- In the scripts entity2 and weaponHash are unused (zero).
+-- min build: 1207
+---@param entity number
+---@param amount number
+---@param entity2 number
+---@param weaponHash number
+---@return boolean
+function _ChangeEntityHealth(entity, amount, entity2, weaponHash) end
+
+-- _CREATE_FOOTPATH_TRAIL  (0x29BA9F78321E5A6C)
+-- min build: 1207
+---@param p0 any
+---@param waypointRecord string
+---@param bUseSnowOffset boolean
+---@param p3 number
+---@param p4 number
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param bInit boolean
+---@return any
+function _CreateFootpathTrail(p0, waypointRecord, bUseSnowOffset, p3, p4, p5, p6, p7, p8, p9, p10, bInit) end
+
+-- _DELETE_CARRIABLE  (0x0D0DB2B6AF19A987)
+-- min build: 1207
+---@return number
+function _DeleteCarriable() end
+
+-- _DELETE_ENTITY_2  (0x5E94EA09E7207C16)
+-- Must be called from a background script, otherwise it will do nothing.
+-- min build: 1207
+---@return number
+function _DeleteEntity2() end
+
+-- _DISABLE_STAIRS_STEP_FOR_VOLUME  (0x37CEB637BA3B1A47)
+-- Disables stair stepping behavior within the specified volume.
+-- Entities can still move up stairs, but stepping animation and foot placement become irregular, causing them to skip steps or slide instead of properly stepping each stair.
+-- Pair with _ENABLE_STAIRS_STEP_FOR_VOLUME to restore normal behavior.
+-- min build: 1207
+---@param volume number
+function _DisableStairsStepForVolume(volume) end
+
+-- _DOES_THREAD_OWN_THIS_ENTITY  (0x88AD6CC10D8D35B2)
+-- Returns true if calling script owns specified entity
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _DoesThreadOwnThisEntity(entity) end
+
+-- _ENABLE_STAIRS_STEP_FOR_VOLUME  (0xEAB3D91D30A344F1)
+-- Re-enables normal stair stepping behavior within the specified volume.
+-- Restores proper step-by-step movement and foot placement after _DISABLE_STAIRS_STEP_FOR_VOLUME.
+-- min build: 1207
+---@param volume number
+function _EnableStairsStepForVolume(volume) end
+
+-- _FIND_ENTITY_LOOTING_PED  (0xEF2D9ED7CE684F08)
+-- Returns the ped which is currently looting another ped. Returns null if no one is looting the ped.
+-- min build: 1207
+---@param entity number
+---@return number
+function _FindEntityLootingPed(entity) end
+
+-- _FORCE_TRAIN_WAGON_POPULATION  (0x119A5714578F4E05)
+-- Enable/disable automatic ambient passenger population on a train wagon (carriage).
+-- 	- toggle=true: wagon is kept populated; removed/deleted passengers are replaced quickly.
+-- 	- toggle=false: stop auto-filling; after removing passengers, no new peds spawn until re-enabled.
+-- 
+-- Notes:
+-- 	- Intended for train carriage entities (wagons) obtained from a train (e.g., VEHICLE::GET_TRAIN_CARRIAGE).
+-- 	- Often used with passenger collection via VEHICLE::_GET_ALL_WAGON_PASSENGERS.
+-- 
+-- Example (from scripts):
+-- 	for (int i = 0; i < VEHICLE::_GET_NUM_CARS_FROM_TRAIN_CONFIG(trainConfig); ++i) {
+-- 		Vehicle wagon = VEHICLE::GET_TRAIN_CARRIAGE(train, i);
+-- 		if (ENTITY::DOES_ENTITY_EXIST(wagon) && !ENTITY::IS_ENTITY_DEAD(wagon)) {
+-- 			ENTITY::_FORCE_TRAIN_WAGON_POPULATION(wagon, true);
+-- 		}
+-- 	}
+-- min build: 1207
+---@param trainWagon number
+---@param toggle boolean
+function _ForceTrainWagonPopulation(trainWagon, toggle) end
+
+-- _GET_CARCASS_FROM_PELT  (0x2A77EF9BEC8518F4)
+-- Returns the original animal/carcass entity from which a pelt entity was obtained.
+-- Observed after skinning an animal: passing the created pelt entity returns the original animal entity. Returns 0 if no valid source entity exists.
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetCarcassFromPelt(entity) end
+
+-- _GET_CARRIABLE_FROM_ENTITY  (0x31FEF6A20F00B963)
+-- Returns a hash of an entity's name. (Alternative Name: _GET_ENTITY_PROMPT_NAME_HASH)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetCarriableFromEntity(entity) end
+
+-- _GET_COLLISION_INTENSITY  (0x6D58167F62238284)
+-- Returns the collision intensity currently registered on the specified entity.
+-- Used after HAS_ENTITY_COLLIDED_WITH_ANYTHING to measure how strong the impact was. Higher values indicate a stronger collision/impact.
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetCollisionIntensity(entity) end
+
+-- _GET_ENTITIES_IN_VOLUME  (0x886171A12F400B89)
+-- min build: 1207
+---@param volume number
+---@param itemSet number
+---@param entityType number
+---@return number
+function _GetEntitiesInVolume(volume, itemSet, entityType) end
+
+-- _GET_ENTITIES_NEAR_POINT  (0x59B57C4B06531E1E)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param itemSet number
+---@param p5 number
+---@return number
+function _GetEntitiesNearPoint(x, y, z, radius, itemSet, p5) end
+
+-- _GET_ENTITY_ALBEDO  (0x120376C23F019C6C)
+-- Gets the albedo/material variant hash currently associated with the specified entity.
+-- Writes the current albedo hash to albedoHash and returns whether the entity already has a valid albedo/material entry assigned.
+-- If this returns false, scripts can fall back to resolving texture dictionaries/material data and applying a replacement.
+-- min build: 1207
+---@param entity number
+---@return boolean
+---@return number
+function _GetEntityAlbedo(entity) end
+
+-- _GET_ENTITY_ANIM_CURRENT_TIME  (0x627520389E288A73)
+-- Returns a normalized value between 0.0f and 1.0f. You can get the actual anim time by multiplying this by GET_ANIM_DURATION
+-- min build: 1207
+---@param entity number
+---@param animDict string
+---@param animName string
+---@return number
+function _GetEntityAnimCurrentTime(entity, animDict, animName) end
+
+-- _GET_ENTITY_BY_DOORHASH  (0xF7424890E4A094C0)
+-- Params: p1 = 0 in R* Scripts (GET_DOOR_ENTITY_FROM_ID)
+-- https://github.com/femga/rdr3_discoveries/blob/master/doorHashes/doorhashes.lua
+-- min build: 1207
+---@param doorHash number
+---@param p1 number
+---@return number
+function _GetEntityByDoorhash(doorHash, p1) end
+
+-- _GET_ENTITY_CAN_BE_DAMAGED  (0x75DF9E73F2F005FD)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _GetEntityCanBeDamaged(entity) end
+
+-- _GET_ENTITY_CARRY_CONFIG  (0x0FD25587BB306C86)
+-- Returns zero if the entity is not a carriable
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetEntityCarryConfig(entity) end
+
+-- _GET_ENTITY_CARRYING_FLAG  (0x808077647856DE62)
+-- flagId: see _SET_ENTITY_CARRYING_FLAG
+-- min build: 1207
+---@param entity number
+---@param flagId number
+---@return boolean
+function _GetEntityCarryingFlag(entity, flagId) end
+
+-- _GET_ENTITY_COLLISION_INTENSITY  (0xDFC2B226D56D85F6)
+-- Returns a collision impact/intensity value between two entities.
+-- 
+-- Notes:
+-- - Observed usage treats values above roughly 500.0 as a hard hit that can trigger ragdoll behavior when one entity hits another.
+-- - This is not a simple distance check; the value behaves more like impact force or collision strength.
+-- - Useful for detecting hard hits between vehicles, peds, objects, etc.
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@return number
+function _GetEntityCollisionIntensity(entity1, entity2) end
+
+-- _GET_ENTITY_FORWARD_VECTOR_YX  (0x935A30AA88FB1014)
+-- Gets the entity's forward vector in YX(Z) eulers. Similar to GET_ENTITY_FORWARD_VECTOR
+-- min build: 1207
+---@param entity number
+---@return vector3
+function _GetEntityForwardVectorYx(entity) end
+
+-- _GET_ENTITY_HEALTH_FLOAT  (0x96C638784DB4C815)
+-- Returns (CUR_HEALTH / MAX_HEALTH)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetEntityHealthFloat(entity) end
+
+-- _GET_ENTITY_PROOFS  (0x6CF0DAD7FA1088EA)
+-- Note: this native was removed in 1232 but added back in 1311
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetEntityProofs(entity) end
+
+-- _GET_ENTITY_SCRIPT  (0x2A08A32B6D49906F)
+-- min build: 1207
+---@param entity number
+---@return number
+---@return any
+function _GetEntityScript(entity) end
+
+-- _GET_ENTITY_THREAT_TIER  (0xE12F56CB25D9CE23)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetEntityThreatTier(entity) end
+
+-- _GET_ENTITY_WORLD_POSITION_OF_DIMENSIONS  (0xF3FDA9A617A15145)
+-- min build: 1207
+---@param entity number
+---@return vector3
+---@return vector3
+function _GetEntityWorldPositionOfDimensions(entity) end
+
+-- _GET_HEADING_OF_ENTITY_BONE  (0x3AB3A77672F6473F)
+-- Returns the rotation/heading of a specific bone on an entity as a Vector3.
+-- The exact meaning of p2 and p3 is not confirmed.
+-- min build: 1207
+---@param entity number
+---@param boneIndex number
+---@param p2 number
+---@param p3 number
+---@return vector3
+function _GetHeadingOfEntityBone(entity, boneIndex, p2, p3) end
+
+-- _GET_IS_BIRD  (0xC346A546612C49A9)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _GetIsBird(entity) end
+
+-- _GET_IS_CARRIABLE_PELT  (0x255B6DB4E3AD3C3E)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _GetIsCarriablePelt(entity) end
+
+-- _GET_IS_PREDATOR  (0x5594AFE9DE0C01B7)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _GetIsPredator(entity) end
+
+-- _GET_LAST_ENTITY_TO_DAMAGE_ENTITY  (0xAF72EC7E1B54539B)
+-- Returns the last entity that dealt damage to the specified entity.
+-- Returns 0 if no valid attacker is found.
+-- min build: 1311
+---@param entity number
+---@return number
+function _GetLastEntityToDamageEntity(entity) end
+
+-- _GET_OPTIMAL_CARRY_CONFIG  (0x34F008A7E48C496B)
+-- Valid indices: 0 - 3
+-- Index 1 always returns a `hogtied` config, doesn't matter the entity.
+-- It's for humans only and the ped must be resurrected first if it's dead.
+-- min build: 1207
+---@param entity number
+---@param index number
+---@return number
+function _GetOptimalCarryConfig(entity, index) end
+
+-- _GET_PED_ANIMAL_TYPE  (0x964000D355219FC0)
+-- Returns the ped's animal type hash: https://alloc8or.re/rdr3/doc/enums/eAnimalType.txt
+-- Combine this with GET_STRING_FROM_HASH_KEY to display localized entity names
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedAnimalType(ped) end
+
+-- _GET_PINNED_MAP_ENTITY  (0x4735E2A4BB83D9DA)
+-- min build: 1207
+---@param p0 any
+---@return number
+function _GetPinnedMapEntity(p0) end
+
+-- _GET_SCRIPT_OVERRIDE_ENTITY_LOOT_TABLE_PERMANENT  (0x1E804EA9B12030A4)
+-- Returns false if entity is not a ped or object.
+-- min build: 1207
+---@param entity number
+---@return boolean
+---@return number
+function _GetScriptOverrideEntityLootTablePermanent(entity) end
+
+-- _IS_BATCH_MODEL  (0xD4636C2EDB0DEA8A)
+-- Returns whether the model's map entity type is MAP_ENTITY_TYPE_GRASS_BATCH or MAP_ENTITY_TYPE_PROP_BATCH.
+-- 
+-- Scripts use the result to choose how to hide a single model, since batched geometry is not removed through the normal model-hide path:
+-- - TRUE: GRAPHICS::ADD_VEG_MODIFIER_SPHERE / REMOVE_VEG_MODIFIER_SPHERE
+-- - FALSE: ENTITY::CREATE_MODEL_HIDE / CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS / REMOVE_MODEL_HIDE
+-- 
+-- Not limited to foliage: many natural world models return TRUE (rocks, trees, bushes, grass, crops, branches, roots, logs, debris), as well as ambient vfx batches such as butterflies, dragonflies, and fireflies.
+-- 
+-- Model list: https://pastebin.com/fi4ynTnk
+-- min build: 1207
+---@param model number
+---@return boolean
+function _IsBatchModel(model) end
+
+-- _IS_CARRIABLE_MODEL  (0x5AFFA9DDC87846F8)
+-- min build: 1207
+---@param model number
+---@return boolean
+function _IsCarriableModel(model) end
+
+-- _IS_ENTITY_FROZEN  (0x083D497D57B7400F)
+-- Getter for FREEZE_ENTITY_POSITION
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsEntityFrozen(entity) end
+
+-- _IS_ENTITY_FULLY_LOOTED  (0x8DE41E9902E85756)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsEntityFullyLooted(entity) end
+
+-- _IS_ENTITY_ON_TRAIN_TRACK  (0x857ACB0AB4BD0D55)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsEntityOnTrainTrack(entity) end
+
+-- _IS_ENTITY_OWNED_BY_PERSISTENCE_SYSTEM  (0xA7E51B53309EAC97)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsEntityOwnedByPersistenceSystem(entity) end
+
+-- _IS_ENTITY_PLAYING_ANY_ANIM  (0x0B7CB1300CBFE19C)
+-- Params: p1 (probably animType) = 1, 0
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@return boolean
+function _IsEntityPlayingAnyAnim(entity, p1) end
+
+-- _IS_ENTITY_UNDERWATER  (0xD4E5C1E93C466127)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@return boolean
+function _IsEntityUnderwater(entity, p1) end
+
+-- _IS_TRACKED_ENTITY_VISIBLE  (0xC8CCDB712FBCBA92)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsTrackedEntityVisible(entity) end
+
+-- _IS_TRAIN_INTERIOR_LOADED  (0xC2E71D7E0A7B4C89)
+-- Checks whether the entity's interior is currently loaded by the game engine.
+-- Mainly used for train carriages. The game can unload distant carriage interiors as an optimization when the player is far away or not standing on the train.
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsTrainInteriorLoaded(entity) end
+
+-- _PAUSE_ENTITY_TRACKING  (0x36EB4D34D4A092C5)
+-- min build: 1207
+---@param entity number
+---@param pause boolean
+function _PauseEntityTracking(entity, pause) end
+
+-- _PIN_MAP_ENTITY  (0xAAACB74442C1BED3)
+-- Pins the given entity on the map and returns the created map pin ID.
+-- Related natives include PIN_CLOSEST_MAP_ENTITY, GET_PINNED_MAP_ENTITY, IS_MAP_ENTITY_PINNED, and _UNPIN_MAP_ENTITY.
+-- min build: 1207
+---@param entity number
+---@return number
+function _PinMapEntity(entity) end
+
+-- _PRELOAD_ENTITY_INTERIOR  (0x6C31B06E91518269)
+-- Enables or disables preloading for an entity interior.
+-- Used to force-load interiors for train carriages that the engine disabled due to distance-based optimization.
+-- This does not affect entities whose interiors are already managed by the engine because they are close to the player.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function _PreloadEntityInterior(entity, toggle) end
+
+-- _REQUEST_ENTITY_LOOT_LIST  (0xA88E215CEB0435C0)
+-- min build: 1207
+---@param mount number
+---@param visiblelootslotrequestType number
+---@param flag number
+---@param p4 number
+---@param p5 boolean
+---@return boolean
+---@return any
+function _RequestEntityLootList(mount, visiblelootslotrequestType, flag, p4, p5) end
+
+-- _REQUEST_ENTITY_VISIBILITY_TRACKING  (0x3F08C6163A4AB1D6)
+-- Enables visibility tracking for the specified entity.
+-- 
+-- Observed behavior:
+-- - For peds, PED::_IS_PED_VISIBILITY_TRACKED can return true after this is called.
+-- - For vehicles, IS_VEHICLE_VISIBLE returns true in the tracked/visible-state context observed from scripts.
+-- 
+-- Commonly called right after creating or spawning an entity.
+-- min build: 1207
+---@param entity number
+function _RequestEntityVisibilityTracking(entity) end
+
+-- _SEARCH_BUILDING_POOL_FOR_ENTITY_WITH_THIS_MODEL  (0x66B2B83B94B22458)
+-- Alternative Name: _GET_ENTITY_FROM_MAP_OBJECT; You can get existing objects and manipulate them using this native.
+-- min build: 1207
+---@param modelHash number
+---@return number
+function _SearchBuildingPoolForEntityWithThisModel(modelHash) end
+
+-- _SET_ANIMAL_PELT_TEXTURE  (0xDD03FC2089AD093C)
+-- Sets the texture variant used by an animal pelt entity.
+-- Observed usage calls this on a pelt entity after the required TXD resources are streamed.
+-- peltAsset identifies the base pelt asset, such as joaat("PROVISION_WOLF_FUR"), while albedoHash appears to select the visual texture/albedo variant.
+-- min build: 1207
+---@param entity number
+---@param peltAsset number
+---@param albedoHash number
+---@param p3 number
+function _SetAnimalPeltTexture(entity, peltAsset, albedoHash, p3) end
+
+-- _SET_AUTO_PICKUP  (0xBD94CECFB2D65119)
+-- Configures automatic pickup behavior for a carriable entity.
+-- Typically used after TASK_CARRIABLE.
+-- It enables auto-pickup behavior with controls for pickup animation, pickup range, and whether the pickup prompt is enabled.
+-- min build: 1207
+---@param entity number
+---@param noPickupAnim boolean
+---@param autoPickupRange number
+---@param p3 number
+---@param p4 number
+---@param enablePickupPrompt boolean
+function _SetAutoPickup(entity, noPickupAnim, autoPickupRange, p3, p4, enablePickupPrompt) end
+
+-- _SET_CARRIABLE_PICKUP_LIGHT  (0xA48E4801DEBDF7E4)
+-- Enables or disables the pickup light effect for carriable/interactable entities.
+-- Unlike SET_PICKUP_LIGHT, this does not apply a generic light effect to all objects.
+-- It highlights entities that can be interacted with in a pickup context and has no visible effect if the entity is not carriable or interactable.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function _SetCarriablePickupLight(entity, toggle) end
+
+-- _SET_ENTITY_ANIM_AGE  (0xC0EDEF16D90661EE)
+-- Sets an entity animation age/alpha value.
+-- Observed in scripts with torch weapon entities. alpha controls the animation age where 0.0 is the start and 1.0 is the end.
+-- min build: 1207
+---@param entity number
+---@param alpha number
+function _SetEntityAnimAge(entity, alpha) end
+
+-- _SET_ENTITY_ANIM_CURRENT_TIME  (0x11CDABDC7783B2BC)
+-- https://gfycat.com/amazingmiserlyamericanquarterhorse
+-- min build: 1207
+---@param entity number
+---@param animDict string
+---@param animName string
+---@param time number
+function _SetEntityAnimCurrentTime(entity, animDict, animName, time) end
+
+-- _SET_ENTITY_ANIM_SPEED  (0xEAA885BA3CEA4E4A)
+-- min build: 1207
+---@param entity number
+---@param animDict string
+---@param animName string
+---@param speedMultiplier number
+function _SetEntityAnimSpeed(entity, animDict, animName, speedMultiplier) end
+
+-- _SET_ENTITY_ATTACHED_OFFSET  (0x16908E859C3AB698)
+-- Applies and updates the positional offset of an entity relative to the entity it is attached to, while also controlling whether the offset is interpreted horizontally.
+-- Typically used after ATTACH_ENTITY_TO_ENTITY.
+-- min build: 1207
+---@param entity number
+---@param horizontalMode boolean
+---@param x number
+---@param y number
+---@param z number
+function _SetEntityAttachedOffset(entity, horizontalMode, x, y, z) end
+
+-- _SET_ENTITY_CARCASS_TYPE  (0x399657ED871B3A6C)
+-- Changes type and quality of skins
+-- type hashes: https://pastebin.com/C1WvQjCy
+-- min build: 1207
+---@param entity number
+---@param type number
+function _SetEntityCarcassType(entity, type) end
+
+-- _SET_ENTITY_CARRYING_FLAG  (0x18FF3110CF47115D)
+-- flagId: https://github.com/femga/rdr3_discoveries/tree/master/AI/CARRYING_FLAGS
+-- https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CCarryingFlags__Flags
+-- 
+-- enum eCarryingFlag
+-- {
+-- 	CARRYING_FLAG_CAN_BE_CUT_FREE = 1,
+-- 	CARRYING_FLAG_CAN_BE_CARRIED_ON_FOOT = 2,
+-- 	CARRYING_FLAG_CAN_BE_DROPPED = 4,
+-- 	CARRYING_FLAG_CAN_BE_CARRIED_WHEN_DEAD = 7,
+-- 	CARRYING_FLAG_CAN_CARRY_ANYTHING = 9,
+-- 	CARRYING_FLAG_DISABLE_PROMPT_LOS_CHECKS = 19,
+-- 	CARRYING_FLAG_FORCE_ALLOW_WARP_TO_SAFE_GROUND_LOCATION = 23,
+-- 	CARRYING_FLAG_PICKUPS_IGNORE_HEIGHT_RESTRICTIONS = 26,
+-- 	CARRYING_FLAG_CLEAN_UP_WHEN_NOT_CARRIED = 27,
+-- 	CARRYING_FLAG_BLOCK_KNOCK_OFF_PED_VARIATIONS_FROM_CARRIABLE_INTERACTIONS = 29,
+-- 	CARRYING_FLAG_HIT_WHEN_CARRIABLE = 31,
+-- 	CARRYING_FLAG_DISABLE_CARRIABLE_INTERACTIONS_ON_THIS_MOUNT = 34,
+-- 	CARRYING_FLAG_FORCE_HIDE_PROMPT_GROUP = 37,
+-- };
+-- min build: 1207
+---@param entity number
+---@param flagId number
+---@param value boolean
+function _SetEntityCarryingFlag(entity, flagId, value) end
+
+-- _SET_ENTITY_COORDS_AND_HEADING  (0x203BEFFDBE12E96A)
+-- min build: 1207
+---@param entity number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param heading number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+function _SetEntityCoordsAndHeading(entity, xPos, yPos, zPos, heading, xAxis, yAxis, zAxis) end
+
+-- _SET_ENTITY_COORDS_AND_HEADING_NO_OFFSET  (0x0918E3565C20F03C)
+-- min build: 1207
+---@param entity number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param heading number
+---@param p5 boolean
+---@param p6 boolean
+function _SetEntityCoordsAndHeadingNoOffset(entity, xPos, yPos, zPos, heading, p5, p6) end
+
+-- _SET_ENTITY_CUSTOM_PICKUP_RADIUS  (0x482D17E45665DA44)
+-- min build: 1207
+---@param entity number
+---@param radius number
+function _SetEntityCustomPickupRadius(entity, radius) end
+
+-- _SET_ENTITY_DISABLE_FIRE  (0x56E0735D6273B227)
+-- Disables or re-enables the visible fire/flame effect on a burning entity.
+-- 
+-- Notes:
+-- - Only affects the visible fire effect.
+-- - Does not extinguish the fire itself.
+-- - Does not affect the light emitted by the fire.
+-- - The entity may still technically remain on fire while the flame effect is hidden.
+-- - Often used with OBJECT::_SET_OBJECT_BURN_OPACITY(entity, 0.0f) to further suppress burn visuals.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function _SetEntityDisableFire(entity, toggle) end
+
+-- _SET_ENTITY_FADE_IN  (0xA91E6CF94404E8C9)
+-- min build: 1207
+---@param entity number
+function _SetEntityFadeIn(entity) end
+
+-- _SET_ENTITY_FULLY_LOOTED  (0x6BCF5F3D8FFE988D)
+-- min build: 1207
+---@param entity number
+---@param looted boolean
+function _SetEntityFullyLooted(entity, looted) end
+
+-- _SET_ENTITY_LIGHTS_ENABLED  (0xEBDC12861D079ABA)
+-- Forces entity lights to stay enabled regardless of environmental conditions such as day/night cycle.
+-- Despite the known dump name, this acts as an always-enabled override rather than a simple light toggle. Pass false to return lights to default behavior. Related to _SET_ENTITY_LIGHTS_OFF.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function _SetEntityLightsEnabled(entity, toggle) end
+
+-- _SET_ENTITY_LIGHTS_OFF  (0x2D40BCBFE9305DEA)
+-- Controls a forced lights-off state for entities with built-in light sources.
+-- This does not enable lights; it overrides the light state by forcing them off. Pass false to remove the forced-off override.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function _SetEntityLightsOff(entity, toggle) end
+
+-- _SET_ENTITY_LOCKON_POINT_OFFSET  (0xAF7F3099B9FEB535)
+-- Sets an offset for the entity's lock-on/target focus point.
+-- This does not move the entity itself. It shifts the point used by targeting or camera focus when the entity is selected as a target.
+-- min build: 1207
+---@param entity number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+function _SetEntityLockonPointOffset(entity, offsetX, offsetY, offsetZ) end
+
+-- _SET_ENTITY_ROTATION_PARALLEL_TO_LINE  (0xD45BB89B53FC0CFD)
+-- Sets the entity rotation so it is parallel to the direction defined by two world coordinates, without moving the entity.
+-- This does not make the entity face either coordinate directly; it aligns the entity with the line direction between the two points. Observed usage passes p7 = 1.
+-- min build: 1207
+---@param entity number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p7 number
+function _SetEntityRotationParallelToLine(entity, x1, y1, z1, x2, y2, z2, p7) end
+
+-- _SET_ENTITY_THREAT_TIER  (0x4B436BAC8CBE9B07)
+-- tier: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eEntityThreatTier
+-- min build: 1207
+---@param entity number
+---@param tier number
+---@param p2 boolean
+function _SetEntityThreatTier(entity, tier, p2) end
+
+-- _SET_MATERIAL_FILL_LEVEL_FOR_ENTITY  (0x669655FFB29EF1A9)
+-- Sets a material fill level (e.g., stew, mug, chips, jugs).
+-- Params: p1: 0 or 2; name: depth/degree of fill label name; fillState: 0.0-1.0 (some up to 3.0)
+-- min build: 1207
+---@param entity number
+---@param expressionType number
+---@param dofName string
+---@param fillState number
+function _SetMaterialFillLevelForEntity(entity, expressionType, dofName, fillState) end
+
+-- _UNPIN_MAP_ENTITY  (0xD2B9C78537ED5759)
+-- Removes/unpins a map pin using its pin ID.
+-- 
+-- Earlier documentation incorrectly listed this parameter as an Entity.
+-- Based on the observed pin workflow, this operates on the pin handle/ID returned by _PIN_MAP_ENTITY, not directly on the entity.
+-- min build: 1207
+---@param pinId number
+function _UnpinMapEntity(pinId) end
+
+-- APPLY_FORCE_TO_ENTITY  (0xF15E8F5D333F09C4)
+-- min build: 1207
+---@param entity number
+---@param forceFlags number
+---@param x number
+---@param y number
+---@param z number
+---@param offX number
+---@param offY number
+---@param offZ number
+---@param boneIndex number
+---@param isDirectionRel boolean
+---@param ignoreUpVec boolean
+---@param isForceRel boolean
+---@param p12 boolean
+---@param p13 boolean
+function ApplyForceToEntity(entity, forceFlags, x, y, z, offX, offY, offZ, boneIndex, isDirectionRel, ignoreUpVec, isForceRel, p12, p13) end
+
+-- APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS  (0x31DA7CEC5334DB37)
+-- p6/relative - makes the xyz force not relative to world coords, but to something else
+-- p7/highForce - setting false will make the force really low
+-- min build: 1207
+---@param entity number
+---@param forceType number
+---@param x number
+---@param y number
+---@param z number
+---@param component number
+---@param isDirectionRel boolean
+---@param isForceRel boolean
+---@param p8 boolean
+function ApplyForceToEntityCenterOfMass(entity, forceType, x, y, z, component, isDirectionRel, isForceRel, p8) end
+
+-- ATTACH_ENTITY_TO_ENTITY  (0x6B9BBD38AB0796DF)
+-- Attaches entity1 to bone (boneIndex) of entity2.
+-- 
+-- boneIndex - this is different to boneID, use GET_PED_BONE_INDEX to get the index from the ID. use the index for attaching to specific bones. entity1 will be attached to entity2's centre if bone index given doesn't correspond to bone indexes for that entity type.
+-- https://github.com/femga/rdr3_discoveries/tree/master/boneNames
+-- 
+-- useSoftPinning - if set to false attached entity will not detach when fixed
+-- collision - controls collision between the two entities (FALSE disables collision).
+-- isPed - pitch doesn't work when false and roll will only work on negative numbers (only peds)
+-- vertexIndex - position of vertex
+-- fixedRot - if false it ignores entity vector
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param boneIndex number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param p9 boolean
+---@param useSoftPinning boolean
+---@param collision boolean
+---@param isPed boolean
+---@param vertexIndex number
+---@param fixedRot boolean
+---@param p15 boolean
+---@param p16 boolean
+function AttachEntityToEntity(entity1, entity2, boneIndex, xPos, yPos, zPos, xRot, yRot, zRot, p9, useSoftPinning, collision, isPed, vertexIndex, fixedRot, p15, p16) end
+
+-- ATTACH_ENTITY_TO_ENTITY_PHYSICALLY  (0xB629A43CA1643481)
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param p2 number
+---@param boneIndex number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@param p11 number
+---@param p12 number
+---@param p13 number
+---@param p14 boolean
+---@param p15 boolean
+---@param p16 boolean
+---@param p17 boolean
+---@param p18 number
+---@param p19 boolean
+---@param p20 number
+---@param p21 number
+function AttachEntityToEntityPhysically(entity1, entity2, p2, boneIndex, offsetX, offsetY, offsetZ, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) end
+
+-- CLEAR_ENTITY_LAST_DAMAGE_ENTITY  (0xBB19AC7D4DCEFD0F)
+-- min build: 1207
+---@param entity number
+function ClearEntityLastDamageEntity(entity) end
+
+-- CREATE_FORCED_OBJECT  (0x0961A905AFBC34C7)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 any
+---@param modelHash number
+---@param p5 boolean
+function CreateForcedObject(x, y, z, p3, modelHash, p5) end
+
+-- CREATE_MODEL_HIDE  (0x069848B3FB3C4426)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param model number
+---@param p5 boolean
+function CreateModelHide(x, y, z, radius, model, p5) end
+
+-- CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS  (0xD136090A9AAAB17D)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param model number
+---@param p5 boolean
+function CreateModelHideExcludingScriptObjects(x, y, z, radius, model, p5) end
+
+-- CREATE_MODEL_SWAP  (0x10B2218320B6F5AC)
+-- Only works with objects!
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param originalModel number
+---@param newModel number
+---@param p6 boolean
+function CreateModelSwap(x, y, z, radius, originalModel, newModel, p6) end
+
+-- DELETE_ENTITY  (0x4CD38C78BD19A497)
+-- Deletes the specified entity, then sets the handle pointed to by the pointer to NULL.
+-- min build: 1207
+---@return number
+function DeleteEntity() end
+
+-- DETACH_ENTITY  (0x64CDE9D6BF8ECAD3)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param collision boolean
+function DetachEntity(entity, p1, collision) end
+
+-- DOES_ENTITY_BELONG_TO_THIS_SCRIPT  (0x622B1980CBE13332)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@return boolean
+function DoesEntityBelongToThisScript(entity, p1) end
+
+-- DOES_ENTITY_EXIST  (0xD42BD6EB2E0F1677)
+-- Checks if the Entity exists
+-- min build: 1207
+---@param entity number
+---@return boolean
+function DoesEntityExist(entity) end
+
+-- DOES_ENTITY_HAVE_DRAWABLE  (0x20487F0DA9AF164A)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function DoesEntityHaveDrawable(entity) end
+
+-- DOES_ENTITY_HAVE_PHYSICS  (0xA512B3F1B2A0B51C)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function DoesEntityHavePhysics(entity) end
+
+-- FIND_ANIM_EVENT_PHASE  (0x42718CC559BD7776)
+-- min build: 1207
+---@param animDictionary string
+---@param animName string
+---@param p2 string
+---@return boolean
+---@return any
+---@return any
+function FindAnimEventPhase(animDictionary, animName, p2) end
+
+-- FORCE_ENTITY_AI_AND_ANIMATION_UPDATE  (0x4C9E96473D4F1A88)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+function ForceEntityAiAndAnimationUpdate(entity, p1) end
+
+-- FREEZE_ENTITY_POSITION  (0x7D9EFB7AD6B19754)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function FreezeEntityPosition(entity, toggle) end
+
+-- GET_ANIM_DURATION  (0x9FFAF4940A54CC09)
+-- min build: 1207
+---@param animDict string
+---@param animName string
+---@return number
+function GetAnimDuration(animDict, animName) end
+
+-- GET_CARRIABLE_ENTITY_STATE  (0x61914209C36EFDDB)
+-- enum eCarriableState
+-- {
+-- 	CARRIABLE_STATE_NONE,
+-- 	CARRIABLE_STATE_TRANSITIONING_TO_HOGTIED,
+-- 	CARRIABLE_STATE_CARRIABLE_INTRO,
+-- 	CARRIABLE_STATE_CARRIABLE,
+-- 	CARRIABLE_STATE_BEING_PICKED_UP_FROM_GROUND,
+-- 	CARRIABLE_STATE_CARRIED_BY_HUMAN,
+-- 	CARRIABLE_STATE_BEING_PLACED_ON_GROUND,
+-- 	CARRIABLE_STATE_CARRIED_BY_MOUNT,
+-- 	CARRIABLE_STATE_BEING_PLACED_ON_MOUNT,
+-- 	CARRIABLE_STATE_BEING_PICKED_UP_FROM_MOUNT,
+-- 	CARRIABLE_STATE_BEING_CUT_FREE,
+-- 	CARRIABLE_STATE_BEING_PLACED_ON_GROUND_ESCAPE,
+-- 	CARRIABLE_STATE_BEING_PLACED_IN_VEHICLE
+-- };
+-- min build: 1207
+---@param entity number
+---@return number
+function GetCarriableEntityState(entity) end
+
+-- GET_ENTITY_ALPHA  (0x1BB501624FAF2BEA)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityAlpha(entity) end
+
+-- GET_ENTITY_ATTACHED_TO  (0x56D713888A566481)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityAttachedTo(entity) end
+
+-- GET_ENTITY_BONE_INDEX_BY_NAME  (0xBACA8FE9C76C124E)
+-- min build: 1207
+---@param entity number
+---@param boneName string
+---@return number
+function GetEntityBoneIndexByName(entity, boneName) end
+
+-- GET_ENTITY_COLLISION_DISABLED  (0xAA2FADD30F45A9DA)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function GetEntityCollisionDisabled(entity) end
+
+-- GET_ENTITY_COORDS  (0xA86D5F069399F44D)
+-- Gets the current coordinates for a specified entity.
+-- `entity` = The entity to get the coordinates from.
+-- `alive` = Unused by the game, potentially used by debug builds in order to assert whether or not an entity was alive.
+-- 
+-- If entity is a ped and it's in a vehicle or on a mount the coords of that entity are returned. Set 'realCoords' to true when you need the true ped coords.
+-- min build: 1207
+---@param entity number
+---@param alive boolean
+---@param realCoords boolean
+---@return vector3
+function GetEntityCoords(entity, alive, realCoords) end
+
+-- GET_ENTITY_FORWARD_VECTOR  (0x2412D9C05BB09B97)
+-- Gets the entity's forward vector in XY(Z) eulers.
+-- min build: 1207
+---@param entity number
+---@return vector3
+function GetEntityForwardVector(entity) end
+
+-- GET_ENTITY_FORWARD_X  (0xDB0954E9960F6457)
+-- Gets the X-component of the entity's forward vector.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityForwardX(entity) end
+
+-- GET_ENTITY_FORWARD_Y  (0x9A5C073ECBDA7EE7)
+-- Gets the Y-component of the entity's forward vector.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityForwardY(entity) end
+
+-- GET_ENTITY_HEADING  (0xC230DD956E2F5507)
+-- Returns the heading of the entity in degrees. Also know as the "Yaw" of an entity.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityHeading(entity) end
+
+-- GET_ENTITY_HEALTH  (0x82368787EA73C0F7)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityHealth(entity) end
+
+-- GET_ENTITY_HEIGHT  (0x296DEBC84474B375)
+-- min build: 1207
+---@param entity number
+---@param X number
+---@param Y number
+---@param Z number
+---@param atTop boolean
+---@param inWorldCoords boolean
+---@return number
+function GetEntityHeight(entity, X, Y, Z, atTop, inWorldCoords) end
+
+-- GET_ENTITY_HEIGHT_ABOVE_GROUND  (0x0D3B5BAEA08F63E9)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityHeightAboveGround(entity) end
+
+-- GET_ENTITY_LOD_DIST  (0xDF240D0C2A948683)
+-- Returns the LOD distance of an entity.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityLodDist(entity) end
+
+-- GET_ENTITY_MATRIX  (0x3A9B1120AF13FBF2)
+-- min build: 1207
+---@param entity number
+---@return vector3
+---@return vector3
+---@return vector3
+---@return vector3
+function GetEntityMatrix(entity) end
+
+-- GET_ENTITY_MAX_HEALTH  (0x15D757606D170C3C)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@return number
+function GetEntityMaxHealth(entity, p1) end
+
+-- GET_ENTITY_MODEL  (0xDA76A9F39210D365)
+-- Returns the model hash from the entity
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityModel(entity) end
+
+-- GET_ENTITY_PITCH  (0xEF355ABEFF7F5005)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityPitch(entity) end
+
+-- GET_ENTITY_POPULATION_TYPE  (0xADE28862B6D7B85B)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityPopulationType(entity) end
+
+-- GET_ENTITY_ROLL  (0xBF966536FA8B6879)
+-- Displays the current ROLL axis of the entity [-180.0000/180.0000+]
+-- (Sideways Roll) such as a vehicle tipped on its side
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityRoll(entity) end
+
+-- GET_ENTITY_ROTATION  (0xE09CAF86C32CB48F)
+-- min build: 1207
+---@param entity number
+---@param rotationOrder number
+---@return vector3
+function GetEntityRotation(entity, rotationOrder) end
+
+-- GET_ENTITY_SPEED  (0xFB6BA510A533DF81)
+-- Result is in meters per second (m/s)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntitySpeed(entity) end
+
+-- GET_ENTITY_SPEED_VECTOR  (0xF2DB09816A419DC5)
+-- min build: 1207
+---@param entity number
+---@param relative boolean
+---@return vector3
+function GetEntitySpeedVector(entity, relative) end
+
+-- GET_ENTITY_SUBMERGED_LEVEL  (0x4A77C3F73FD9E831)
+-- Get how much of the entity is submerged.  1.0f is whole entity.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntitySubmergedLevel(entity) end
+
+-- GET_ENTITY_TYPE  (0x97F696ACA466B4E0)
+-- Returns entityType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eEntityType
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityType(entity) end
+
+-- GET_ENTITY_UPRIGHT_VALUE  (0x56398BE65160C3BE)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetEntityUprightValue(entity) end
+
+-- GET_ENTITY_VELOCITY  (0x4805D2B1D8CF94A9)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@return vector3
+function GetEntityVelocity(entity, p1) end
+
+-- GET_IS_ANIMAL  (0x9A100F1CF4546629)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function GetIsAnimal(entity) end
+
+-- GET_MATCHING_ENTITIES  (0x84CCF9A12942C83D)
+-- min build: 1207
+---@param volume number
+---@param itemSet number
+---@param entityType number
+---@param p3 any
+---@param p4 number
+---@param p5 string
+---@return number
+function GetMatchingEntities(volume, itemSet, entityType, p3, p4, p5) end
+
+-- GET_NEAREST_PARTICIPANT_TO_ENTITY  (0x6888A43C35A5F630)
+-- min build: 1207
+---@param entity number
+---@return number
+function GetNearestParticipantToEntity(entity) end
+
+-- GET_NEAREST_PLAYER_TO_ENTITY  (0x990E294FC387FB88)
+-- min build: 1207
+---@param entity number
+---@param playerPedToIgnore number
+---@param flags number
+---@return number
+function GetNearestPlayerToEntity(entity, playerPedToIgnore, flags) end
+
+-- GET_NEAREST_PLAYER_TO_ENTITY_ON_TEAM  (0xB2C30C3B4AFF718C)
+-- min build: 1207
+---@param entity number
+---@param team number
+---@param playerPedToIgnore number
+---@param flags number
+---@return number
+function GetNearestPlayerToEntityOnTeam(entity, team, playerPedToIgnore, flags) end
+
+-- GET_OBJECT_INDEX_FROM_ENTITY_INDEX  (0x280BBE5601EAA983)
+-- Simply returns whatever is passed to it (Regardless of whether the handle is valid or not).
+-- min build: 1207
+---@param entity number
+---@return number
+function GetObjectIndexFromEntityIndex(entity) end
+
+-- GET_OFFSET_FROM_ENTITY_GIVEN_WORLD_COORDS  (0x497C6B1A2C9AE69C)
+-- min build: 1207
+---@param entity number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@return vector3
+function GetOffsetFromEntityGivenWorldCoords(entity, posX, posY, posZ) end
+
+-- GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS  (0x1899F328B0E12848)
+-- Offset values are relative to the entity.
+-- 
+-- x = left/right
+-- y = forward/backward
+-- z = up/down
+-- min build: 1207
+---@param entity number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@return vector3
+function GetOffsetFromEntityInWorldCoords(entity, offsetX, offsetY, offsetZ) end
+
+-- GET_PED_INDEX_FROM_ENTITY_INDEX  (0x0F16D042BD640EA3)
+-- Simply returns whatever is passed to it (Regardless of whether the handle is valid or not).
+-- min build: 1207
+---@param entity number
+---@return number
+function GetPedIndexFromEntityIndex(entity) end
+
+-- GET_VEHICLE_INDEX_FROM_ENTITY_INDEX  (0xDF1E5AAC561AFC59)
+-- Simply returns whatever is passed to it (Regardless of whether the handle is valid or not).
+-- min build: 1207
+---@param entity number
+---@return number
+function GetVehicleIndexFromEntityIndex(entity) end
+
+-- GET_WORLD_POSITION_OF_ENTITY_BONE  (0x82CFA50E34681CA5)
+-- Returns the coordinates of an entity-bone.
+-- https://github.com/femga/rdr3_discoveries/tree/master/boneNames
+-- min build: 1207
+---@param entity number
+---@param boneIndex number
+---@return vector3
+function GetWorldPositionOfEntityBone(entity, boneIndex) end
+
+-- HAS_ANIM_EVENT_FIRED  (0x5851CC48405F4A07)
+-- min build: 1207
+---@param entity number
+---@param actionHash number
+---@return boolean
+function HasAnimEventFired(entity, actionHash) end
+
+-- HAS_COLLISION_LOADED_AROUND_ENTITY  (0xBEB1600952B9CF5C)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function HasCollisionLoadedAroundEntity(entity) end
+
+-- HAS_COLLISION_LOADED_AROUND_POSITION  (0x6BFBDC46139C45AB)
+-- Old name: _HAS_COLLISION_LOADED_AT_COORDS
+-- min build: 1207
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@return boolean
+function HasCollisionLoadedAroundPosition(xPos, yPos, zPos) end
+
+-- HAS_ENTITY_ANIM_FINISHED  (0xAEB40615337EF1E3)
+-- min build: 1207
+---@param entity number
+---@param animDict string
+---@param animName string
+---@param p3 number
+---@return boolean
+function HasEntityAnimFinished(entity, animDict, animName, p3) end
+
+-- HAS_ENTITY_BEEN_DAMAGED_BY_ANY_OBJECT  (0x73BB763880CD23A6)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function HasEntityBeenDamagedByAnyObject(entity) end
+
+-- HAS_ENTITY_BEEN_DAMAGED_BY_ANY_PED  (0x9934E9C42D52D87E)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function HasEntityBeenDamagedByAnyPed(entity) end
+
+-- HAS_ENTITY_BEEN_DAMAGED_BY_ANY_VEHICLE  (0x695D7C26DE65C423)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function HasEntityBeenDamagedByAnyVehicle(entity) end
+
+-- HAS_ENTITY_BEEN_DAMAGED_BY_ENTITY  (0x7B6E7BEC1143AC86)
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param p2 boolean
+---@param p3 boolean
+---@return boolean
+function HasEntityBeenDamagedByEntity(entity1, entity2, p2, p3) end
+
+-- HAS_ENTITY_CLEAR_LOS_TO_COORD  (0x0C9DBF48C6BA6E4C)
+-- min build: 1207
+---@param entity number
+---@param x number
+---@param y number
+---@param z number
+---@param flags number
+---@return boolean
+function HasEntityClearLosToCoord(entity, x, y, z, flags) end
+
+-- HAS_ENTITY_CLEAR_LOS_TO_ENTITY  (0xFCDFF7B72D23A1AC)
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param traceType number
+---@return boolean
+function HasEntityClearLosToEntity(entity1, entity2, traceType) end
+
+-- HAS_ENTITY_CLEAR_LOS_TO_ENTITY_IN_FRONT  (0xE88F19660651D566)
+-- Has the entity1 got a clear line of sight to the other entity2 from the direction entity1 is facing.
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param traceType number
+---@return boolean
+function HasEntityClearLosToEntityInFront(entity1, entity2, traceType) end
+
+-- HAS_ENTITY_COLLIDED_WITH_ANYTHING  (0xDF18751EC74F90FF)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function HasEntityCollidedWithAnything(entity) end
+
+-- IS_AN_ENTITY  (0x27CFF3E5A286D3DF)
+-- min build: 1207
+---@param handle number
+---@return boolean
+function IsAnEntity(handle) end
+
+-- IS_ENTITY_A_MISSION_ENTITY  (0x138190F64DB4BBD1)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAMissionEntity(entity) end
+
+-- IS_ENTITY_A_PED  (0xCF8176912DDA4EA5)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAPed(entity) end
+
+-- IS_ENTITY_A_VEHICLE  (0xC3D96AF45FCCEC4C)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAVehicle(entity) end
+
+-- IS_ENTITY_AN_OBJECT  (0x0A27A546A375FDEF)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAnObject(entity) end
+
+-- IS_ENTITY_AT_COORD  (0x5E58342602E94718)
+-- Checks if entity is within x/y/zSize distance of x/y/z. 
+-- 
+-- Last three are unknown ints, almost always p7 = 0, p8 = 1, p9 = 0
+-- min build: 1207
+---@param entity number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xSize number
+---@param ySize number
+---@param zSize number
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 number
+---@return boolean
+function IsEntityAtCoord(entity, xPos, yPos, zPos, xSize, ySize, zSize, p7, p8, p9) end
+
+-- IS_ENTITY_AT_ENTITY  (0xC057F02B837A27F6)
+-- Checks if entity1 is within the box defined by x/y/zSize of entity2.
+-- 
+-- Last three parameters are almost always p5 = 0, p6 = 1, p7 = 0
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param xSize number
+---@param ySize number
+---@param zSize number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 number
+---@return boolean
+function IsEntityAtEntity(entity1, entity2, xSize, ySize, zSize, p5, p6, p7) end
+
+-- IS_ENTITY_ATTACHED  (0xEE6AD63ABF59C0B7)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAttached(entity) end
+
+-- IS_ENTITY_ATTACHED_TO_ANY_OBJECT  (0x306C1F6178F01AB3)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAttachedToAnyObject(entity) end
+
+-- IS_ENTITY_ATTACHED_TO_ANY_PED  (0xC841153DED2CA89A)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAttachedToAnyPed(entity) end
+
+-- IS_ENTITY_ATTACHED_TO_ANY_VEHICLE  (0x12DF6E0D2E736749)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAttachedToAnyVehicle(entity) end
+
+-- IS_ENTITY_ATTACHED_TO_ENTITY  (0x154A3C529497053E)
+-- min build: 1207
+---@param from number
+---@param to number
+---@return boolean
+function IsEntityAttachedToEntity(from, to) end
+
+-- IS_ENTITY_DEAD  (0x7D5B1F88E7504BBA)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityDead(entity) end
+
+-- IS_ENTITY_IN_AIR  (0x886E37EC497200B6)
+-- min build: 1207
+---@param entity number
+---@param p1 any
+---@return boolean
+function IsEntityInAir(entity, p1) end
+
+-- IS_ENTITY_IN_ANGLED_AREA  (0xD3151E53134595E5)
+-- Creates a spherical cone at origin that extends to surface with the angle specified. Then returns true if the entity is inside the spherical cone
+-- 
+-- Angle is measured in degrees.
+-- min build: 1207
+---@param entity number
+---@param originX number
+---@param originY number
+---@param originZ number
+---@param edgeX number
+---@param edgeY number
+---@param edgeZ number
+---@param angle number
+---@param p8 boolean
+---@param p9 boolean
+---@param p10 any
+---@return boolean
+function IsEntityInAngledArea(entity, originX, originY, originZ, edgeX, edgeY, edgeZ, angle, p8, p9, p10) end
+
+-- IS_ENTITY_IN_AREA  (0x0C2634C40A16193E)
+-- min build: 1207
+---@param entity number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 any
+---@return boolean
+function IsEntityInArea(entity, x1, y1, z1, x2, y2, z2, p7, p8, p9) end
+
+-- IS_ENTITY_IN_VOLUME  (0x5A5526BC09C06623)
+-- min build: 1207
+---@param entity number
+---@param volume number
+---@param p2 boolean
+---@param p3 number
+---@return boolean
+function IsEntityInVolume(entity, volume, p2, p3) end
+
+-- IS_ENTITY_IN_WATER  (0xDDE5C125AC446723)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityInWater(entity) end
+
+-- IS_ENTITY_OCCLUDED  (0x140188E884645624)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityOccluded(entity) end
+
+-- IS_ENTITY_ON_SCREEN  (0x613C15D5D8DB781F)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityOnScreen(entity) end
+
+-- IS_ENTITY_PLAYING_ANIM  (0xDEE49D5CA6C49148)
+-- min build: 1207
+---@param entity number
+---@param animDict string
+---@param animName string
+---@param animType number
+---@return boolean
+function IsEntityPlayingAnim(entity, animDict, animName, animType) end
+
+-- IS_ENTITY_STATIC  (0x86468ADFA0F6B861)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityStatic(entity) end
+
+-- IS_ENTITY_TOUCHING_ENTITY  (0x9A2304A64C3C8423)
+-- min build: 1207
+---@param entity number
+---@param targetEntity number
+---@return boolean
+function IsEntityTouchingEntity(entity, targetEntity) end
+
+-- IS_ENTITY_TOUCHING_MODEL  (0x2AE3EBC8DEB9768B)
+-- min build: 1207
+---@param entity number
+---@param modelHash number
+---@return boolean
+function IsEntityTouchingModel(entity, modelHash) end
+
+-- IS_ENTITY_UPRIGHT  (0xF6F6AFD8D4FB2658)
+-- min build: 1207
+---@param entity number
+---@param angle number
+---@return boolean
+function IsEntityUpright(entity, angle) end
+
+-- IS_ENTITY_UPSIDEDOWN  (0x109DE3DA41AAD94A)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityUpsidedown(entity) end
+
+-- IS_ENTITY_VISIBLE  (0xFFC96ECB7FA404CA)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityVisible(entity) end
+
+-- IS_ENTITY_VISIBLE_TO_SCRIPT  (0xF213C724E77F321A)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityVisibleToScript(entity) end
+
+-- IS_ENTITY_WAITING_FOR_WORLD_COLLISION  (0x5E1CC2E8DC3111DD)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityWaitingForWorldCollision(entity) end
+
+-- IS_MAP_ENTITY_PINNED  (0x1FF441D7954F8709)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function IsMapEntityPinned(p0) end
+
+-- PIN_CLOSEST_MAP_ENTITY  (0x6F3068258A499E52)
+-- min build: 1207
+---@param modelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param flags number
+---@return any
+function PinClosestMapEntity(modelHash, x, y, z, flags) end
+
+-- PLACE_ENTITY_ON_GROUND_PROPERLY  (0x9587913B9E772D29)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@return boolean
+function PlaceEntityOnGroundProperly(entity, p1) end
+
+-- PLAY_ENTITY_ANIM  (0xDC6D22FAB76D4874)
+-- https://github.com/femga/rdr3_discoveries/tree/master/animations
+-- min build: 1207
+---@param entity number
+---@param animName string
+---@param animDict string
+---@param p3 number
+---@param loop boolean
+---@param stayInAnim boolean
+---@param p6 boolean
+---@param delta number
+---@param bitset any
+---@return boolean
+function PlayEntityAnim(entity, animName, animDict, p3, loop, stayInAnim, p6, delta, bitset) end
+
+-- REMOVE_FORCED_OBJECT  (0x553FA683F2BCD814)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function RemoveForcedObject(p0, p1, p2, p3, p4) end
+
+-- REMOVE_MODEL_HIDE  (0x3F38A98576F6213A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function RemoveModelHide(p0, p1, p2, p3, p4, p5) end
+
+-- REMOVE_MODEL_SWAP  (0x824E1C26A14CB817)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param originalModel number
+---@param newModel number
+---@param p6 boolean
+function RemoveModelSwap(x, y, z, radius, originalModel, newModel, p6) end
+
+-- RESET_ENTITY_ALPHA  (0x744B9EF44779D9AB)
+-- min build: 1207
+---@param entity number
+function ResetEntityAlpha(entity) end
+
+-- SCRIPT_OVERRIDE_ENTITY_LOOT_TABLE_PERMANENT  (0x8C03CD6B5E0E85E8)
+-- Sets the loot table an entity will carry. Returns true if loot table has been successfully set. Returns false if entity is not a ped or object.
+-- https://github.com/femga/rdr3_discoveries/blob/master/AI/EVENTS/loot_rewards.lua
+-- min build: 1207
+---@param entity number
+---@param lootTable number
+---@return boolean
+function ScriptOverrideEntityLootTablePermanent(entity, lootTable) end
+
+-- SET_CAN_AUTO_VAULT_ON_ENTITY  (0x80646744FA88F9D7)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetCanAutoVaultOnEntity(entity, toggle) end
+
+-- SET_CAN_CLIMB_ON_ENTITY  (0x24AED2A608F93C4C)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetCanClimbOnEntity(entity, toggle) end
+
+-- SET_ENTITY_ALPHA  (0x0DF7692B1D9E7BA7)
+-- skin - everything alpha except skin
+-- Set entity alpha level. Ranging from 0 to 255 but changes occur after every 20 percent (after every 51).
+-- min build: 1207
+---@param entity number
+---@param alphaLevel number
+---@param skin boolean
+function SetEntityAlpha(entity, alphaLevel, skin) end
+
+-- SET_ENTITY_ALWAYS_PRERENDER  (0xACAD101E1FB66689)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityAlwaysPrerender(entity, toggle) end
+
+-- SET_ENTITY_AS_MISSION_ENTITY  (0xDC19C288082E586E)
+-- Makes the specified entity (ped, vehicle or object) persistent. Persistent entities will not automatically be removed by the engine.
+-- min build: 1207
+---@param entity number
+---@param scriptHostObject boolean
+---@param grabFromOtherScript boolean
+function SetEntityAsMissionEntity(entity, scriptHostObject, grabFromOtherScript) end
+
+-- SET_ENTITY_AS_NO_LONGER_NEEDED  (0x4971D2F8162B9674)
+-- Marks the specified entity (ped, vehicle or object) as no longer needed.
+-- Entities marked as no longer needed, will be deleted as the engine sees fit.
+-- min build: 1207
+---@return number
+function SetEntityAsNoLongerNeeded() end
+
+-- SET_ENTITY_CAN_BE_DAMAGED  (0x0D06D522B90E861F)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityCanBeDamaged(entity, toggle) end
+
+-- SET_ENTITY_CAN_BE_DAMAGED_BY_RELATIONSHIP_GROUP  (0x0EF1AFB18649E015)
+-- min build: 1207
+---@param entity number
+---@param bCanBeDamaged boolean
+---@param relGroup number
+function SetEntityCanBeDamagedByRelationshipGroup(entity, bCanBeDamaged, relGroup) end
+
+-- SET_ENTITY_CAN_BE_TARGETED_WITHOUT_LOS  (0x6D09F32E284D0FB7)
+-- Sets whether the entity can be targeted without being in line-of-sight.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityCanBeTargetedWithoutLos(entity, toggle) end
+
+-- SET_ENTITY_COLLISION  (0xF66F820909453B8C)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+---@param keepPhysics boolean
+function SetEntityCollision(entity, toggle, keepPhysics) end
+
+-- SET_ENTITY_COMPLETELY_DISABLE_COLLISION  (0xE0580EC84813875A)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+---@param keepPhysics boolean
+function SetEntityCompletelyDisableCollision(entity, toggle, keepPhysics) end
+
+-- SET_ENTITY_COORDS  (0x06843DA7060A026B)
+-- min build: 1207
+---@param entity number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@param clearArea boolean
+function SetEntityCoords(entity, xPos, yPos, zPos, xAxis, yAxis, zAxis, clearArea) end
+
+-- SET_ENTITY_COORDS_NO_OFFSET  (0x239A3351AC1DA385)
+-- Axis - Invert Axis Flags
+-- min build: 1207
+---@param entity number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+function SetEntityCoordsNoOffset(entity, xPos, yPos, zPos, xAxis, yAxis, zAxis) end
+
+-- SET_ENTITY_DYNAMIC  (0xFBFC4473F66CE344)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityDynamic(entity, toggle) end
+
+-- SET_ENTITY_HAS_GRAVITY  (0x0CEDB728A1083FA7)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityHasGravity(entity, toggle) end
+
+-- SET_ENTITY_HEADING  (0xCF2B9C0645C4651B)
+-- min build: 1207
+---@param entity number
+---@param heading number
+function SetEntityHeading(entity, heading) end
+
+-- SET_ENTITY_HEALTH  (0xAC2767ED8BDFAB15)
+-- Sets the entity's health. healthAmount sets the health value to that, and sets the maximum health core value. Setting healthAmount to 0 will kill the entity. entityKilledBy parameter can also be 0
+-- min build: 1207
+---@param entity number
+---@param healthAmount number
+---@param entityKilledBy number
+function SetEntityHealth(entity, healthAmount, entityKilledBy) end
+
+-- SET_ENTITY_INVINCIBLE  (0xA5C38736C426FCB8)
+-- Sets a ped or an object totally invincible. It doesn't take any kind of damage. Peds will not ragdoll on explosions.
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityInvincible(entity, toggle) end
+
+-- SET_ENTITY_IS_TARGET_PRIORITY  (0x0A5D170C44CB2189)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param p2 number
+function SetEntityIsTargetPriority(entity, p1, p2) end
+
+-- SET_ENTITY_LOAD_COLLISION_FLAG  (0x9B9EE31AED48072E)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityLoadCollisionFlag(entity, toggle) end
+
+-- SET_ENTITY_LOD_DIST  (0x5FB407F0A7C877BF)
+-- LOD distance can be 0 to 0xFFFF (higher values will result in 0xFFFF) as it is actually stored as a 16-bit value (aka uint16_t).
+-- min build: 1207
+---@param entity number
+---@param value number
+function SetEntityLodDist(entity, value) end
+
+-- SET_ENTITY_MAX_HEALTH  (0x166E7CF68597D8B5)
+-- min build: 1207
+---@param entity number
+---@param value number
+function SetEntityMaxHealth(entity, value) end
+
+-- SET_ENTITY_MOTION_BLUR  (0x516C6ABD18322B63)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityMotionBlur(entity, toggle) end
+
+-- SET_ENTITY_NO_COLLISION_ENTITY  (0xE037BF068223C38D)
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param thisFrameOnly boolean
+function SetEntityNoCollisionEntity(entity1, entity2, thisFrameOnly) end
+
+-- SET_ENTITY_NOWEAPONDECALS  (0xC64E597783BE9A1D)
+-- Old name: _SET_ENTITY_DECALS_DISABLED
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityNoweapondecals(entity, toggle) end
+
+-- SET_ENTITY_ONLY_DAMAGED_BY_PLAYER  (0x473598683095D430)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityOnlyDamagedByPlayer(entity, toggle) end
+
+-- SET_ENTITY_ONLY_DAMAGED_BY_RELATIONSHIP_GROUP  (0x6C1F6AA2F0ADD104)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param relationshipGroup number
+function SetEntityOnlyDamagedByRelationshipGroup(entity, p1, relationshipGroup) end
+
+-- SET_ENTITY_PROOFS  (0xFAEE099C6F890BB8)
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/ENTITY_PROOFS
+-- BOOL p2: handles an additional special proofs flag, so it simply indicates whether it should be enabled or disabled, not sure what exactly it proofs the entity from though
+-- min build: 1207
+---@param entity number
+---@param proofsBitset number
+---@param specialFlag boolean
+function SetEntityProofs(entity, proofsBitset, specialFlag) end
+
+-- SET_ENTITY_QUATERNION  (0x100E7007D13E3687)
+-- min build: 1207
+---@param entity number
+---@param x number
+---@param y number
+---@param z number
+---@param w number
+function SetEntityQuaternion(entity, x, y, z, w) end
+
+-- SET_ENTITY_RENDER_SCORCHED  (0x85B8A7534E44BC23)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityRenderScorched(entity, toggle) end
+
+-- SET_ENTITY_REQUIRES_MORE_EXPENSIVE_RIVER_CHECK  (0x850C940EE3E7B8B5)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityRequiresMoreExpensiveRiverCheck(entity, toggle) end
+
+-- SET_ENTITY_ROTATION  (0x9CC8314DFEDE441E)
+-- min build: 1207
+---@param entity number
+---@param pitch number
+---@param roll number
+---@param yaw number
+---@param rotationOrder number
+---@param p5 boolean
+function SetEntityRotation(entity, pitch, roll, yaw, rotationOrder, p5) end
+
+-- SET_ENTITY_SHOULD_FREEZE_WAITING_ON_COLLISION  (0x740CB4F3F602C9F4)
+-- Old name: _SET_ENTITY_CLEANUP_BY_ENGINE
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityShouldFreezeWaitingOnCollision(entity, toggle) end
+
+-- SET_ENTITY_VELOCITY  (0x1C99BB7B6E96D16F)
+-- Note that the third parameter(denoted as z) is "up and down" with positive numbers encouraging upwards movement.
+-- min build: 1207
+---@param entity number
+---@param x number
+---@param y number
+---@param z number
+function SetEntityVelocity(entity, x, y, z) end
+
+-- SET_ENTITY_VISIBLE  (0x1794B4FCC84D812F)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function SetEntityVisible(entity, toggle) end
+
+-- SET_OBJECT_AS_NO_LONGER_NEEDED  (0x3AE22DEB5BA5A3E6)
+-- This is an alias of SET_ENTITY_AS_NO_LONGER_NEEDED.
+-- min build: 1207
+---@return number
+function SetObjectAsNoLongerNeeded() end
+
+-- SET_PED_AS_NO_LONGER_NEEDED  (0x2595DD4236549CE3)
+-- This is an alias of SET_ENTITY_AS_NO_LONGER_NEEDED.
+-- min build: 1207
+---@return number
+function SetPedAsNoLongerNeeded() end
+
+-- SET_VEHICLE_AS_NO_LONGER_NEEDED  (0x629BFA74418D6239)
+-- This is an alias of SET_ENTITY_AS_NO_LONGER_NEEDED.
+-- min build: 1207
+---@return number
+function SetVehicleAsNoLongerNeeded() end
+
+-- STOP_ENTITY_ANIM  (0x786591D986DE9159)
+-- Doesn't actually return anything.
+-- min build: 1207
+---@param entity number
+---@param animation string
+---@param animGroup string
+---@param p3 number
+---@return boolean
+function StopEntityAnim(entity, animation, animGroup, p3) end
+
+-- WOULD_ENTITY_BE_OCCLUDED  (0x3546FAB293FF2981)
+-- min build: 1207
+---@param entityModelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 boolean
+---@return boolean
+function WouldEntityBeOccluded(entityModelHash, x, y, z, p4) end

--- a/.luals/redm-natives/EVENT.lua
+++ b/.luals/redm-natives/EVENT.lua
@@ -1,0 +1,298 @@
+---@meta
+
+-- RDR3 namespace: EVENT -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x18E93EBFC1FCFA48  (0x18E93EBFC1FCFA48)
+-- Only used in R* SP Script beat_rat_infestation and homeinvasion
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+---@param p2 boolean
+---@return any
+function N_0x18E93EBFC1FCFA48(volume, p1, p2) end
+
+-- _0x1A5C5D350068A673  (0x1A5C5D350068A673)
+-- AGGRO_CHECK_PROPERTY_DAMAGE: Property damage found with event
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x1A5C5D350068A673(ped, p1) end
+
+-- _0x1D1B448D719415AB  (0x1D1B448D719415AB)
+-- _GET*
+-- min build: 1207
+---@param ped number
+---@return any
+function N_0x1D1B448D719415AB(ped) end
+
+-- _0x26054EB81AC0893B  (0x26054EB81AC0893B)
+-- min build: 1207
+---@param object number
+---@return boolean
+function N_0x26054EB81AC0893B(object) end
+
+-- _0x2DD42FAD06E6F19E  (0x2DD42FAD06E6F19E)
+-- min build: 1207
+---@param object number
+---@param p1 boolean
+---@param p2 boolean
+---@return any
+function N_0x2DD42FAD06E6F19E(object, p1, p2) end
+
+-- _0x36D0F2BA2C0D9BDE  (0x36D0F2BA2C0D9BDE)
+-- _ADD* (_ADD_SHOCKING_EVENT_* ?)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@return any
+function N_0x36D0F2BA2C0D9BDE(entity, p1) end
+
+-- _0x4465C3D1475BD3FD  (0x4465C3D1475BD3FD)
+-- min build: 1207
+---@param model number
+function N_0x4465C3D1475BD3FD(model) end
+
+-- _0x4B2B1A891D437CA7  (0x4B2B1A891D437CA7)
+-- Only used in R* SP Script coachrobberies
+-- _SET_S*
+-- min build: 1207
+---@param p0 number
+function N_0x4B2B1A891D437CA7(p0) end
+
+-- _0x56B3410626A473E7  (0x56B3410626A473E7)
+-- Only used in R* SP Script beat_rat_infestation
+-- Params: p0 = value returned by 0x18E93EBFC1FCFA48
+-- min build: 1207
+---@param p0 any
+function N_0x56B3410626A473E7(p0) end
+
+-- _0x7C511E91738A0828  (0x7C511E91738A0828)
+-- Only used in R* SP Scripts
+-- Hash only used in R* Script mob3.ysc: ROBBERY
+-- _ADD_PED*
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+---@param p2 number
+---@param p3 number
+function N_0x7C511E91738A0828(ped1, ped2, p2, p3) end
+
+-- _0x83D43F0FD5276E4D  (0x83D43F0FD5276E4D)
+-- _GET*
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@return any
+function N_0x83D43F0FD5276E4D(entity, p1) end
+
+-- _0x9520175B35E2268D  (0x9520175B35E2268D)
+-- _SET_P*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x9520175B35E2268D(ped, p1) end
+
+-- _0xA86B0EE9B39D15D6  (0xA86B0EE9B39D15D6)
+-- min build: 1207
+---@param object number
+function N_0xA86B0EE9B39D15D6(object) end
+
+-- _0xAD17A18215DD23D6  (0xAD17A18215DD23D6)
+-- Might return time since some (?) event.
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@param p2 number
+---@return number
+function N_0xAD17A18215DD23D6(entity, p1, p2) end
+
+-- _0xB6F4825153920582  (0xB6F4825153920582)
+-- _S* (_SUPPRESS_EVENTS_NEXT_FRAME?)
+-- min build: 1207
+function N_0xB6F4825153920582() end
+
+-- _0xE28D7FC9FD32ABEB  (0xE28D7FC9FD32ABEB)
+-- HAS_ACTOR_RECEIVED_TRACKED_EVENT_THAT_SHOULD_ALERT - iTimeSinceEvent >= iTimeLimitMS
+-- min build: 1311
+---@param entity number
+---@param eventType number
+---@param p2 number
+function N_0xE28D7FC9FD32ABEB(entity, eventType, p2) end
+
+-- _0xE2C2FBB7825FFC66  (0xE2C2FBB7825FFC66)
+-- min build: 1207
+function N_0xE2C2FBB7825FFC66() end
+
+-- _ADD_MODEL_TO_EVENT_MONITOR  (0x608AD36A644A97FE)
+-- Models used in the scripts: P_REGISTER05X, P_REGISTER06X, P_REGISTER03X, PLAYER_ZERO, PLAYER_THREE, A_C_HORSE_MORGAN_FLAXENCHESTNUT
+-- min build: 1207
+---@param model number
+---@param p1 boolean
+---@param p2 boolean
+function _AddModelToEventMonitor(model, p1, p2) end
+
+-- _CREATE_SHOCKING_EVENT  (0xCA1315C33B9A2847)
+-- min build: 1207
+---@return number
+---@return any
+function _CreateShockingEvent() end
+
+-- _EVENT_FLUSH_ALL_EVENT_TRACKERS  (0xAD8F2424C6E1E3A8)
+-- min build: 1207
+---@param ped number
+function _EventFlushAllEventTrackers(ped) end
+
+-- _EVENT_GET_RECENT_EVENT  (0x796EECFF0C6D39BE)
+-- Returns eventType
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@param p2 number
+---@return number
+function _EventGetRecentEvent(entity, p1, p2) end
+
+-- _EVENT_GET_SOURCE_ENTITY_FROM_EVENT  (0x822A001BCEA5BD81)
+-- min build: 1207
+---@param entity number
+---@param eventType number
+---@param p2 number
+---@param p3 number
+---@return number
+function _EventGetSourceEntityFromEvent(entity, eventType, p2, p3) end
+
+-- _EVENT_GET_TARGET_ENTITY_FROM_EVENT  (0x38497F139981C5C9)
+-- min build: 1207
+---@param entity number
+---@param eventType number
+---@param p2 number
+---@param p3 number
+---@return number
+function _EventGetTargetEntityFromEvent(entity, eventType, p2, p3) end
+
+-- _EVENT_GET_TIME_SINCE_EVENT  (0xC6A7DC546E94FED5)
+-- min build: 1207
+---@param entity number
+---@param eventType number
+---@param p2 number
+---@param p3 number
+---@return number
+function _EventGetTimeSinceEvent(entity, eventType, p2, p3) end
+
+-- _IS_EVENT_TRACKER_ACTIVE  (0x797B3D4D92E56094)
+-- min build: 1207
+---@param eventName string
+---@param shockingEvent number
+---@return boolean
+function _IsEventTrackerActive(eventName, shockingEvent) end
+
+-- _REMOVE_ALL_SHOCKING_EVENTS_IN_AREA  (0xB4C71BA9CAB097BD)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 boolean
+function _RemoveAllShockingEventsInArea(x, y, z, radius, p4) end
+
+-- _REMOVE_ALL_SHOCKING_EVENTS_OF_TYPE_IN_AREA  (0x6A648D42BF271DC7)
+-- eventType: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- min build: 1207
+---@param eventType number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p5 boolean
+function _RemoveAllShockingEventsOfTypeInArea(eventType, x, y, z, radius, p5) end
+
+-- _SET_EVENT_TRACKER_FOR_PED  (0xBB1E41DD3D3C6250)
+-- min build: 1207
+---@param ped number
+---@param eventName string
+---@param p2 number
+function _SetEventTrackerForPed(ped, eventName, p2) end
+
+-- ADD_SHOCKING_EVENT_AT_POSITION  (0xD9F8455409B525E9)
+-- eventType: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- https://github.com/femga/rdr3_discoveries/blob/master/AI/EVENTS
+-- min build: 1207
+---@param eventType number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@return number
+function AddShockingEventAtPosition(eventType, x, y, z, p4, p5, p6, p7, p8, p9, p10) end
+
+-- ADD_SHOCKING_EVENT_FOR_ENTITY  (0x7FD8F3BE76F89422)
+-- eventType: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- min build: 1207
+---@param eventType number
+---@param entity number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 boolean
+---@param p9 boolean
+---@param p10 number
+---@param p11 number
+---@return number
+function AddShockingEventForEntity(eventType, entity, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) end
+
+-- IS_SHOCKING_EVENT_IN_SPHERE  (0x9DB47E16060D6354)
+-- eventType: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- min build: 1207
+---@param eventType number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function IsShockingEventInSphere(eventType, x, y, z, radius) end
+
+-- REMOVE_ALL_SHOCKING_EVENTS  (0xD47A168C2AB90DC4)
+-- min build: 1207
+---@param p0 boolean
+function RemoveAllShockingEvents(p0) end
+
+-- REMOVE_ALL_SHOCKING_EVENTS_OF_TYPE  (0x118873DD538490B4)
+-- eventType: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- min build: 1207
+---@param eventType number
+---@param p1 boolean
+function RemoveAllShockingEventsOfType(eventType, p1) end
+
+-- REMOVE_SHOCKING_EVENT  (0xE8BB3CC253A34559)
+-- min build: 1207
+---@param event number
+---@return boolean
+function RemoveShockingEvent(event) end
+
+-- REMOVE_SHOCKING_EVENT_SPAWN_BLOCKING_AREAS  (0xDB249021652420C5)
+-- min build: 1207
+function RemoveShockingEventSpawnBlockingAreas() end
+
+-- SET_DECISION_MAKER  (0x8AE2F981CDDB8FA4)
+-- min build: 1207
+---@param ped number
+---@param name number
+function SetDecisionMaker(ped, name) end
+
+-- SET_DECISION_MAKER_TO_DEFAULT  (0x6B9C5C38838FB6E6)
+-- min build: 1207
+---@param ped number
+function SetDecisionMakerToDefault(ped) end
+
+-- SUPPRESS_SHOCKING_EVENTS_NEXT_FRAME  (0x84994FAD4E4E4E69)
+-- min build: 1207
+function SuppressShockingEventsNextFrame() end

--- a/.luals/redm-natives/FIRE.lua
+++ b/.luals/redm-natives/FIRE.lua
@@ -1,0 +1,351 @@
+---@meta
+
+-- RDR3 namespace: FIRE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x24DB6B9F2B719043  (0x24DB6B9F2B719043)
+-- Only used in R* SP Related Camp Scripts
+-- min build: 1207
+---@param p0 number
+function N_0x24DB6B9F2B719043(p0) end
+
+-- _0x41B87A6495EE13DD  (0x41B87A6495EE13DD)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@return any
+function N_0x41B87A6495EE13DD(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _0x68F6A75FDF5A70D6  (0x68F6A75FDF5A70D6)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+function N_0x68F6A75FDF5A70D6(x, y, z, p3) end
+
+-- _0x754937C28271BC65  (0x754937C28271BC65)
+-- min build: 1207
+---@param p0 any
+function N_0x754937C28271BC65(p0) end
+
+-- _ADD_EXPLOSION_WITH_DAMAGE_CAUSER  (0xB7DF150605EEDC9B)
+-- Adds an explosion with entity as damage causer.
+-- explosionType: see ADD_EXPLOSION
+-- _A* - _ADD_D*
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@param x number
+---@param y number
+---@param z number
+---@param explosionType number
+---@param damageScale number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param cameraShake number
+function _AddExplosionWithDamageCauser(entity, p1, x, y, z, explosionType, damageScale, isAudible, isInvisible, cameraShake) end
+
+-- _ADD_EXPLOSION_WITH_USER_VFX_AND_DAMAGE_CAUSER  (0x34AE85C7CA4857AA)
+-- Adds an explosion with vfx and entity as damage causer.
+-- explosionFx: see ADD_EXPLOSION_WITH_USER_VFX
+-- _A* - _ADD_D*
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param x number
+---@param y number
+---@param z number
+---@param explosionType number
+---@param explosionFx number
+---@param damageScale number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param cameraShake number
+function _AddExplosionWithUserVfxAndDamageCauser(entity, p1, x, y, z, explosionType, explosionFx, damageScale, isAudible, isInvisible, cameraShake) end
+
+-- _GET_CLOSEST_FIRE_POS_IN_VOLUME  (0x559FC1D310813031)
+-- min build: 1232
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return boolean
+---@return vector3
+function _GetClosestFirePosInVolume(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- _IS_ENTITY_BEING_DAMAGED_BY_FIRE  (0xA4454592DCF7C992)
+-- Returns true if entity is being damaged by fire, once damage caused to entity by fire (like burned appearance) has cleared over time, the native returns false.
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsEntityBeingDamagedByFire(entity) end
+
+-- _IS_ENTITY_CONSUMED_BY_FIRE  (0xCDC25355C0D65963)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _IsEntityConsumedByFire(entity) end
+
+-- _IS_EXPLOSION_IN_VOLUME  (0xE24822A4CFC9107A)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param explosionType number
+---@param volume number
+---@return boolean
+function _IsExplosionInVolume(explosionType, volume) end
+
+-- _IS_PED_SHOCKING_EVENT_ACTIVE  (0xAB7993BA61A4674F)
+-- Tested with fire & dynamite. Only returns true using value p1 = 1 and when the ped is affected by fire.
+-- min build: 1232
+---@param ped number
+---@param p1 number
+---@return boolean
+function _IsPedShockingEventActive(ped, p1) end
+
+-- _STOP_FIRE_IN_BOX  (0xB7C7BDC375AEA9A4)
+-- min build: 1207
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+function _StopFireInBox(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- ADD_EXPLOSION  (0x7D6F58F69DA92530)
+-- https://github.com/femga/rdr3_discoveries/tree/master/graphics/explosions
+-- 
+-- explosionType:
+-- enum eExplosionTag
+-- {
+-- 	EXP_TAG_DONTCARE = -1,
+-- 	EXP_TAG_GRENADE,
+-- 	EXP_TAG_STICKYBOMB,
+-- 	EXP_TAG_MOLOTOV,
+-- 	EXP_TAG_MOLOTOV_VOLATILE,
+-- 	EXP_TAG_HI_OCTANE,
+-- 	EXP_TAG_CAR,
+-- 	EXP_TAG_PLANE,
+-- 	EXP_TAG_PETROL_PUMP,
+-- 	EXP_TAG_DIR_STEAM,
+-- 	EXP_TAG_DIR_FLAME,
+-- 	EXP_TAG_DIR_WATER_HYDRANT,
+-- 	EXP_TAG_BOAT,
+-- 	EXP_TAG_BULLET,
+-- 	EXP_TAG_SMOKEGRENADE,
+-- 	EXP_TAG_BZGAS,
+-- 	EXP_TAG_GAS_CANISTER,
+-- 	EXP_TAG_EXTINGUISHER,
+-- 	EXP_TAG_TRAIN,
+-- 	EXP_TAG_DIR_FLAME_EXPLODE,
+-- 	EXP_TAG_VEHICLE_BULLET,
+-- 	EXP_TAG_BIRD_CRAP,
+-- 	EXP_TAG_FIREWORK,
+-- 	EXP_TAG_TORPEDO,
+-- 	EXP_TAG_TORPEDO_UNDERWATER,
+-- 	EXP_TAG_LANTERN,
+-- 	EXP_TAG_DYNAMITE,
+-- 	EXP_TAG_DYNAMITESTACK,
+-- 	EXP_TAG_DYNAMITE_VOLATILE,
+-- 	EXP_TAG_RIVER_BLAST,
+-- 	EXP_TAG_PLACED_DYNAMITE,
+-- 	EXP_TAG_FIRE_ARROW,
+-- 	EXP_TAG_DYNAMITE_ARROW,
+-- 	EXP_TAG_PHOSPHOROUS_BULLET,
+-- 	EXP_TAG_LIGHTNING_STRIKE,
+-- 	EXP_TAG_TRACKING_ARROW,
+-- 	EXP_TAG_POISON_BOTTLE
+-- };
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param explosionType number
+---@param damageScale number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param cameraShake number
+function AddExplosion(x, y, z, explosionType, damageScale, isAudible, isInvisible, cameraShake) end
+
+-- ADD_EXPLOSION_WITH_USER_VFX  (0x53BA259F3A67A99E)
+-- Changes explosionFx (Visual Effect) for specified explosionType
+-- explosionType: see ADD_EXPLOSION
+-- explosionFx: https://github.com/femga/rdr3_discoveries/blob/master/graphics/explosions/explosion_vfxTags.lua
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param explosionType number
+---@param explosionFx number
+---@param damageScale number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param cameraShake number
+function AddExplosionWithUserVfx(x, y, z, explosionType, explosionFx, damageScale, isAudible, isInvisible, cameraShake) end
+
+-- ADD_OWNED_EXPLOSION  (0xD84A917A64D4D016)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param explosionType number
+---@param damageScale number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param cameraShake number
+function AddOwnedExplosion(ped, x, y, z, explosionType, damageScale, isAudible, isInvisible, cameraShake) end
+
+-- GET_CLOSEST_FIRE_POS  (0xB646FB657F448261)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return vector3
+function GetClosestFirePos(x, y, z) end
+
+-- GET_NUMBER_OF_FIRES_IN_RANGE  (0xF9617BC6FAE61E08)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return number
+function GetNumberOfFiresInRange(x, y, z, radius) end
+
+-- GET_OWNER_OF_EXPLOSION_IN_ANGLED_AREA  (0x8002DDAB58594D78)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param explosionType number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param radius number
+---@return number
+function GetOwnerOfExplosionInAngledArea(explosionType, x1, y1, z1, x2, y2, z2, radius) end
+
+-- IS_ENTITY_ON_FIRE  (0x1BD7C371CE257C3E)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityOnFire(entity) end
+
+-- IS_EXPLOSION_ACTIVE_IN_AREA  (0xD96E82AEBFFAAFF0)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param explosionType number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@return boolean
+function IsExplosionActiveInArea(explosionType, x1, y1, z1, x2, y2, z2) end
+
+-- IS_EXPLOSION_IN_ANGLED_AREA  (0x5AE661ECD18524C9)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param explosionType number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param angle number
+---@return boolean
+function IsExplosionInAngledArea(explosionType, x1, y1, z1, x2, y2, z2, angle) end
+
+-- IS_EXPLOSION_IN_AREA  (0x8391BA4313A25AD3)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param explosionType number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@return boolean
+function IsExplosionInArea(explosionType, x1, y1, z1, x2, y2, z2) end
+
+-- IS_EXPLOSION_IN_SPHERE  (0xD62DD846D82CBB90)
+-- explosionType: see ADD_EXPLOSION
+-- min build: 1207
+---@param explosionType number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function IsExplosionInSphere(explosionType, x, y, z, radius) end
+
+-- REMOVE_SCRIPT_FIRE  (0x790125C36E194069)
+-- min build: 1207
+---@param fireHandle number
+function RemoveScriptFire(fireHandle) end
+
+-- START_ENTITY_FIRE  (0xC4DC7418A44D6822)
+-- fireFlags: 2 = zone/env fire, 8 = scorched carcass.
+-- min build: 1207
+---@param entity number
+---@param intensity number
+---@param boneIndex number
+---@param fireFlags number
+function StartEntityFire(entity, intensity, boneIndex, fireFlags) end
+
+-- START_SCRIPT_FIRE  (0x6B83617E04503888)
+-- Starts a fire:
+-- 
+-- xyz: Location of fire
+-- maxChildren: The max amount of times a fire can spread to other objects. Must be 25 or less, or the function will do nothing.
+-- isGasFire: Whether or not the fire is powered by gasoline.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param p4 number
+---@param p5 boolean
+---@param soundsetName string
+---@param p7 number
+---@param p8 number
+---@return number
+function StartScriptFire(x, y, z, p3, p4, p5, soundsetName, p7, p8) end
+
+-- STOP_ENTITY_FIRE  (0x8390751DC40C1E98)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function StopEntityFire(p0, p1) end
+
+-- STOP_FIRE_IN_RANGE  (0xDB38F247BD421708)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+function StopFireInRange(x, y, z, radius) end

--- a/.luals/redm-natives/FLOCK.lua
+++ b/.luals/redm-natives/FLOCK.lua
@@ -1,0 +1,356 @@
+---@meta
+
+-- RDR3 namespace: FLOCK -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0816C31480764AB0  (0x0816C31480764AB0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x0816C31480764AB0(p0, p1, p2, p3) end
+
+-- _0x09EE00B8F858E0BE  (0x09EE00B8F858E0BE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0x09EE00B8F858E0BE(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x1520626FFAFFFA8F  (0x1520626FFAFFFA8F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1520626FFAFFFA8F(p0, p1) end
+
+-- _0x17E3E5C46ECCD308  (0x17E3E5C46ECCD308)
+-- _SET_G* - _SET_H*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x17E3E5C46ECCD308(p0, p1, p2) end
+
+-- _0x19870C40C7EE15BE  (0x19870C40C7EE15BE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x19870C40C7EE15BE(p0, p1) end
+
+-- _0x1DA6CB02071055D5  (0x1DA6CB02071055D5)
+-- min build: 1207
+---@param p0 any
+---@return vector3
+function N_0x1DA6CB02071055D5(p0) end
+
+-- _0x2DF3D457D86F8E57  (0x2DF3D457D86F8E57)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x2DF3D457D86F8E57(p0, p1) end
+
+-- _0x34B9C4D86DF2C2F3  (0x34B9C4D86DF2C2F3)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x34B9C4D86DF2C2F3(p0) end
+
+-- _0x36486AF7DA93A464  (0x36486AF7DA93A464)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x36486AF7DA93A464(p0) end
+
+-- _0x53187E563F938E76  (0x53187E563F938E76)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x53187E563F938E76(p0) end
+
+-- _0x6C57BEA886A20C6B  (0x6C57BEA886A20C6B)
+-- _SET_G* - _SET_H*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x6C57BEA886A20C6B(p0, p1) end
+
+-- _0x706B434FEFAD6A24  (0x706B434FEFAD6A24)
+-- min build: 1207
+---@param p0 any
+function N_0x706B434FEFAD6A24(p0) end
+
+-- _0x8049B17BEC937662  (0x8049B17BEC937662)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0x8049B17BEC937662(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xA881F5C77A560906  (0xA881F5C77A560906)
+-- min build: 1207
+---@param p0 any
+function N_0xA881F5C77A560906(p0) end
+
+-- _0xC3D581A34BC0A1F0  (0xC3D581A34BC0A1F0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xC3D581A34BC0A1F0(p0, p1) end
+
+-- _0xC72CE37081DAE625  (0xC72CE37081DAE625)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xC72CE37081DAE625(p0, p1, p2, p3) end
+
+-- _0xC95611869E14F8AF  (0xC95611869E14F8AF)
+-- _SET_G* - _SET_H*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xC95611869E14F8AF(p0, p1, p2, p3) end
+
+-- _0xCC6B5AAFC87BFC7B  (0xCC6B5AAFC87BFC7B)
+-- _SET_G* - _SET_H*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xCC6B5AAFC87BFC7B(p0, p1, p2) end
+
+-- _0xD95F04A4E73BE85E  (0xD95F04A4E73BE85E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xD95F04A4E73BE85E(p0, p1) end
+
+-- _0xE36D2CB540597EF7  (0xE36D2CB540597EF7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function N_0xE36D2CB540597EF7(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0xE93415B3307208E5  (0xE93415B3307208E5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@return any
+function N_0xE93415B3307208E5(p0, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- _0xF2CCA7B68CFAB2B9  (0xF2CCA7B68CFAB2B9)
+-- species: SPECIES_BIRD_CROW
+-- min build: 1207
+---@param species number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param x3 number
+---@param y3 number
+---@param z3 number
+---@param p10 number
+---@param p11 number
+---@param p12 number
+---@param p13 number
+function N_0xF2CCA7B68CFAB2B9(species, x1, y1, z1, x2, y2, z2, x3, y3, z3, p10, p11, p12, p13) end
+
+-- _0xFA821997794F48E7  (0xFA821997794F48E7)
+-- _SET_G* - _SET_H*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xFA821997794F48E7(p0, p1, p2) end
+
+-- _0xFB16F08F47B83B4C  (0xFB16F08F47B83B4C)
+-- min build: 1207
+---@param p0 any
+function N_0xFB16F08F47B83B4C(p0) end
+
+-- _0xFDB008B3BCF5992F  (0xFDB008B3BCF5992F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xFDB008B3BCF5992F(p0, p1, p2) end
+
+-- _0xFF1E339CE40EAAAF  (0xFF1E339CE40EAAAF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFF1E339CE40EAAAF(p0, p1) end
+
+-- _ADD_PED_TO_FLOCK  (0x933E5D31A7D13069)
+-- min build: 1207
+---@param p0 any
+---@param ped number
+function _AddPedToFlock(p0, ped) end
+
+-- _CLEAR_HERD  (0x67A43EA3F6FE0076)
+-- min build: 1207
+---@param herdHandle number
+function _ClearHerd(herdHandle) end
+
+-- _CREATE_HERD  (0xCB4EF7EDAE2E16F1)
+-- min build: 1207
+---@return number
+function _CreateHerd() end
+
+-- _DELETE_HERD  (0xE0961AED72642B80)
+-- min build: 1207
+---@param herdHandle number
+function _DeleteHerd(herdHandle) end
+
+-- _GET_ANIMAL_IS_WILD  (0x3B005FF0538ED2A9)
+-- Ped (horse) will run away from players and mounting will trigger them to buck until disabled.
+-- Used for: REL_DOMESTICATED_ANIMAL
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _GetAnimalIsWild(ped) end
+
+-- _GET_ANIMAL_RARITY  (0xF8B48A361DC388AE)
+-- enum eAnimalRarityLevel
+-- {
+-- 	ARL_COMMON,
+-- 	ARL_RARE,
+-- 	ARL_LEGENDARY,
+-- 	ARL_NUMRARITYLEVELS
+-- };
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetAnimalRarity(ped) end
+
+-- _IS_HERD_VALID  (0x8D913E493BAFE0A3)
+-- min build: 1207
+---@param herdHandle number
+---@return boolean
+function _IsHerdValid(herdHandle) end
+
+-- _IS_PED_IN_HERD  (0x9E13ACC38BA8F9C3)
+-- _IS_E* - _IS_M*
+-- min build: 1207
+---@param herdHandle number
+---@param ped number
+---@return boolean
+function _IsPedInHerd(herdHandle, ped) end
+
+-- _REMOVE_HERD_PED  (0x408D1149C5E39C1E)
+-- min build: 1207
+---@param herdHandle number
+---@param ped number
+function _RemoveHerdPed(herdHandle, ped) end
+
+-- _SET_ANIMAL_IS_WILD  (0xAEB97D84CDF3C00B)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetAnimalIsWild(ped, toggle) end
+
+-- _SET_ANIMAL_RARITY  (0x8B6F0F59B1B99801)
+-- rarityLevel: see _GET_ANIMAL_RARITY
+-- min build: 1207
+---@param ped number
+---@param rarityLevel number
+function _SetAnimalRarity(ped, rarityLevel) end
+
+-- GET_ANIMAL_TUNING_BOOL_PARAM  (0x1C1993824A396603)
+-- index: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eAnimalTuningBools
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/ANIMAL_TUNING_BOOL_PARAMS
+-- min build: 1207
+---@param animal number
+---@param index number
+---@return boolean
+function GetAnimalTuningBoolParam(animal, index) end
+
+-- GET_ANIMAL_TUNING_FLOAT_PARAM  (0x4BC3ECFDA0297E27)
+-- index: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eAnimalTuningFloats
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/ANIMAL_TUNING_FLOAT_PARAMS
+-- min build: 1207
+---@param animal number
+---@param index number
+---@return number
+function GetAnimalTuningFloatParam(animal, index) end
+
+-- GET_SPECIES_TUNING_FLOAT_PARAM  (0xE108489621422F91)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@return number
+function GetSpeciesTuningFloatParam(p0, p1, p2) end
+
+-- RESET_ANIMAL_TUNING_BOOL_PARAM  (0x96AA1304D30E6BC3)
+-- min build: 1355
+---@param animal number
+---@param index number
+function ResetAnimalTuningBoolParam(animal, index) end
+
+-- RESET_ANIMAL_TUNING_FLOAT_PARAM  (0xE776A195488FC520)
+-- min build: 1355
+---@param animal number
+---@param index number
+function ResetAnimalTuningFloatParam(animal, index) end
+
+-- SET_ANIMAL_TUNING_BOOL_PARAM  (0x9FF1E042FA597187)
+-- min build: 1207
+---@param animal number
+---@param index number
+---@param value boolean
+function SetAnimalTuningBoolParam(animal, index, value) end
+
+-- SET_ANIMAL_TUNING_FLOAT_PARAM  (0xCBDA22C87977244F)
+-- min build: 1207
+---@param animal number
+---@param index number
+---@param value number
+function SetAnimalTuningFloatParam(animal, index, value) end
+
+-- SET_SPECIES_TUNING_BOOL_PARAM  (0x6D1D94C2459B42EE)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 boolean
+function SetSpeciesTuningBoolParam(p0, p1, p2, p3) end
+
+-- SET_SPECIES_TUNING_FLOAT_PARAM  (0x963240B6C252BA49)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+function SetSpeciesTuningFloatParam(p0, p1, p2, p3) end

--- a/.luals/redm-natives/GANG.lua
+++ b/.luals/redm-natives/GANG.lua
@@ -1,0 +1,257 @@
+---@meta
+
+-- RDR3 namespace: GANG -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0E5C9FB9ED5DFF1C  (0x0E5C9FB9ED5DFF1C)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x0E5C9FB9ED5DFF1C(p0) end
+
+-- _0x1F11702DDBD915C6  (0x1F11702DDBD915C6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x1F11702DDBD915C6(p0, p1) end
+
+-- _0x2F7EB8B6F6AFE79C  (0x2F7EB8B6F6AFE79C)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2F7EB8B6F6AFE79C(p0) end
+
+-- _0x3ADC71A66356D706  (0x3ADC71A66356D706)
+-- min build: 1207
+---@return any
+function N_0x3ADC71A66356D706() end
+
+-- _0x48D82C83987E18E4  (0x48D82C83987E18E4)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x48D82C83987E18E4(p0) end
+
+-- _0x51C5EF47086AA0D7  (0x51C5EF47086AA0D7)
+-- min build: 1207
+---@return any
+function N_0x51C5EF47086AA0D7() end
+
+-- _0x53A94294FDDCF98C  (0x53A94294FDDCF98C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x53A94294FDDCF98C(p0, p1) end
+
+-- _0x6102830F764B3DE1  (0x6102830F764B3DE1)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x6102830F764B3DE1(player) end
+
+-- _0x644E02F24F9D4E98  (0x644E02F24F9D4E98)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x644E02F24F9D4E98(p0, p1) end
+
+-- _0x7933754F260B428A  (0x7933754F260B428A)
+-- min build: 1207
+---@param player number
+---@return any
+function N_0x7933754F260B428A(player) end
+
+-- _0x7BAA30C9BBE8AEE7  (0x7BAA30C9BBE8AEE7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x7BAA30C9BBE8AEE7(p0, p1) end
+
+-- _0xA9CEAE8D6637FBAD  (0xA9CEAE8D6637FBAD)
+-- min build: 1207
+---@param p0 any
+function N_0xA9CEAE8D6637FBAD(p0) end
+
+-- _0xAD22AB64FA428DF3  (0xAD22AB64FA428DF3)
+-- min build: 1207
+---@param p0 any
+function N_0xAD22AB64FA428DF3(p0) end
+
+-- _0xAFD3599A3CC5637D  (0xAFD3599A3CC5637D)
+-- min build: 1207
+---@return any
+function N_0xAFD3599A3CC5637D() end
+
+-- _0xB22B1D9F74095382  (0xB22B1D9F74095382)
+-- min build: 1207
+---@param p0 any
+function N_0xB22B1D9F74095382(p0) end
+
+-- _0xB38C256498748413  (0xB38C256498748413)
+-- min build: 1207
+function N_0xB38C256498748413() end
+
+-- _0xC81A9E2C8EFD28D5  (0xC81A9E2C8EFD28D5)
+-- min build: 1207
+---@param p0 any
+function N_0xC81A9E2C8EFD28D5(p0) end
+
+-- _0xDA801F7F6A5278D3  (0xDA801F7F6A5278D3)
+-- _NETWORK_GET_* or _NETWORK_IS_*
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0xDA801F7F6A5278D3(player) end
+
+-- _0xE4C64CD37CB176AA  (0xE4C64CD37CB176AA)
+-- min build: 1207
+---@param p0 number
+---@return any
+function N_0xE4C64CD37CB176AA(p0) end
+
+-- _0xEE4F20004D0288B7  (0xEE4F20004D0288B7)
+-- min build: 1207
+function N_0xEE4F20004D0288B7() end
+
+-- _0xFA7C5B7E087A4CEB  (0xFA7C5B7E087A4CEB)
+-- min build: 1207
+---@return any
+function N_0xFA7C5B7E087A4CEB() end
+
+-- _NETWORK_GET_GANG_LEADER_HANDLE  (0xCE88A261DCBBA0D9)
+-- min build: 1207
+---@param gangId any
+---@return boolean
+---@return any
+function _NetworkGetGangLeaderHandle(gangId) end
+
+-- _NETWORK_GET_GANG_MEMBERS  (0xD1BF325C8252A982)
+-- min build: 1207
+---@param gangId any
+---@return number
+---@return any
+function _NetworkGetGangMembers(gangId) end
+
+-- _NETWORK_GET_GANG_PRIVACY  (0x9970AE8C3D706139)
+-- min build: 1207
+---@return number
+function _NetworkGetGangPrivacy() end
+
+-- _NETWORK_GET_GANG_SIZE  (0x853B0FA4D8732C57)
+-- min build: 1207
+---@param gangId any
+---@return number
+function _NetworkGetGangSize(gangId) end
+
+-- _NETWORK_IS_GANG_MEMBER  (0x9BE7DCB22D32CCBE)
+-- min build: 1207
+---@param gangId any
+---@param player number
+---@return boolean
+function _NetworkIsGangMember(gangId, player) end
+
+-- _NETWORK_IS_GANG_OPEN  (0xFCF96CCBD81B24C8)
+-- min build: 1207
+---@param gangId any
+---@return boolean
+function _NetworkIsGangOpen(gangId) end
+
+-- _NETWORK_IS_IN_MY_GANG  (0x81FB74C83C2ED69F)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _NetworkIsInMyGang(player) end
+
+-- _NETWORK_KICK_GANG_MEMBER  (0xCD9E2D9BC52FD80F)
+-- banTimeSeconds is 120 in R* Scripts
+-- min build: 1207
+---@param player number
+---@param banTimeSeconds number
+function _NetworkKickGangMember(player, banTimeSeconds) end
+
+-- _NETWORK_LEAVE_GANG  (0x0A04A07BC3074EDB)
+-- min build: 1207
+---@param disband boolean
+function _NetworkLeaveGang(disband) end
+
+-- _NETWORK_REQUEST_GANG_JOIN  (0xC0474C8BCF6787AD)
+-- Returns true if join succeeded, false if failed.
+-- min build: 1207
+---@param gangId any
+---@return boolean
+function _NetworkRequestGangJoin(gangId) end
+
+-- _NETWORK_SET_GANG_PRIVACY  (0xC5BF29F4035277C2)
+-- min build: 1207
+---@param privacyType number
+---@return boolean
+function _NetworkSetGangPrivacy(privacyType) end
+
+-- _NETWORK_SET_GANG_SIZE  (0x833D8268D51B4522)
+-- min build: 1207
+---@param size number
+---@return boolean
+function _NetworkSetGangSize(size) end
+
+-- _NETWORK_START_GANG  (0xD1A226F2E05E58FC)
+-- openStatus = true -> sets privacyType = 2 (PUBLIC_ADVERTISED)
+-- openStatus = false -> sets privacyType = 1 (INVITE_ONLY)
+-- 
+-- campSize: NET_CAMP_SIZE_SMALLEST = 4, NET_CAMP_SIZE_LARGEST = 7
+-- min build: 1207
+---@param openStatus boolean
+---@param campSize number
+function _NetworkStartGang(openStatus, campSize) end
+
+-- NETWORK_GET_GANG_ID  (0x901E0DC25080C8B9)
+-- min build: 1207
+---@param player number
+---@return any
+function NetworkGetGangId(player) end
+
+-- NETWORK_GET_GANG_LEADER  (0x4BE6C13A45CCA8EC)
+-- min build: 1207
+---@param gangId any
+---@return number
+function NetworkGetGangLeader(gangId) end
+
+-- NETWORK_GET_NUM_GANG_MEMBERS  (0x149A2751AB66AC02)
+-- min build: 1207
+---@param gangId any
+---@return number
+function NetworkGetNumGangMembers(gangId) end
+
+-- NETWORK_IS_GANG_ACTIVE  (0x0F99F6436528A089)
+-- min build: 1207
+---@param gangId any
+---@return boolean
+function NetworkIsGangActive(gangId) end
+
+-- NETWORK_IS_GANG_ID_VALID  (0xD6F6ACF4392187FB)
+-- min build: 1207
+---@param gangId any
+---@return boolean
+function NetworkIsGangIdValid(gangId) end
+
+-- NETWORK_IS_GANG_IN_SESSION  (0x93A91A351A07360E)
+-- min build: 1207
+---@param gangId any
+---@return boolean
+function NetworkIsGangInSession(gangId) end
+
+-- NETWORK_IS_GANG_LEADER  (0x424B17A7DC5C90BC)
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsGangLeader(player) end
+
+-- NETWORK_IS_IN_SAME_GANG  (0x3F59FE6F37869576)
+-- min build: 1207
+---@param player1 number
+---@param player2 number
+---@return boolean
+function NetworkIsInSameGang(player1, player2) end

--- a/.luals/redm-natives/GOOGLE_ANALYTICS.lua
+++ b/.luals/redm-natives/GOOGLE_ANALYTICS.lua
@@ -1,0 +1,28 @@
+---@meta
+
+-- RDR3 namespace: GOOGLE_ANALYTICS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _GOOGLE_ANALYTICS_END_EVENT  (0x87BBCC4360A9BDE3)
+-- min build: 1355
+---@return boolean
+function _GoogleAnalyticsEndEvent() end
+
+-- _GOOGLE_ANALYTICS_POP_PAGE  (0xC6DE040378364798)
+-- min build: 1207
+---@param pageName string
+function _GoogleAnalyticsPopPage(pageName) end
+
+-- _GOOGLE_ANALYTICS_PUSH_PAGE  (0xD43A616AE3AC4EF6)
+-- min build: 1207
+---@param pageName string
+function _GoogleAnalyticsPushPage(pageName) end
+
+-- _GOOGLE_ANALYTICS_START_EVENT  (0x1C54F031D7C0F7AC)
+-- min build: 1355
+---@param eventCategory string
+---@param eventAction string
+---@param eventLabel string
+---@param eventValue number
+---@return boolean
+function _GoogleAnalyticsStartEvent(eventCategory, eventAction, eventLabel, eventValue) end

--- a/.luals/redm-natives/GRAPHICS.lua
+++ b/.luals/redm-natives/GRAPHICS.lua
@@ -1,0 +1,1985 @@
+---@meta
+
+-- RDR3 namespace: GRAPHICS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x085C5B61A0114F32  (0x085C5B61A0114F32)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x085C5B61A0114F32(p0, p1) end
+
+-- _0x0D5B19C34068FEE7  (0x0D5B19C34068FEE7)
+-- Gets set to 1 when GET_STATUS_OF_TAKE_HIGH_QUALITY_PHOTO = PHOTO_OPERATION_SUCCEEDED
+-- min build: 1311
+---@param p0 any
+function N_0x0D5B19C34068FEE7(p0) end
+
+-- _0x1460B644397453EB  (0x1460B644397453EB)
+-- _RESET_*
+-- min build: 1207
+function N_0x1460B644397453EB() end
+
+-- _0x171C18E994C1A395  (0x171C18E994C1A395)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x171C18E994C1A395(p0, p1, p2, p3, p4) end
+
+-- _0x1A9F09AB458D49C6  (0x1A9F09AB458D49C6)
+-- Used in shop scripts for CATALOG_BOOK
+-- false = Normal -> [CATALOG_BOOK_SHUTDOWN]
+-- true = Trees flickering? -> [CATALOG_BOOK_OPEN]
+-- min build: 1207
+---@param p0 boolean
+function N_0x1A9F09AB458D49C6(p0) end
+
+-- _0x1C6306E5BC25C29C  (0x1C6306E5BC25C29C)
+-- min build: 1207
+function N_0x1C6306E5BC25C29C() end
+
+-- _0x1FF8731BE1DFC0C0  (0x1FF8731BE1DFC0C0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1FF8731BE1DFC0C0(p0, p1) end
+
+-- _0x26DD2FB0A88CC412  (0x26DD2FB0A88CC412)
+-- effectName2, p2 and p3 are unused
+-- 
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectName string
+---@param effectName2 string
+---@param p2 any
+---@param p3 any
+function N_0x26DD2FB0A88CC412(effectName, effectName2, p2, p3) end
+
+-- _0x285438C26C732F9D  (0x285438C26C732F9D)
+-- min build: 1207
+---@return any
+function N_0x285438C26C732F9D() end
+
+-- _0x32DE2BFFDA43E62A  (0x32DE2BFFDA43E62A)
+-- min build: 1207
+function N_0x32DE2BFFDA43E62A() end
+
+-- _0x38D9D50F2085E9B3  (0x38D9D50F2085E9B3)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectNameHash number
+function N_0x38D9D50F2085E9B3(effectNameHash) end
+
+-- _0x3DA7A10583A4BEC0  (0x3DA7A10583A4BEC0)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@return boolean
+function N_0x3DA7A10583A4BEC0() end
+
+-- _0x402E1A61D2587FCD  (0x402E1A61D2587FCD)
+-- Only used in R* SP Script spd_agnesdown1
+-- min build: 1207
+---@param p0 any
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param p5 number
+---@param heading number
+---@return boolean
+function N_0x402E1A61D2587FCD(p0, x, y, z, p4, p5, heading) end
+
+-- _0x4046493D2EEACA0E  (0x4046493D2EEACA0E)
+-- _DISABLE_*
+-- min build: 1207
+function N_0x4046493D2EEACA0E() end
+
+-- _0x41F88A85A579A61D  (0x41F88A85A579A61D)
+-- Used in CREATE_BEZIER_BLOOD_TRAIL_OF_TYPE
+-- min build: 1207
+---@param p0 number
+function N_0x41F88A85A579A61D(p0) end
+
+-- _0x453D16D41FC51D3E  (0x453D16D41FC51D3E)
+-- min build: 1207
+---@param p0 boolean
+function N_0x453D16D41FC51D3E(p0) end
+
+-- _0x48FE0DB54045B975  (0x48FE0DB54045B975)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0x48FE0DB54045B975(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x4BD66B4E3427689B  (0x4BD66B4E3427689B)
+-- Used in CREATE_BEZIER_BLOOD_TRAIL_OF_TYPE
+-- min build: 1207
+---@param p0 string
+function N_0x4BD66B4E3427689B(p0) end
+
+-- _0x4FB67D172C4476F3  (0x4FB67D172C4476F3)
+-- p1: AMB_ANN_COAL_CHUTE_DIVE, AMB_ANN_COAL_CHUTE
+-- p2: EMIT
+-- p3: either 0.0f or 1.0f
+-- min build: 1207
+---@param entity number
+---@param p1 string
+---@param p2 string
+---@param p3 number
+function N_0x4FB67D172C4476F3(entity, p1, p2, p3) end
+
+-- _0x503941F65DBA24EC  (0x503941F65DBA24EC)
+-- min build: 1207
+---@param p0 any
+function N_0x503941F65DBA24EC(p0) end
+
+-- _0x519928DF02EB5101  (0x519928DF02EB5101)
+-- min build: 1355
+---@param p0 any
+function N_0x519928DF02EB5101(p0) end
+
+-- _0x5C674EB487891F6B  (0x5C674EB487891F6B)
+-- min build: 1207
+---@return any
+function N_0x5C674EB487891F6B() end
+
+-- _0x5C9C3A466B3296A8  (0x5C9C3A466B3296A8)
+-- Only used in R* SP Script spd_agnesdown1
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x5C9C3A466B3296A8(p0) end
+
+-- _0x67B0778C62E74423  (0x67B0778C62E74423)
+-- min build: 1207
+---@param p0 any
+function N_0x67B0778C62E74423(p0) end
+
+-- _0x6C03118E9E5C1A14  (0x6C03118E9E5C1A14)
+-- min build: 1207
+---@param p0 any
+function N_0x6C03118E9E5C1A14(p0) end
+
+-- _0x71845905BCCDE781  (0x71845905BCCDE781)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectNameHash number
+function N_0x71845905BCCDE781(effectNameHash) end
+
+-- _0x735762E8D7573E42  (0x735762E8D7573E42)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x735762E8D7573E42(p0, p1, p2) end
+
+-- _0x812C1563185C6FB2  (0x812C1563185C6FB2)
+-- Used in CREATE_BEZIER_BLOOD_TRAIL_OF_TYPE
+-- _ENABLE_*
+-- min build: 1207
+function N_0x812C1563185C6FB2() end
+
+-- _0x815653A42C5ABE76  (0x815653A42C5ABE76)
+-- min build: 1207
+function N_0x815653A42C5ABE76() end
+
+-- _0x8996FA6AD9FE4E90  (0x8996FA6AD9FE4E90)
+-- min build: 1207
+---@param p0 any
+function N_0x8996FA6AD9FE4E90(p0) end
+
+-- _0x910E260AEAD855DE  (0x910E260AEAD855DE)
+-- min build: 1207
+function N_0x910E260AEAD855DE() end
+
+-- _0x94B261F1F35293E1  (0x94B261F1F35293E1)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+function N_0x94B261F1F35293E1(p0) end
+
+-- _0x981C7D863980FA51  (0x981C7D863980FA51)
+-- min build: 1207
+function N_0x981C7D863980FA51() end
+
+-- _0x9D1B0B5066205692  (0x9D1B0B5066205692)
+-- min build: 1207
+function N_0x9D1B0B5066205692() end
+
+-- _0x9F158A49B0D84C3C  (0x9F158A49B0D84C3C)
+-- min build: 1207
+---@param p0 any
+function N_0x9F158A49B0D84C3C(p0) end
+
+-- _0x9F6D859C80708B26  (0x9F6D859C80708B26)
+-- min build: 1311
+---@param p0 boolean
+---@param p1 boolean
+function N_0x9F6D859C80708B26(p0, p1) end
+
+-- _0xA04EF43030593ABC  (0xA04EF43030593ABC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA04EF43030593ABC(p0, p1) end
+
+-- _0xA0F4D12D6042F6D5  (0xA0F4D12D6042F6D5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA0F4D12D6042F6D5(p0, p1) end
+
+-- _0xA15CCAB8AD038291  (0xA15CCAB8AD038291)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xA15CCAB8AD038291(p0, p1, p2, p3) end
+
+-- _0xA1A86055792FB249  (0xA1A86055792FB249)
+-- min build: 1207
+---@param personaPhotoLocalCacheType number
+function N_0xA1A86055792FB249(personaPhotoLocalCacheType) end
+
+-- _0xA201A3D0AC087C37  (0xA201A3D0AC087C37)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectName string
+function N_0xA201A3D0AC087C37(effectName) end
+
+-- _0xA21AF60C9F99CCC5  (0xA21AF60C9F99CCC5)
+-- min build: 1207
+function N_0xA21AF60C9F99CCC5() end
+
+-- _0xB032C085D9A03907  (0xB032C085D9A03907)
+-- _SET_D* or _SET_E*
+-- min build: 1207
+function N_0xB032C085D9A03907() end
+
+-- _0xB958D97A0DFAA0C2  (0xB958D97A0DFAA0C2)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectName string
+---@return boolean
+function N_0xB958D97A0DFAA0C2(effectName) end
+
+-- _0xC06F2F45A73EABCD  (0xC06F2F45A73EABCD)
+-- Used in NET_CAMP_SPIRIT_ANIMAL_CLEAR_ANIMAL_VISIBILITY
+-- min build: 1311
+---@param entity number
+function N_0xC06F2F45A73EABCD(entity) end
+
+-- _0xC28F62AC9774FC1B  (0xC28F62AC9774FC1B)
+-- min build: 1207
+---@return any
+function N_0xC28F62AC9774FC1B() end
+
+-- _0xC37792A3F9C90771  (0xC37792A3F9C90771)
+-- Doesn't actually return anything.
+-- 
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@return any
+function N_0xC37792A3F9C90771() end
+
+-- _0xC489FE31AC726512  (0xC489FE31AC726512)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xC489FE31AC726512(p0, p1) end
+
+-- _0xC76FC4C2FC5F4405  (0xC76FC4C2FC5F4405)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectNameHash number
+function N_0xC76FC4C2FC5F4405(effectNameHash) end
+
+-- _0xCC3B787E73E64160  (0xCC3B787E73E64160)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xCC3B787E73E64160(p0, p1, p2, p3, p4) end
+
+-- _0xD1472AFF30C103D6  (0xD1472AFF30C103D6)
+-- Only used in R* Script nb_stalking_hunter
+-- min build: 1311
+---@param p0 number
+function N_0xD1472AFF30C103D6(p0) end
+
+-- _0xD543487A1F12828F  (0xD543487A1F12828F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xD543487A1F12828F(p0, p1, p2, p3) end
+
+-- _0xD9BC98B55BCFAA9B  (0xD9BC98B55BCFAA9B)
+-- min build: 1207
+---@param p0 any
+function N_0xD9BC98B55BCFAA9B(p0) end
+
+-- _0xE63D68F455CA0B47  (0xE63D68F455CA0B47)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0xE63D68F455CA0B47(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xE75CDDEBF618C8FF  (0xE75CDDEBF618C8FF)
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@param effectNameHash number
+---@return boolean
+function N_0xE75CDDEBF618C8FF(effectNameHash) end
+
+-- _0xEB48CE48EEC41FD4  (0xEB48CE48EEC41FD4)
+-- min build: 1207
+---@param p0 any
+function N_0xEB48CE48EEC41FD4(p0) end
+
+-- _0xEC3D8C228FE553D7  (0xEC3D8C228FE553D7)
+-- min build: 1207
+---@param p0 boolean
+---@return boolean
+function N_0xEC3D8C228FE553D7(p0) end
+
+-- _0xEC3F7F24EEEB3BA3  (0xEC3F7F24EEEB3BA3)
+-- min build: 1207
+function N_0xEC3F7F24EEEB3BA3() end
+
+-- _0xF2F543D48F319A3A  (0xF2F543D48F319A3A)
+-- min build: 1207
+function N_0xF2F543D48F319A3A() end
+
+-- _0xFB680A9B33D0EDBE  (0xFB680A9B33D0EDBE)
+-- _DISABLE_*
+-- min build: 1207
+---@param p0 boolean
+function N_0xFB680A9B33D0EDBE(p0) end
+
+-- _0xFC9B53C072F418E0  (0xFC9B53C072F418E0)
+-- min build: 1207
+---@return any
+function N_0xFC9B53C072F418E0() end
+
+-- _0xFD05B1DDE83749FA  (0xFD05B1DDE83749FA)
+-- R* Script spd_agnesdow1: p0 = SPD_AGNES_DOWD_01
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function N_0xFD05B1DDE83749FA(p0) end
+
+-- _0xFF584F097C17FA8F  (0xFF584F097C17FA8F)
+-- Returns whether the 'killFX' setting is enabled.
+-- 
+-- ANIMPOSTFX_*
+-- min build: 1207
+---@return boolean
+function N_0xFF584F097C17FA8F() end
+
+-- _0xFF8018C778349234  (0xFF8018C778349234)
+-- min build: 1207
+---@param p0 any
+function N_0xFF8018C778349234(p0) end
+
+-- _ADD_BLOOD_POOL  (0xFA2ECC78A6014D4F)
+-- https://i.imgur.com/ULQU9US.jpg
+-- More rounded and small puddle
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param unused boolean
+function _AddBloodPool(x, y, z, unused) end
+
+-- _ADD_BLOOD_POOL_2  (0xF708298675ABDC6A)
+-- https://i.imgur.com/rPITUCV.jpg
+-- More customizable and more like quadrants
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param size number
+---@param p5 number
+---@param permanent boolean
+---@param p7 number
+---@param p8 boolean
+function _AddBloodPool2(x, y, z, p3, size, p5, permanent, p7, p8) end
+
+-- _ADD_BLOOD_POOLS_FOR_PED  (0xDFCE8CE9F3EBE93F)
+-- Creates blood pools for the given ped in some interval for a few seconds.
+-- min build: 1207
+---@param ped number
+function _AddBloodPoolsForPed(ped) end
+
+-- _ADD_BLOOD_POOLS_FOR_PED_WITH_PARAMS  (0xC349EE1E6EFA494B)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param size number
+---@param p3 number
+function _AddBloodPoolsForPedWithParams(ped, p1, size, p3) end
+
+-- _ADD_BLOOD_TRAIL_POINT  (0xDD9DC1AB63D513CE)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function _AddBloodTrailPoint(x, y, z) end
+
+-- _ADD_BLOOD_TRAIL_SPLAT  (0xF5E45CB1CF965D2D)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function _AddBloodTrailSplat(x, y, z) end
+
+-- _ADD_ENTITY_TO_ENTITY_MASK  (0xC6F81FCD15350323)
+-- min build: 1207
+---@param entity number
+---@param mask number
+function _AddEntityToEntityMask(entity, mask) end
+
+-- _ADD_ENTITY_TO_ENTITY_MASK_WITH_INTENSITY  (0x958DEBD9353C0935)
+-- min build: 1207
+---@param entity number
+---@param mask number
+---@param intensity number
+function _AddEntityToEntityMaskWithIntensity(entity, mask, intensity) end
+
+-- _ADD_VEG_MODIFIER_ZONE  (0xBD3324281E8B9933)
+-- Adds Vegetation Blocking Zone, Added Snow Flattening veg mod Zone
+-- Returns veg modifier handle
+-- min build: 1207
+---@param volume number
+---@param p1 number
+---@param flags number
+---@param p3 number
+---@return number
+function _AddVegModifierZone(volume, p1, flags, p3) end
+
+-- _ANIMPOSTFX_CLEAR_EFFECT  (0xC5CB91D65852ED7E)
+-- min build: 1207
+---@param effectName string
+function _AnimpostfxClearEffect(effectName) end
+
+-- _ANIMPOSTFX_GET_STACKHASH  (0x842CCC9491FFCD9B)
+-- Known effects: MP_Trans_SceneToPhoto
+-- MP_Trans_WinLose
+-- SpectateFilter
+-- MP_CharacterCreatorPhoto
+-- MP_Trans_PhotoToScene
+-- InterrogationHit
+-- min build: 1207
+---@param effectName string
+---@return number
+function _AnimpostfxGetStackhash(effectName) end
+
+-- _ANIMPOSTFX_HAS_EVENT_TRIGGERED  (0xFBF161FCFEC8589E)
+-- Returns true if an AnimPostFX event has just been triggered, using an effect name string.
+-- Same kind of event system as ANIMPOSTFX_HAS_EVENT_TRIGGERED_BY_STACKHASH, but keyed by effect name such as "ChapterTitle_IntroCh01".
+-- min build: 1207
+---@param effectName string
+---@param eventType number
+---@param bPeekOnly boolean
+---@return boolean
+---@return boolean
+function _AnimpostfxHasEventTriggered(effectName, eventType, bPeekOnly) end
+
+-- _ANIMPOSTFX_HAS_LOADED  (0xBF2DD155B2ADCD0A)
+-- min build: 1207
+---@param effectName string
+---@return boolean
+function _AnimpostfxHasLoaded(effectName) end
+
+-- _ANIMPOSTFX_IS_STACKHASH_PLAYING  (0xEEF83A759AE06A27)
+-- min build: 1207
+---@param effectNameHash number
+---@return boolean
+function _AnimpostfxIsStackhashPlaying(effectNameHash) end
+
+-- _ANIMPOSTFX_IS_TAG_PLAYING  (0x2D4F9C852CE8A253)
+-- min build: 1207
+---@param effectName string
+---@return boolean
+function _AnimpostfxIsTagPlaying(effectName) end
+
+-- _ANIMPOSTFX_PLAY_TAG  (0x9B8D5D4CB8AF58B3)
+-- min build: 1207
+---@param effectNameHash number
+function _AnimpostfxPlayTag(effectNameHash) end
+
+-- _ANIMPOSTFX_PLAY_TIMED  (0x3A9A281FF71249E9)
+-- min build: 1207
+---@param effectName string
+---@param duration number
+function _AnimpostfxPlayTimed(effectName, duration) end
+
+-- _ANIMPOSTFX_PRELOAD_POSTFX  (0x5199405EABFBD7F0)
+-- min build: 1207
+---@param effectName string
+function _AnimpostfxPreloadPostfx(effectName) end
+
+-- _ANIMPOSTFX_PRELOAD_POSTFX_BY_STACKHASH  (0xF3E039322BFBD4D8)
+-- min build: 1207
+---@param effectNameHash number
+function _AnimpostfxPreloadPostfxByStackhash(effectNameHash) end
+
+-- _ANIMPOSTFX_SET_POSTFX_COLOR  (0x63011D0C7C6519E0)
+-- min build: 1311
+---@param effectName string
+---@param p1 number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+function _AnimpostfxSetPostfxColor(effectName, p1, red, green, blue, alpha) end
+
+-- _ANIMPOSTFX_SET_POTENCY  (0xF972F0AB16DC5260)
+-- Health Core Effect Filter Potency: p1 = 1
+-- Stamina Core Effect Filter Potency: p1 = 2
+-- Multiple Core Effect Filter Potency: p1 = 3
+-- min build: 1207
+---@param effectName string
+---@param p1 number
+---@param potency number
+function _AnimpostfxSetPotency(effectName, p1, potency) end
+
+-- _ANIMPOSTFX_SET_STRENGTH  (0xCAB4DD2D5B2B7246)
+-- must be called after ANIMPOSTFX_PLAY, strength 0.0f - 1.0f
+-- min build: 1207
+---@param effectName string
+---@param strength number
+function _AnimpostfxSetStrength(effectName, strength) end
+
+-- _ANIMPOSTFX_SET_TO_UNLOAD  (0x37D7BDBA89F13959)
+-- min build: 1207
+---@param effectName string
+function _AnimpostfxSetToUnload(effectName) end
+
+-- _ANIMPOSTFX_STOP_STACKHASH_POSTFX  (0xEDA5CBECF56E1386)
+-- min build: 1207
+---@param effectNameHash number
+function _AnimpostfxStopStackhashPostfx(effectNameHash) end
+
+-- _ANIMPOSTFX_STOP_TAG  (0xAD74C22A541AB987)
+-- min build: 1207
+---@param effectName string
+function _AnimpostfxStopTag(effectName) end
+
+-- _BLOCK_PICKUP_OBJECT_LIGHT  (0x50C14328119E1DD1)
+-- min build: 1207
+---@param pickupObject number
+---@param toggle boolean
+function _BlockPickupObjectLight(pickupObject, toggle) end
+
+-- _BLOOD_TRAIL_FOR_WAYPOINT  (0xB9C92616929CC25D)
+-- p1: 0.3f in R* Scripts
+-- min build: 1207
+---@param waypointRecording string
+---@param p1 number
+function _BloodTrailForWaypoint(waypointRecording, p1) end
+
+-- _CHANGE_PHOTO_MODE_CONTRAST  (0x62B9F9A1272AED80)
+-- min build: 1207
+---@param value number
+function _ChangePhotoModeContrast(value) end
+
+-- _CHANGE_PHOTO_MODE_EXPOSURE  (0xC8D0611D9A0CF5D3)
+-- min build: 1207
+---@param value number
+function _ChangePhotoModeExposure(value) end
+
+-- _CREATE_SWATCH_TEXTURE_DICT  (0x3D084D5568FB4028)
+-- min build: 1207
+---@param slots number
+---@return boolean
+function _CreateSwatchTextureDict(slots) end
+
+-- _DESTROY_SWATCH_TEXTURE_DICT  (0xDAD7FB8402651654)
+-- min build: 1207
+function _DestroySwatchTextureDict() end
+
+-- _DISABLE_FAR_ARTIFICIAL_LIGHTS  (0xCD284E2F6AC27EE9)
+-- Only used in guama1 R* Script
+-- Disables lod/distant lights when BOOL is set to true
+-- min build: 1207
+---@param disable boolean
+function _DisableFarArtificialLights(disable) end
+
+-- _DISABLE_STATIC_VEG_MODIFIER  (0xDD0BC0EDCB2162F6)
+-- min build: 1207
+---@param p0 number
+function _DisableStaticVegModifier(p0) end
+
+-- _DOES_CHECKPOINT_HAVE_FX  (0x4C11CCACB7C02B6E)
+-- min build: 1207
+---@param checkpoint number
+---@return boolean
+function _DoesCheckpointHaveFx(checkpoint) end
+
+-- _DRAW_MARKER  (0x2A32FAA57B937173)
+-- https://github.com/femga/rdr3_discoveries/blob/master/graphics/markers/marker_types.lua
+-- min build: 1207
+---@param type number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param dirX number
+---@param dirY number
+---@param dirZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+---@param bobUpAndDown boolean
+---@param faceCamera boolean
+---@param p19 number
+---@param rotate boolean
+---@param textureDict string
+---@param textureName string
+---@param drawOnEnts boolean
+function _DrawMarker(type, posX, posY, posZ, dirX, dirY, dirZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, red, green, blue, alpha, bobUpAndDown, faceCamera, p19, rotate, textureDict, textureName, drawOnEnts) end
+
+-- _ENABLE_STATIC_VEG_MODIFIER  (0xDFEA23EC90113657)
+-- min build: 1207
+---@param p0 number
+function _EnableStaticVegModifier(p0) end
+
+-- _GENERATE_SWATCH_TEXTURE  (0x160921255327C591)
+-- Example:
+-- local hash = GetHashKey("CLOTHING_ITEM_M_EYES_001_TINT_001")
+-- _GENERATE_SWATCH_TEXTURE(0, hash, 0, true)
+-- metapedType: see 0xEC9A1261BF0CE510
+-- min build: 1207
+---@param slotId number
+---@param componentHash number
+---@param metapedType number
+---@param p3 boolean
+function _GenerateSwatchTexture(slotId, componentHash, metapedType, p3) end
+
+-- _GENERATE_SWATCH_TEXTURE_DIRECTLY  (0x646ED1A1D28487DF)
+-- Example: https://pastebin.com/tTgpER9A
+-- min build: 1207
+---@param slot number
+---@param p1 any
+function _GenerateSwatchTextureDirectly(slot, p1) end
+
+-- _GET_CURRENT_NUMBER_OF_LOCAL_PHOTOS  (0x78C56B8A7B1D000C)
+-- min build: 1207
+---@return number
+function _GetCurrentNumberOfLocalPhotos() end
+
+-- _GET_ENTITY_MASK_LAYERS  (0xE8A8378BF651079C)
+-- min build: 1207
+---@param entity number
+---@return boolean
+---@return number
+---@return number
+---@return number
+---@return number
+function _GetEntityMaskLayers(entity) end
+
+-- _GET_MAX_NUMBER_OF_LOCAL_PHOTOS  (0x8E587FCD30E05592)
+-- Always returns 200.
+-- min build: 1207
+---@return number
+function _GetMaxNumberOfLocalPhotos() end
+
+-- _GET_MODIFIED_VISIBILITY_DISTANCE  (0x25CA89B2A39DCC69)
+-- _GET_C* - _GET_E*
+-- min build: 1207
+---@return number
+function _GetModifiedVisibilityDistance() end
+
+-- _GET_PHOTO_MODE_CONTRAST  (0x98F4154989B81EC6)
+-- min build: 1207
+---@return number
+function _GetPhotoModeContrast() end
+
+-- _GET_PHOTO_MODE_EXPOSURE  (0x06C0D8BB6B04A709)
+-- min build: 1207
+---@return number
+function _GetPhotoModeExposure() end
+
+-- _GET_PROXY_INTERIOR_INDEX  (0x5D1C5D8E62E8EE1C)
+-- Returns proxyInteriorIndex
+-- min build: 1207
+---@param interiorId number
+---@return number
+function _GetProxyInteriorIndex(interiorId) end
+
+-- _IS_PROXY_INTERIOR_INDEX_ARTIFICIAL_LIGHTS_ENABLED  (0x113857D66A9CABE6)
+-- min build: 1207
+---@param proxyInteriorIndex number
+---@return boolean
+function _IsProxyInteriorIndexArtificialLightsEnabled(proxyInteriorIndex) end
+
+-- _IS_STATIC_VEG_MODIFIER_ENABLED  (0xDE9BAD3292AA6D5E)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function _IsStaticVegModifierEnabled(p0) end
+
+-- _IS_TEXTURE_IN_DICT  (0xA2A51869BDED733B)
+-- min build: 1207
+---@param txdHash number
+---@param dict number
+---@return boolean
+function _IsTextureInDict(txdHash, dict) end
+
+-- _IS_TRACKED_POINT_VALID  (0xF2FDDCC8C6BAE1B3)
+-- min build: 1207
+---@param point number
+---@return boolean
+function _IsTrackedPointValid(point) end
+
+-- _NUM_PIXELS_VISIBLE_AT_TRACKED_POINT  (0xDFE332A5DA6FE7C9)
+-- Returns iNumPixels, iPixelsVisible
+-- min build: 1207
+---@param iTrackedPoint number
+---@return number
+function _NumPixelsVisibleAtTrackedPoint(iTrackedPoint) end
+
+-- _PEDSHOT_FINISH_CLEANUP_DATA  (0xC2B8164C3BE871A4)
+-- min build: 1207
+function _PedshotFinishCleanupData() end
+
+-- _PEDSHOT_GENERATE_PERSONA_PHOTO  (0xD9C24F53631F2372)
+-- min build: 1207
+---@param texture string
+---@param ped number
+---@param playerSlot number
+---@return boolean
+function _PedshotGeneratePersonaPhoto(texture, ped, playerSlot) end
+
+-- _PEDSHOT_INIT_CLEANUP_DATA  (0x55285F885F662169)
+-- min build: 1207
+function _PedshotInitCleanupData() end
+
+-- _PEDSHOT_PREVIOUS_PERSONA_PHOTO_DATA_CLEANUP  (0x3E2FDDBE435A8787)
+-- min build: 1207
+function _PedshotPreviousPersonaPhotoDataCleanup() end
+
+-- _PEDSHOT_SET_PERSONA_PHOTO_TYPE  (0x196D3ACBEBA4A44B)
+-- min build: 1207
+---@param personaPhotoLocalCacheType number
+function _PedshotSetPersonaPhotoType(personaPhotoLocalCacheType) end
+
+-- _REMOVE_ENTITY_FROM_ENTITY_MASK  (0x56A786E87FF53478)
+-- min build: 1207
+---@param entity number
+function _RemoveEntityFromEntityMask(entity) end
+
+-- _RESET_ENTITY_AURA  (0xAF4D239B8903FCBE)
+-- Used for script function RPG_GLOBAL_STATS__PRIVATE__DEACTIVATE_STAT_FLAG - Inspiration Aura unequip
+-- min build: 1207
+function _ResetEntityAura() end
+
+-- _RESET_MASK_OVERLAY  (0x5AC6E0FA028369DE)
+-- Clears/removes the 2D fullscreen mask overlay currently applied with _SET_MASK_OVERLAY.
+-- Used during cleanup when the player puts away binoculars, exits a camera view, or when a screen fade/cutscene ends.
+-- min build: 1207
+function _ResetMaskOverlay() end
+
+-- _SET_CLOUD_HEIGHT  (0xC332C91388F5580B)
+-- min build: 1207
+---@param height number
+function _SetCloudHeight(height) end
+
+-- _SET_CLOUD_LAYER  (0xB8C984C0D47F4F07)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param p2 number
+function _SetCloudLayer(x, y, p2) end
+
+-- _SET_CLOUD_NOISE  (0xFE7966DF01452F32)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function _SetCloudNoise(x, y, z) end
+
+-- _SET_CLOUD_POSITION  (0x10C1767B93257480)
+-- Only used in finale2, smuggler2, winter4
+-- _SET_CLOUD_A* - _SET_CLOUD_H*
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function _SetCloudPosition(x, y, z) end
+
+-- _SET_DISTRICT_PHOTO_TAKEN_STAT  (0x9937FACBBF267244)
+-- min build: 1207
+---@param p0 string
+function _SetDistrictPhotoTakenStat(p0) end
+
+-- _SET_ENTITY_AURA  (0x249CD6B7285536F2)
+-- Used for script function RPG_GLOBAL_STATS__PRIVATE__ACTIVATE_STAT_FLAG - Quite and Inspiration Aura equip
+-- Params: 0f, 2f, 2f
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+function _SetEntityAura(p0, p1, p2) end
+
+-- _SET_ENTITY_MASK_LAYERS  (0xE92012611461A42A)
+-- min build: 1207
+---@param entity number
+---@return number
+---@return number
+---@return number
+---@return number
+function _SetEntityMaskLayers(entity) end
+
+-- _SET_ENTITY_RENDER_GUARMA_SHIP  (0xC38B4952B728397A)
+-- Only used in guama1 R* SP Script while spawning the ship
+-- _SET_ENTITY_QUATERNION_* - SET_ENTITY_RENDER_*
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function _SetEntityRenderGuarmaShip(vehicle, toggle) end
+
+-- _SET_LIGHTS_COLOR_FOR_ENTITY  (0x6EC2A67962296F49)
+-- https://gfycat.com/meagerfaireyra
+-- min build: 1207
+---@param entity number
+---@param red number
+---@param green number
+---@param blue number
+function _SetLightsColorForEntity(entity, red, green, blue) end
+
+-- _SET_LIGHTS_INTENSITY_FOR_ENTITY  (0x07C0F87AAC57F2E4)
+-- min build: 1207
+---@param entity number
+---@param intensity number
+function _SetLightsIntensityForEntity(entity, intensity) end
+
+-- _SET_LIGHTS_TYPE_FOR_ENTITY  (0xAB72C67163DC4DB4)
+-- type must be less than or equal to 20
+-- min build: 1207
+---@param entity number
+---@param type number
+function _SetLightsTypeForEntity(entity, type) end
+
+-- _SET_MASK_OVERLAY  (0x21F00E08CBB5F37B)
+-- Applies a 2D fullscreen mask/overlay component to the screen.
+-- Used in cutscenes or scripts when the player/ped looks through binoculars, scopes, or cameras.
+-- Example component: COMPONENT_BINOCULARS_SCOPE01.
+-- Clear with _RESET_MASK_OVERLAY.
+-- min build: 1207
+---@param maskName string
+function _SetMaskOverlay(maskName) end
+
+-- _SET_PARTICLE_FX_LOOPED_UPDATE_DISTANT_SMOKE  (0x9DDC222D85D5AF2A)
+-- _SET_PARTICLE_FX_LOOPED_FA* - _SET_PARTICLE_FX_LOOPED_OF*
+-- min build: 1207
+---@param ptfxHandle number
+---@param scalar number
+function _SetParticleFxLoopedUpdateDistantSmoke(ptfxHandle, scalar) end
+
+-- _SET_PARTICLE_FX_NON_LOOPED_EMITTER_SCALE  (0x56C392C2BD78B024)
+-- min build: 1311
+---@param p0 number
+---@param p1 number
+---@param p2 number
+function _SetParticleFxNonLoopedEmitterScale(p0, p1, p2) end
+
+-- _SET_PEARLESCENT_FX_ENABLED  (0x72E30372E7CC4415)
+-- Enables/disables a kind of 'shiny' effect on metals.
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function _SetPearlescentFxEnabled(object, toggle) end
+
+-- _SET_PHOTO_IN_PHOTOMODE_STAT  (0xFA91736933AB3D93)
+-- min build: 1207
+---@param p0 boolean
+function _SetPhotoInPhotomodeStat(p0) end
+
+-- _SET_PHOTO_MODE_AO_ENHANCED  (0xF5793BB386E1FF9C)
+-- Toggles an enhanced/high-quality ambient occlusion mode used in Photo Mode.
+-- Called with 1 when photo mode's manual exposure/contrast adjustments become active (after the PauseMenuIn post-fx transition finishes), and called with 0 when photo mode is closed/torn down.
+-- Stores the value into a global bool that appears to gate a higher quality AO pass while composing photos.
+-- 
+-- Parameters:
+-- - bEnabled: true to enable the enhanced AO pass, false to disable it.
+-- min build: 1207
+---@param bEnabled boolean
+function _SetPhotoModeAoEnhanced(bEnabled) end
+
+-- _SET_PHOTO_MODE_EXPOSURE_LOCKED  (0x5CD6A2CCE5087161)
+-- min build: 1311
+---@param locked boolean
+function _SetPhotoModeExposureLocked(locked) end
+
+-- _SET_PHOTO_OVERLAY_EFFECT_STAT  (0x8B3296278328B5EB)
+-- min build: 1207
+---@param p0 number
+function _SetPhotoOverlayEffectStat(p0) end
+
+-- _SET_PHOTO_SELF_STAT  (0x2705D18C11B61046)
+-- min build: 1207
+---@param p0 boolean
+function _SetPhotoSelfStat(p0) end
+
+-- _SET_PHOTO_STUDIO_STAT  (0x8E6AFF353C09652E)
+-- min build: 1207
+---@param p0 number
+function _SetPhotoStudioStat(p0) end
+
+-- _SET_PLAYER_APPEAR_IN_PHOTO  (0x75D568607909333E)
+-- min build: 1232
+---@param player number
+function _SetPlayerAppearInPhoto(player) end
+
+-- _SET_POSSE_ID_FOR_PHOTO  (0x564837D4A9EDE296)
+-- min build: 1207
+---@param posseId any
+function _SetPosseIdForPhoto(posseId) end
+
+-- _SET_PROXY_INTERIOR_INDEX_ARTIFICIAL_LIGHTS_STATE  (0xBFCB17895BB99E4E)
+-- state: false disables artificial interior light sources for specific proxyInteriorIndex
+-- min build: 1207
+---@param proxyInteriorIndex number
+---@param state boolean
+function _SetProxyInteriorIndexArtificialLightsState(proxyInteriorIndex, state) end
+
+-- _SET_REGION_PHOTO_TAKEN_STAT  (0xD1031B83AC093BC7)
+-- min build: 1207
+---@param p0 string
+function _SetRegionPhotoTakenStat(p0) end
+
+-- _SET_SNIPER_GLINTS_ENABLED  (0x6E8EB45A4F4460EB)
+-- min build: 1207
+---@param enabled boolean
+function _SetSniperGlintsEnabled(enabled) end
+
+-- _SET_SNOW_COVERAGE_TYPE  (0xF02A9C330BBFC5C7)
+-- enum class eSnowCoverageType
+-- {
+-- 	Primary,
+-- 	Secondary,
+-- 	Xmas,
+-- 	XmasSecondary // since b1232
+-- };
+-- min build: 1207
+---@param type number
+function _SetSnowCoverageType(type) end
+
+-- _SET_STATE_PHOTO_TAKEN_STAT  (0x8952E857696B8A79)
+-- min build: 1207
+---@param p0 string
+function _SetStatePhotoTakenStat(p0) end
+
+-- _START_PARTICLE_FX_NON_LOOPED_ON_PED_BONE_2  (0xC695870B8A149B96)
+-- min build: 1207
+---@param effectName string
+---@param ped number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param boneIndex number
+---@param scale number
+---@param axisX boolean
+---@param axisY boolean
+---@param axisZ boolean
+---@return boolean
+function _StartParticleFxNonLoopedOnPedBone2(effectName, ped, offsetX, offsetY, offsetZ, rotX, rotY, rotZ, boneIndex, scale, axisX, axisY, axisZ) end
+
+-- _UPDATE_PHOTO_MODE_EXPOSURE  (0x9229ED770975BD9E)
+-- Resets the exposure to the value when exposure lock was enabled
+-- min build: 1311
+function _UpdatePhotoModeExposure() end
+
+-- ADD_DECAL  (0x57CB267624EF85C0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+---@param p15 any
+---@param p16 any
+---@param p17 any
+---@param p18 any
+---@param p19 any
+---@param p20 any
+---@param p21 any
+---@return number
+function AddDecal(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) end
+
+-- ADD_PETROL_TRAIL_DECAL_INFO  (0x73354FB6D03D2E8A)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+function AddPetrolTrailDecalInfo(x, y, z, p3) end
+
+-- ADD_VEG_MODIFIER_SPHERE  (0xFA50F79257745E74)
+-- Returns veg modifier handle
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param modType number
+---@param flags number
+---@param p6 number
+---@return number
+function AddVegModifierSphere(x, y, z, radius, modType, flags, p6) end
+
+-- ALLOW_PICKUP_LIGHT_SYNC  (0x7C348310A6E2FB91)
+-- min build: 1207
+---@param pickupObject number
+---@param allow boolean
+function AllowPickupLightSync(pickupObject, allow) end
+
+-- ANIMPOSTFX_HAS_EVENT_TRIGGERED_BY_STACKHASH  (0x9AB192A9EF980EED)
+-- min build: 1207
+---@param effectNameHash number
+---@param eventType number
+---@param bPeekOnly boolean
+---@return boolean
+---@return boolean
+function AnimpostfxHasEventTriggeredByStackhash(effectNameHash, eventType, bPeekOnly) end
+
+-- ANIMPOSTFX_IS_PRELOADING_BY_STACKHASH  (0x59EA80079B86D8C7)
+-- min build: 1207
+---@param effectNameHash number
+---@return boolean
+function AnimpostfxIsPreloadingByStackhash(effectNameHash) end
+
+-- ANIMPOSTFX_IS_RUNNING  (0x4A123E85D7C4CA0B)
+-- min build: 1207
+---@param effectName string
+---@return boolean
+function AnimpostfxIsRunning(effectName) end
+
+-- ANIMPOSTFX_PLAY  (0x4102732DF6B4005F)
+-- https://github.com/femga/rdr3_discoveries/blob/master/graphics/animpostfx
+-- min build: 1207
+---@param effectName string
+function AnimpostfxPlay(effectName) end
+
+-- ANIMPOSTFX_STOP  (0xB4FD7446BAB2F394)
+-- min build: 1207
+---@param effectName string
+function AnimpostfxStop(effectName) end
+
+-- ANIMPOSTFX_STOP_ALL  (0x66560A0D4C64FD21)
+-- min build: 1207
+function AnimpostfxStopAll() end
+
+-- ATTACH_TV_AUDIO_TO_ENTITY  (0x40866A418EB8EFDE)
+-- min build: 1207
+---@param entity number
+function AttachTvAudioToEntity(entity) end
+
+-- BEGIN_CREATE_LOW_QUALITY_COPY_OF_PHOTO  (0x494A9874F17A7D50)
+-- Called together with FREE_MEMORY_FOR_LOW_QUALITY_PHOTO
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function BeginCreateLowQualityCopyOfPhoto(p0) end
+
+-- BEGIN_TAKE_HIGH_QUALITY_PHOTO  (0xA15BFFC0A01B34E1)
+-- min build: 1207
+---@return boolean
+function BeginTakeHighQualityPhoto() end
+
+-- BLOCK_PICKUP_PLACEMENT_LIGHT  (0x0552AA3FFC5B87AA)
+-- min build: 1207
+---@param pickup number
+---@param toggle boolean
+function BlockPickupPlacementLight(pickup, toggle) end
+
+-- CASCADE_SHADOWS_CLEAR_SHADOW_SAMPLE_TYPE  (0xF7C29D7C12C36F03)
+-- min build: 1207
+function CascadeShadowsClearShadowSampleType() end
+
+-- CASCADE_SHADOWS_ENABLE_ENTITY_TRACKER  (0x8FBFD2AEB196B369)
+-- When this is set to ON, shadows only draw as you get nearer.
+-- 
+-- When OFF, they draw from a further distance.
+-- min build: 1207
+---@param toggle boolean
+function CascadeShadowsEnableEntityTracker(toggle) end
+
+-- CASCADE_SHADOWS_SET_CASCADE_BOUNDS  (0xD9EDB2E4512D563E)
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 boolean
+---@param p7 number
+function CascadeShadowsSetCascadeBounds(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- CASCADE_SHADOWS_SET_SHADOW_SAMPLE_TYPE  (0xCE4774E0F9AD48D1)
+-- Possible values:
+-- "CSM_ST_POINT"
+-- "CSM_ST_LINEAR"
+-- "CSM_ST_BOX3x3"
+-- "CSM_ST_BOX4x4"
+-- "CSM_ST_DITHER2_LINEAR"
+-- "CSM_ST_CUBIC"
+-- "CSM_ST_POISSON16"
+-- "CSM_ST_SOFT8"
+-- "CSM_ST_SOFT16"
+-- "CSM_ST_SOFT32"
+-- "CSM_ST_DITHER16_RPDB"
+-- "CSM_ST_POISSON16_RPDB_GNORM"
+-- "CSM_ST_HIGHRES_BOX4x4"
+-- "CSM_ST_ESM"
+-- min build: 1207
+---@param type string
+function CascadeShadowsSetShadowSampleType(type) end
+
+-- CLEAR_TIMECYCLE_MODIFIER  (0x0E3F4AF2D63491FB)
+-- min build: 1207
+function ClearTimecycleModifier() end
+
+-- CREATE_CHECKPOINT_WITH_NAMEHASH  (0x175668836B44CBB0)
+-- min build: 1207
+---@param typeHash number
+---@param posX1 number
+---@param posY1 number
+---@param posZ1 number
+---@param posX2 number
+---@param posY2 number
+---@param posZ2 number
+---@param radius number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+---@param reserved number
+---@return number
+function CreateCheckpointWithNamehash(typeHash, posX1, posY1, posZ1, posX2, posY2, posZ2, radius, red, green, blue, alpha, reserved) end
+
+-- CREATE_TRACKED_POINT  (0xFB405CB357C69CB9)
+-- Creates a tracked point, useful for checking the visibility of a 3D point on screen.
+-- min build: 1207
+---@return number
+function CreateTrackedPoint() end
+
+-- DELETE_CHECKPOINT  (0x0DED5B0C8EBAAE12)
+-- min build: 1207
+---@param checkpoint number
+function DeleteCheckpoint(checkpoint) end
+
+-- DESTROY_TRACKED_POINT  (0x37A59922109F8F1C)
+-- min build: 1207
+---@param point number
+function DestroyTrackedPoint(point) end
+
+-- DISABLE_ENTITYMASK  (0x5C9978A2A3DC3D0D)
+-- min build: 1207
+function DisableEntitymask() end
+
+-- DISABLE_HDTEX_THIS_FRAME  (0x98A7CD5EA379A854)
+-- min build: 1207
+function DisableHdtexThisFrame() end
+
+-- DOES_PARTICLE_FX_LOOPED_EXIST  (0x9DD5AFF561E88F2A)
+-- min build: 1207
+---@param ptfxHandle number
+---@return boolean
+function DoesParticleFxLoopedExist(ptfxHandle) end
+
+-- DRAW_LIGHT_WITH_RANGE  (0xD2D9E04C0DF927F4)
+-- min build: 1207
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param colorR number
+---@param colorG number
+---@param colorB number
+---@param range number
+---@param intensity number
+function DrawLightWithRange(posX, posY, posZ, colorR, colorG, colorB, range, intensity) end
+
+-- DRAW_LOW_QUALITY_PHOTO_TO_PHONE  (0xF1142E5D64B47802)
+-- nullsub, doesn't do anything (GTA5 leftover, there is no phone in RDR3)
+-- min build: 1207
+---@param p0 boolean
+---@param photoRotation number
+function DrawLowQualityPhotoToPhone(p0, photoRotation) end
+
+-- DRAW_RECT  (0x405224591DF02025)
+-- Draws a rectangle on the screen.
+-- 
+-- -x: The relative X point of the center of the rectangle. (0.0-1.0, 0.0 is the left edge of the screen, 1.0 is the right edge of the screen)
+-- 
+-- -y: The relative Y point of the center of the rectangle. (0.0-1.0, 0.0 is the top edge of the screen, 1.0 is the bottom edge of the screen)
+-- 
+-- -width: The relative width of the rectangle. (0.0-1.0, 1.0 means the whole screen width)
+-- 
+-- -height: The relative height of the rectangle. (0.0-1.0, 1.0 means the whole screen height)
+-- 
+-- -R: Red part of the color. (0-255)
+-- 
+-- -G: Green part of the color. (0-255)
+-- 
+-- -B: Blue part of the color. (0-255)
+-- 
+-- -A: Alpha part of the color. (0-255, 0 means totally transparent, 255 means totally opaque)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param width number
+---@param height number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+---@param p8 boolean
+---@param p9 boolean
+function DrawRect(x, y, width, height, red, green, blue, alpha, p8, p9) end
+
+-- DRAW_SPRITE  (0xC9884ECADE94CB34)
+-- Draws a 2D sprite on the screen.
+-- 
+-- Parameters:
+-- textureDict - Name of texture dictionary to load texture from
+-- 
+-- textureName - Name of texture to load from texture dictionary
+-- 
+-- screenX/Y - Screen offset (0.5 = center)
+-- scaleX/Y - Texture scaling. Negative values can be used to flip the texture on that axis. (0.5 = half)
+-- 
+-- heading - Texture rotation in degrees (default = 0.0) positive is clockwise, measured in degrees
+-- 
+-- red,green,blue - Sprite color (default = 255/255/255)
+-- 
+-- alpha - opacity level
+-- 
+-- https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/textures
+-- min build: 1207
+---@param textureDict string
+---@param textureName string
+---@param screenX number
+---@param screenY number
+---@param width number
+---@param height number
+---@param heading number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+---@param p11 boolean
+function DrawSprite(textureDict, textureName, screenX, screenY, width, height, heading, red, green, blue, alpha, p11) end
+
+-- DRAW_TV_CHANNEL  (0xC0A145540254A840)
+-- min build: 1207
+---@param xPos number
+---@param yPos number
+---@param xScale number
+---@param yScale number
+---@param rotation number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+function DrawTvChannel(xPos, yPos, xScale, yScale, rotation, red, green, blue, alpha) end
+
+-- ENABLE_ENTITYMASK  (0xFAAD23DE7A54FC14)
+-- min build: 1207
+function EnableEntitymask() end
+
+-- ENABLE_MOON_CYCLE_OVERRIDE  (0x6FE93BCC7BF12B63)
+-- Old name: _ENABLE_EXTRA_TIMECYCLE_MODIFIER_STRENGTH
+-- min build: 1207
+---@param strength number
+function EnableMoonCycleOverride(strength) end
+
+-- ENABLE_MOVIE_SUBTITLES  (0x6FC9B065229C0787)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param toggle boolean
+function EnableMovieSubtitles(toggle) end
+
+-- END_PETROL_TRAIL_DECALS  (0x0E126AAE933F3B56)
+-- min build: 1207
+function EndPetrolTrailDecals() end
+
+-- FREE_MEMORY_FOR_HIGH_QUALITY_PHOTO  (0xD45547D8396F002A)
+-- min build: 1207
+function FreeMemoryForHighQualityPhoto() end
+
+-- FREE_MEMORY_FOR_LOW_QUALITY_PHOTO  (0x614682E715ADBAAC)
+-- min build: 1207
+function FreeMemoryForLowQualityPhoto() end
+
+-- FREE_MEMORY_FOR_MISSION_CREATOR_PHOTO  (0x7DFF8F94937D2659)
+-- min build: 1207
+function FreeMemoryForMissionCreatorPhoto() end
+
+-- GET_SCREEN_COORD_FROM_WORLD_COORD  (0xCB50D7AFCC8B0EC6)
+-- min build: 1207
+---@param worldX number
+---@param worldY number
+---@param worldZ number
+---@return boolean
+---@return number
+---@return number
+function GetScreenCoordFromWorldCoord(worldX, worldY, worldZ) end
+
+-- GET_SCREEN_RESOLUTION  (0x66773C92835D0909)
+-- Hardcoded to always set x to 1280 and y to 720.
+-- min build: 1207
+---@return number
+---@return number
+function GetScreenResolution() end
+
+-- GET_STATUS_OF_CREATE_LOW_QUALITY_COPY_OF_PHOTO  (0x13430D3D5A45F14B)
+-- Old name: _GET_STATUS_OF_DRAW_LOW_QUALITY_PHOTO
+-- min build: 1207
+---@param p0 any
+---@return number
+function GetStatusOfCreateLowQualityCopyOfPhoto(p0) end
+
+-- GET_STATUS_OF_LOAD_MISSION_CREATOR_PHOTO  (0xC71B50AE58D07369)
+-- contentId: returned by NETWORK::_UGC_QUERY_GET_CREATOR_PHOTO(uVar0, 0, sParam3)
+-- min build: 1207
+---@param contentId string
+---@return number
+function GetStatusOfLoadMissionCreatorPhoto(contentId) end
+
+-- GET_STATUS_OF_SAVE_HIGH_QUALITY_PHOTO  (0xD6663EC374092383)
+-- 0 = succeeded
+-- 1 = getting status
+-- 2 = failed
+-- min build: 1207
+---@return number
+function GetStatusOfSaveHighQualityPhoto() end
+
+-- GET_STATUS_OF_SORTED_LIST_OPERATION  (0xB28894CD7408BD0C)
+-- 0 = succeeded
+-- 1 = getting status
+-- 2 = failed
+-- min build: 1207
+---@return number
+function GetStatusOfSortedListOperation() end
+
+-- GET_STATUS_OF_TAKE_HIGH_QUALITY_PHOTO  (0x4A3DA74C3CCB1725)
+-- min build: 1207
+---@return number
+function GetStatusOfTakeHighQualityPhoto() end
+
+-- GET_TIMECYCLE_MODIFIER_INDEX  (0xA705394293E2B3D3)
+-- min build: 1207
+---@return number
+function GetTimecycleModifierIndex() end
+
+-- GET_TIMECYCLE_TRANSITION_MODIFIER_INDEX  (0x2DA67BA3C8A6755D)
+-- min build: 1207
+---@return number
+function GetTimecycleTransitionModifierIndex() end
+
+-- GET_TOGGLE_PAUSED_RENDERPHASES_STATUS  (0x86ED21BDB2791CE8)
+-- min build: 1207
+---@return boolean
+function GetTogglePausedRenderphasesStatus() end
+
+-- GET_TV_CHANNEL  (0xF90FBFD68F3C59AE)
+-- min build: 1207
+---@return number
+function GetTvChannel() end
+
+-- IS_DECAL_ALIVE  (0x3E4B4E5CF5D3EEB5)
+-- min build: 1207
+---@param decal number
+---@return boolean
+function IsDecalAlive(decal) end
+
+-- IS_PHOTO_FRAME  (0x86076AE35CBBE55F)
+-- min build: 1355
+---@return boolean
+function IsPhotoFrame() end
+
+-- IS_TRACKED_POINT_VISIBLE  (0xCBB056BA159FB48D)
+-- min build: 1207
+---@param point number
+---@return boolean
+function IsTrackedPointVisible(point) end
+
+-- IS_TVSHOW_CURRENTLY_PLAYING  (0x4D562223E0EB65F3)
+-- Old name: _IS_TV_PLAYLIST_ITEM_PLAYING
+-- min build: 1207
+---@param videoCliphash number
+---@return boolean
+function IsTvshowCurrentlyPlaying(videoCliphash) end
+
+-- LOAD_MISSION_CREATOR_PHOTO  (0x84F0BA7462FF8D58)
+-- min build: 1207
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return boolean
+---@return any
+function LoadMissionCreatorPhoto(p1, p2, p3) end
+
+-- PEDSHOT_IS_AVAILABLE  (0xAF6E67D073D2DCE2)
+-- min build: 1207
+---@return boolean
+function PedshotIsAvailable() end
+
+-- QUEUE_OPERATION_TO_CREATE_SORTED_LIST_OF_PHOTOS  (0xA42EDF1E88734A7E)
+-- min build: 1207
+---@return boolean
+function QueueOperationToCreateSortedListOfPhotos() end
+
+-- REMOVE_DECAL  (0x49A720552EB0BB88)
+-- min build: 1207
+---@param decal number
+function RemoveDecal(decal) end
+
+-- REMOVE_DECALS_FROM_OBJECT  (0xFB8972BAE0013140)
+-- min build: 1207
+---@param obj number
+function RemoveDecalsFromObject(obj) end
+
+-- REMOVE_DECALS_IN_RANGE  (0x86DE59FA02902B40)
+-- Removes all decals in range from a position, it includes the bullet holes, blood pools, petrol...
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param range number
+function RemoveDecalsInRange(x, y, z, range) end
+
+-- REMOVE_GRASS_CULL_SPHERE  (0xAE7BF7CA9E4BA48D)
+-- min build: 1207
+---@param handle number
+function RemoveGrassCullSphere(handle) end
+
+-- REMOVE_PARTICLE_FX  (0x459598F579C98929)
+-- min build: 1207
+---@param ptfxHandle number
+---@param p1 boolean
+function RemoveParticleFx(ptfxHandle, p1) end
+
+-- REMOVE_PARTICLE_FX_FROM_ENTITY  (0x92884B4A49D81325)
+-- min build: 1207
+---@param entity number
+function RemoveParticleFxFromEntity(entity) end
+
+-- REMOVE_PARTICLE_FX_IN_RANGE  (0x87B5905ECA623B68)
+-- min build: 1207
+---@param X number
+---@param Y number
+---@param Z number
+---@param radius number
+function RemoveParticleFxInRange(X, Y, Z, radius) end
+
+-- REMOVE_VEG_MODIFIER_SPHERE  (0x9CF1836C03FB67A2)
+-- min build: 1207
+---@param vegModifierHandle number
+---@param p1 number
+function RemoveVegModifierSphere(vegModifierHandle, p1) end
+
+-- RESET_ADAPTATION  (0x297B72E2AF094742)
+-- Sets an unknown value related to timecycles.
+-- min build: 1207
+---@param unk number
+function ResetAdaptation(unk) end
+
+-- RESET_PARTICLE_FX_OVERRIDE  (0x274B3DABF7E72DEF)
+-- Resets the effect of SET_PARTICLE_FX_OVERRIDE
+-- min build: 1207
+---@param name string
+function ResetParticleFxOverride(name) end
+
+-- RESET_PAUSED_RENDERPHASES  (0xCCD9AAD85E1B559E)
+-- min build: 1207
+function ResetPausedRenderphases() end
+
+-- SAVE_HIGH_QUALITY_PHOTO  (0x57639FD876B68A91)
+-- min build: 1207
+---@param unused number
+---@return boolean
+function SaveHighQualityPhoto(unused) end
+
+-- SET_ARTIFICIAL_LIGHTS_STATE  (0xB2797619A7C7747B)
+-- Does not affect weapons, particles, fire/explosions, flashlights or the sun.
+-- When set to true, all emissive textures (including ped components that have light effects), street lights, building lights, vehicle lights, etc will all be turned off.
+-- 
+-- state: True turns off all artificial light sources in the map: buildings, street lights, car lights, etc. False turns them back on.
+-- min build: 1207
+---@param state boolean
+function SetArtificialLightsState(state) end
+
+-- SET_CHECKPOINT_RGBA  (0xCAAFC225E33B1D15)
+-- Sets the checkpoint color.
+-- min build: 1207
+---@param checkpoint number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+function SetCheckpointRgba(checkpoint, red, green, blue, alpha) end
+
+-- SET_CHECKPOINT_RGBA2  (0x99AFF17222D4DEB4)
+-- Sets the checkpoint icon color.
+-- min build: 1207
+---@param checkpoint number
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+function SetCheckpointRgba2(checkpoint, red, green, blue, alpha) end
+
+-- SET_DISABLE_PETROL_DECALS_IGNITING_THIS_FRAME  (0x53ED07BF368EDA59)
+-- min build: 1232
+function SetDisablePetrolDecalsIgnitingThisFrame() end
+
+-- SET_GRASS_CULL_SPHERE  (0x27219300C36A8D40)
+-- Returns handle to be used with REMOVE_GRASS_CULL_SPHERE
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param p4 number
+---@return number
+function SetGrassCullSphere(x, y, z, p3, p4) end
+
+-- SET_HIDOF_OVERRIDE  (0xCC23AA1A7CBFE840)
+-- Old name: _SET_HIDOF_ENV_BLUR_PARAMS
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+function SetHidofOverride(p0, p1, p2, p3, p4, p5) end
+
+-- SET_PARTICLE_FX_AMBIENT_COLOUR  (0x3C61B52B00848C26)
+-- Related to Campfires.
+-- p1: AMB_BONFIRE_MP, AMB_CAMPFIRE_LRG_MP
+-- min build: 1207
+---@param entity number
+---@param p1 string
+---@param r number
+---@param g number
+---@param b number
+function SetParticleFxAmbientColour(entity, p1, r, g, b) end
+
+-- SET_PARTICLE_FX_BULLET_IMPACT_LODRANGE_SCALE  (0x8DCCC98DC0DBF9E4)
+-- min build: 1207
+---@param p0 number
+function SetParticleFxBulletImpactLodrangeScale(p0) end
+
+-- SET_PARTICLE_FX_BULLET_IMPACT_SCALE  (0xA53C8D7D0F8C74D0)
+-- min build: 1207
+---@param scale number
+function SetParticleFxBulletImpactScale(scale) end
+
+-- SET_PARTICLE_FX_FOOT_LODRANGE_SCALE  (0x2A1625858887D4E6)
+-- min build: 1207
+---@param p0 number
+function SetParticleFxFootLodrangeScale(p0) end
+
+-- SET_PARTICLE_FX_LOOPED_ALPHA  (0x88786E76234F7054)
+-- min build: 1207
+---@param ptfxHandle number
+---@param alpha number
+function SetParticleFxLoopedAlpha(ptfxHandle, alpha) end
+
+-- SET_PARTICLE_FX_LOOPED_COLOUR  (0x239879FC61C610CC)
+-- min build: 1207
+---@param ptfxHandle number
+---@param r number
+---@param g number
+---@param b number
+---@param p4 boolean
+function SetParticleFxLoopedColour(ptfxHandle, r, g, b, p4) end
+
+-- SET_PARTICLE_FX_LOOPED_EVOLUTION  (0x3674F389B0FACD80)
+-- min build: 1207
+---@param ptfxHandle number
+---@param propertyName string
+---@param amount number
+---@param noNetwork boolean
+function SetParticleFxLoopedEvolution(ptfxHandle, propertyName, amount, noNetwork) end
+
+-- SET_PARTICLE_FX_LOOPED_FAR_CLIP_DIST  (0x9B04D471DA0AD7AA)
+-- min build: 1207
+---@param ptfxHandle number
+---@param range number
+function SetParticleFxLoopedFarClipDist(ptfxHandle, range) end
+
+-- SET_PARTICLE_FX_LOOPED_OFFSETS  (0xD3A4A95FC94FE83B)
+-- min build: 1207
+---@param ptfxHandle number
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+function SetParticleFxLoopedOffsets(ptfxHandle, x, y, z, rotX, rotY, rotZ) end
+
+-- SET_PARTICLE_FX_LOOPED_SCALE  (0x1A9E1C0D98D093B7)
+-- min build: 1207
+---@param ptfxHandle number
+---@param scale number
+function SetParticleFxLoopedScale(ptfxHandle, scale) end
+
+-- SET_PARTICLE_FX_NON_LOOPED_ALPHA  (0xE8A35938A7026CEA)
+-- min build: 1311
+---@param alpha number
+function SetParticleFxNonLoopedAlpha(alpha) end
+
+-- SET_PARTICLE_FX_NON_LOOPED_COLOUR  (0x60B85BED6577A35B)
+-- min build: 1207
+---@param r number
+---@param g number
+---@param b number
+function SetParticleFxNonLoopedColour(r, g, b) end
+
+-- SET_PARTICLE_FX_OVERRIDE  (0xBE711A169E9C7E95)
+-- min build: 1207
+---@param oldAsset string
+---@param newAsset string
+function SetParticleFxOverride(oldAsset, newAsset) end
+
+-- SET_PICKUP_LIGHT  (0x7DFB49BCDB73089A)
+-- https://imgur.com/a/I2swSDJ
+-- 
+-- Old name: _SET_PICKUP_OBJECT_GLOW_ENABLED
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function SetPickupLight(object, toggle) end
+
+-- SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU  (0x906B86E6D7896B9E)
+-- Sets a flag defining whether or not script draw commands should continue being drawn behind the pause menu. This is usually used for draw commands that are used with a world render target.
+-- min build: 1207
+---@param toggle boolean
+function SetScriptGfxDrawBehindPausemenu(toggle) end
+
+-- SET_SCRIPT_GFX_DRAW_ORDER  (0xCFCC78391C8B3814)
+-- Sets the draw order for script draw commands.
+-- min build: 1207
+---@param drawOrder number
+function SetScriptGfxDrawOrder(drawOrder) end
+
+-- SET_TIMECYCLE_MODIFIER  (0xFA08722A5EA82DA7)
+-- https://github.com/femga/rdr3_discoveries/blob/master/graphics/timecycles
+-- min build: 1207
+---@param modifierName string
+function SetTimecycleModifier(modifierName) end
+
+-- SET_TIMECYCLE_MODIFIER_STRENGTH  (0xFDB74C9CC54C3F37)
+-- min build: 1207
+---@param strength number
+function SetTimecycleModifierStrength(strength) end
+
+-- SET_TRACKED_POINT_INFO  (0xF6FDA3D4404D4F2C)
+-- min build: 1207
+---@param point number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+function SetTrackedPointInfo(point, x, y, z, radius) end
+
+-- SET_TRANSITION_OUT_OF_TIMECYCLE_MODIFIER  (0xBB6C707F20D955D4)
+-- min build: 1207
+---@param strength number
+function SetTransitionOutOfTimecycleModifier(strength) end
+
+-- SET_TRANSITION_TIMECYCLE_MODIFIER  (0xFF927A09F481D80C)
+-- min build: 1207
+---@param modifierName string
+---@param transitionBlend number
+function SetTransitionTimecycleModifier(modifierName, transitionBlend) end
+
+-- SET_TV_AUDIO_FRONTEND  (0x64437C98FCC5F291)
+-- Probably changes tvs from being a 3d audio to being "global" audio
+-- min build: 1207
+---@param toggle boolean
+function SetTvAudioFrontend(toggle) end
+
+-- SET_TV_CHANNEL  (0x593FAF7FC9401A56)
+-- min build: 1207
+---@param channel number
+function SetTvChannel(channel) end
+
+-- SET_TV_CHANNEL_PLAYLIST  (0xDEC6B25F5DC8925B)
+-- min build: 1207
+---@param tvChannel number
+---@param playlistName string
+---@param restart boolean
+function SetTvChannelPlaylist(tvChannel, playlistName, restart) end
+
+-- SET_TV_VOLUME  (0x73A97068787D7231)
+-- min build: 1207
+---@param volume number
+function SetTvVolume(volume) end
+
+-- START_NETWORKED_PARTICLE_FX_LOOPED_ON_ENTITY  (0x8F90AB32E1944BDE)
+-- min build: 1207
+---@param effectName string
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return number
+function StartNetworkedParticleFxLoopedOnEntity(effectName, entity, xOffset, yOffset, zOffset, xRot, yRot, zRot, scale, xAxis, yAxis, zAxis) end
+
+-- START_NETWORKED_PARTICLE_FX_LOOPED_ON_ENTITY_BONE  (0x9C56621462FFE7A6)
+-- min build: 1207
+---@param effectName string
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param boneIndex number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return number
+function StartNetworkedParticleFxLoopedOnEntityBone(effectName, entity, xOffset, yOffset, zOffset, xRot, yRot, zRot, boneIndex, scale, xAxis, yAxis, zAxis) end
+
+-- START_NETWORKED_PARTICLE_FX_NON_LOOPED_AT_COORD  (0xFB97618457994A62)
+-- min build: 1207
+---@param effectName string
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return boolean
+function StartNetworkedParticleFxNonLoopedAtCoord(effectName, xPos, yPos, zPos, xRot, yRot, zRot, scale, xAxis, yAxis, zAxis) end
+
+-- START_NETWORKED_PARTICLE_FX_NON_LOOPED_ON_ENTITY  (0xE6CFE43937061143)
+-- min build: 1207
+---@param effectName string
+---@param entity number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scale number
+---@param axisX boolean
+---@param axisY boolean
+---@param axisZ boolean
+---@return boolean
+function StartNetworkedParticleFxNonLoopedOnEntity(effectName, entity, offsetX, offsetY, offsetZ, rotX, rotY, rotZ, scale, axisX, axisY, axisZ) end
+
+-- START_PARTICLE_FX_LOOPED_AT_COORD  (0xBA32867E86125D3A)
+-- https://github.com/femga/rdr3_discoveries/blob/master/graphics/ptfx/ptfx_assets_looped.lua
+-- min build: 1207
+---@param effectName string
+---@param x number
+---@param y number
+---@param z number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@param p11 boolean
+---@return number
+function StartParticleFxLoopedAtCoord(effectName, x, y, z, xRot, yRot, zRot, scale, xAxis, yAxis, zAxis, p11) end
+
+-- START_PARTICLE_FX_LOOPED_ON_ENTITY  (0xBD41E1440CE39800)
+-- min build: 1207
+---@param effectName string
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return number
+function StartParticleFxLoopedOnEntity(effectName, entity, xOffset, yOffset, zOffset, xRot, yRot, zRot, scale, xAxis, yAxis, zAxis) end
+
+-- START_PARTICLE_FX_LOOPED_ON_ENTITY_BONE  (0xD3BA6EC7F2FBD5E9)
+-- min build: 1207
+---@param effectName string
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param boneIndex number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return number
+function StartParticleFxLoopedOnEntityBone(effectName, entity, xOffset, yOffset, zOffset, xRot, yRot, zRot, boneIndex, scale, xAxis, yAxis, zAxis) end
+
+-- START_PARTICLE_FX_LOOPED_ON_PED_BONE  (0xE689C1B1432BB8AF)
+-- min build: 1207
+---@param effectName string
+---@param ped number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param boneIndex number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return number
+function StartParticleFxLoopedOnPedBone(effectName, ped, xOffset, yOffset, zOffset, xRot, yRot, zRot, boneIndex, scale, xAxis, yAxis, zAxis) end
+
+-- START_PARTICLE_FX_NON_LOOPED_AT_COORD  (0x2E80BF72EF7C87AC)
+-- https://github.com/femga/rdr3_discoveries/blob/master/graphics/ptfx/ptfx_assets_non_looped.lua
+-- min build: 1207
+---@param effectName string
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param scale number
+---@param xAxis boolean
+---@param yAxis boolean
+---@param zAxis boolean
+---@return boolean
+function StartParticleFxNonLoopedAtCoord(effectName, xPos, yPos, zPos, xRot, yRot, zRot, scale, xAxis, yAxis, zAxis) end
+
+-- START_PARTICLE_FX_NON_LOOPED_ON_ENTITY  (0xFF4C64C513388C12)
+-- min build: 1207
+---@param effectName string
+---@param entity number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scale number
+---@param axisX boolean
+---@param axisY boolean
+---@param axisZ boolean
+---@return boolean
+function StartParticleFxNonLoopedOnEntity(effectName, entity, offsetX, offsetY, offsetZ, rotX, rotY, rotZ, scale, axisX, axisY, axisZ) end
+
+-- START_PARTICLE_FX_NON_LOOPED_ON_PED_BONE  (0x3FAA72BD940C3AC0)
+-- min build: 1207
+---@param effectName string
+---@param ped number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param boneIndex number
+---@param scale number
+---@param axisX boolean
+---@param axisY boolean
+---@param axisZ boolean
+---@return boolean
+function StartParticleFxNonLoopedOnPedBone(effectName, ped, offsetX, offsetY, offsetZ, rotX, rotY, rotZ, boneIndex, scale, axisX, axisY, axisZ) end
+
+-- START_PETROL_TRAIL_DECALS  (0x46F246D6504F0031)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function StartPetrolTrailDecals(p0, p1) end
+
+-- STOP_PARTICLE_FX_LOOPED  (0x22970F3A088B133B)
+-- min build: 1207
+---@param ptfxHandle number
+---@param p1 boolean
+function StopParticleFxLooped(ptfxHandle, p1) end
+
+-- TOGGLE_PAUSED_RENDERPHASES  (0xEF9E1C45732F55FA)
+-- min build: 1207
+---@param toggle boolean
+function TogglePausedRenderphases(toggle) end
+
+-- UPDATE_LIGHTS_ON_ENTITY  (0xBDBACB52A03CC760)
+-- min build: 1207
+---@param entity number
+function UpdateLightsOnEntity(entity) end
+
+-- USE_PARTICLE_FX_ASSET  (0xA10DB07FC234DD12)
+-- fxName: see data_0/data/effects/ptfx/fxlists/
+-- min build: 1207
+---@param fxName string
+function UseParticleFxAsset(fxName) end

--- a/.luals/redm-natives/HUD.lua
+++ b/.luals/redm-natives/HUD.lua
@@ -1,0 +1,1224 @@
+---@meta
+
+-- RDR3 namespace: HUD -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x052D4AC0922AF91A  (0x052D4AC0922AF91A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x052D4AC0922AF91A(p0, p1) end
+
+-- _0x066725A9D52B3641  (0x066725A9D52B3641)
+-- min build: 1232
+---@return any
+function N_0x066725A9D52B3641() end
+
+-- _0x100157D6D7FE32CA  (0x100157D6D7FE32CA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x100157D6D7FE32CA(p0, p1) end
+
+-- _0x160825DADF1B04B3  (0x160825DADF1B04B3)
+-- min build: 1207
+function N_0x160825DADF1B04B3() end
+
+-- _0x28AE29D909C8FDCE  (0x28AE29D909C8FDCE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x28AE29D909C8FDCE(p0) end
+
+-- _0x2F7BB105144ACF30  (0x2F7BB105144ACF30)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0x2F7BB105144ACF30() end
+
+-- _0x3FE4FB41EF7D2196  (0x3FE4FB41EF7D2196)
+-- min build: 1207
+---@param p0 any
+function N_0x3FE4FB41EF7D2196(p0) end
+
+-- _0x53CE46C01A089DA1  (0x53CE46C01A089DA1)
+-- min build: 1207
+---@param prompt number
+---@param p1 boolean
+function N_0x53CE46C01A089DA1(prompt, p1) end
+
+-- _0x5651516D947ABC53  (0x5651516D947ABC53)
+-- min build: 1207
+function N_0x5651516D947ABC53() end
+
+-- _0x8A59D44189AF2BC5  (0x8A59D44189AF2BC5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8A59D44189AF2BC5(p0, p1) end
+
+-- _0x8B55B324A9123F6B  (0x8B55B324A9123F6B)
+-- min build: 1232
+---@param groupId number
+---@param volume number
+---@param p2 string
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return any
+function N_0x8B55B324A9123F6B(groupId, volume, p2, p3, p4, p5) end
+
+-- _0x958278B97C4AFFD8  (0x958278B97C4AFFD8)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+function N_0x958278B97C4AFFD8(p0, p1) end
+
+-- _0x9D37EB5003E0F2CF  (0x9D37EB5003E0F2CF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9D37EB5003E0F2CF(p0, p1) end
+
+-- _0xBFFF81E12A745A5F  (0xBFFF81E12A745A5F)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0xBFFF81E12A745A5F() end
+
+-- _0xD6BD313CFA41E57A  (0xD6BD313CFA41E57A)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xD6BD313CFA41E57A(p0) end
+
+-- _0xF1E6979C0B779985  (0xF1E6979C0B779985)
+-- min build: 1207
+---@param uiscene number
+function N_0xF1E6979C0B779985(uiscene) end
+
+-- _BUSYSPINNER_SET_TEXT  (0x7F78CD75CC4539E4)
+-- min build: 1207
+---@param text string
+function _BusyspinnerSetText(text) end
+
+-- _CREATE_MP_GAMER_TAG  (0xD877AF112AD2B41B)
+-- min build: 1207
+---@param player number
+---@param username string
+---@param pointedClanTag boolean
+---@param isRockstarClan boolean
+---@param clanTag string
+---@param clanFlag number
+---@return number
+function _CreateMpGamerTag(player, username, pointedClanTag, isRockstarClan, clanTag, clanFlag) end
+
+-- _CREATE_MP_GAMER_TAG_ON_ENTITY  (0xE961BF23EAB76B12)
+-- min build: 1207
+---@param entity number
+---@param text string
+---@return number
+function _CreateMpGamerTagOnEntity(entity, text) end
+
+-- _DISABLE_HUD_CONTEXT  (0x8BC7C1F929D07BF3)
+-- Old name: _DISPLAY_HUD_COMPONENT
+-- min build: 1207
+---@param component number
+function _DisableHudContext(component) end
+
+-- _DISABLE_REDUCED_MENU_TIME_SCALE  (0xC5C7A2F6567FCCBC)
+-- Disables reduced time scale while menus such as weapon wheel and satchel are open.
+-- min build: 1207
+function _DisableReducedMenuTimeScale() end
+
+-- _DISPLAY_TEXT  (0xD79334A4BB99BAD1)
+-- nullsub, this native does nothing since build 1436, use _BG_DISPLAY_TEXT (0x16794E044C9EFB58) instead.
+-- min build: 1207
+---@param text string
+---@param xPos number
+---@param yPos number
+function _DisplayText(text, xPos, yPos) end
+
+-- _DOES_TEXT_BLOCK_EXIST  (0x2C729F2B94CEA911)
+-- min build: 1207
+---@param textDatabase string
+---@return boolean
+function _DoesTextBlockExist(textDatabase) end
+
+-- _ENABLE_HUD_CONTEXT  (0x4CC5F2FC1332577F)
+-- https://github.com/femga/rdr3_discoveries/tree/master/graphics/HUD/hud_presets
+-- Old name: _HIDE_HUD_COMPONENT
+-- min build: 1207
+---@param component number
+function _EnableHudContext(component) end
+
+-- _ENABLE_HUD_CONTEXT_THIS_FRAME  (0xC9CAEAEEC1256E54)
+-- min build: 1207
+---@param component number
+function _EnableHudContextThisFrame(component) end
+
+-- _ENABLE_REDUCED_MENU_TIME_SCALE  (0x26F6BBEA2CE3E3DC)
+-- Enables reduced time scale while menus such as weapon wheel and satchel are open.
+-- min build: 1207
+function _EnableReducedMenuTimeScale() end
+
+-- _GET_COLOR_FROM_NAME  (0xB981DD2DFAF9B1C9)
+-- colorNameHash: https://alloc8or.re/rdr3/doc/enums/eColor.txt
+-- min build: 1207
+---@param colorNameHash number
+---@return number
+---@return number
+---@return number
+---@return number
+function _GetColorFromName(colorNameHash) end
+
+-- _GET_HUD_VISIBILITY_SLOT_STATE  (0x7EC0D68233E391AC)
+-- Returns the current state value for a HUD component slot ID.
+-- Enum: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eHudVisibilitySlotType 
+-- Notes:
+-- - Component-specific semantics: the same numeric state can mean different things depending on the component.
+-- - Used heavily as a gating signal for prompts/targeting/UI updates (e.g., return 0 when 21==2 or 54==2; block logic when 10==2 or 10==4).
+-- min build: 1207
+---@param hudSlot number
+---@return number
+function _GetHudVisibilitySlotState(hudSlot) end
+
+-- _GET_LABEL_TEXT_2  (0x3429670F9B9EF2D3)
+-- _GET_FILENAME_* - _GET_FRAME*
+-- min build: 1207
+---@param label string
+---@return string
+function _GetLabelText2(label) end
+
+-- _GET_TEXT_SUBSTRING_2  (0xD8402B858F4DDD88)
+-- Similar to 0x9D7E12EC6A1EE4E5(GET_TEXT_SUBSTRING) but starts at the beginning of the string
+-- _GET_FILE* - _GET_FRAME*
+-- min build: 1207
+---@param text string
+---@param length number
+---@return string
+function _GetTextSubstring2(text, length) end
+
+-- _GET_TEXT_SUBSTRING_3  (0x806862E5D266CF38)
+-- _GET_BOUNTY* - _GET_CHARACTER*
+-- min build: 1207
+---@param text string
+---@param begin number
+---@param length number
+---@return string
+function _GetTextSubstring3(text, begin, length) end
+
+-- _HUD_CHECK_CLOSEST_HORSE  (0x0501D52D24EA8934)
+-- Returns closest horse entity handle (about 3 meters; facing, directly riding, etc).
+-- Maybe when horse hud interaction prompts are allowed to show (?)
+-- 
+-- Params: p0 is usually true, if its false the native returns the players ped handle (?)
+-- 
+-- _HIDE_* - _IGNORE_*
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function _HudCheckClosestHorse(p0) end
+
+-- _HUD_GET_INVENTORY_WHEEL_CURRENTLY_HIGHLIGHTED  (0x9C409BBC492CB5B1)
+-- Returns the hash of the currently highlighted item in the weapon wheel.
+-- Only works while the wheel is open.
+-- 
+-- Use in conjunction with IS_CONTROL_JUST_RELEASED(0, 'INPUT_OPEN_WHEEL_MENU') to detect item selection/usage.
+-- min build: 1207
+---@return number
+function _HudGetInventoryWheelCurrentlyHighlighted() end
+
+-- _HUD_HIDE_THIS_FRAME  (0xBF4F34A85CA2970D)
+-- min build: 1207
+function _HudHideThisFrame() end
+
+-- _IS_MP_GAMER_TAG_ACTIVE_ON_ENTITY  (0x502E1591A504F843)
+-- min build: 1207
+---@param gamerTagId number
+---@param entity number
+---@return boolean
+function _IsMpGamerTagActiveOnEntity(gamerTagId, entity) end
+
+-- _JOURNAL_CAN_WRITE_ENTRY  (0xCF782691D91F270E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _JournalCanWriteEntry(p0) end
+
+-- _JOURNAL_CLEAR_ALL_PROGRESS  (0xF402978DE6F88D6E)
+-- min build: 1207
+function _JournalClearAllProgress() end
+
+-- _JOURNAL_GET_ENTRY_AT_INDEX  (0x3D16ABD7A1FD8C96)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _JournalGetEntryAtIndex(p0) end
+
+-- _JOURNAL_GET_ENTRY_COUNT  (0xE65B5DE53351BE22)
+-- min build: 1207
+---@return any
+function _JournalGetEntryCount() end
+
+-- _JOURNAL_GET_ENTRY_INFO  (0x5514C3E60673530F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _JournalGetEntryInfo(p0, p1) end
+
+-- _JOURNAL_GET_GRIME_AT_INDEX  (0xCB5945E1B855852F)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _JournalGetGrimeAtIndex(p0) end
+
+-- _JOURNAL_GET_TEXTURE_WITH_LAYOUT  (0x62CC549B3B8EA2AA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function _JournalGetTextureWithLayout(p0, p1, p2) end
+
+-- _JOURNAL_MARK_READ  (0xE4509BABE59BD24E)
+-- min build: 1207
+---@param p0 any
+function _JournalMarkRead(p0) end
+
+-- _JOURNAL_WRITE_ENTRY  (0x6DFDD665E416B093)
+-- min build: 1207
+---@param p0 any
+function _JournalWriteEntry(p0) end
+
+-- _MP_GAMER_TAG_DISABLE_REVIVE_TOP_ICON  (0x1F9A64C2804B3471)
+-- min build: 1207
+---@param gamerTagId number
+function _MpGamerTagDisableReviveTopIcon(gamerTagId) end
+
+-- _MP_GAMER_TAG_ENABLE_REVIVE_TOP_ICON  (0xFFF6579CF0139FCE)
+-- min build: 1207
+---@param gamerTagId number
+function _MpGamerTagEnableReviveTopIcon(gamerTagId) end
+
+-- _SET_CURRENT_UGC_MISSION_DESCRIPTION  (0xCE0D2F5586627CCE)
+-- string1 is the only string used in the scripts, the others are null (0)
+-- min build: 1207
+---@param active boolean
+---@param string1 string
+---@param string2 string
+---@param string3 string
+---@param string4 string
+function _SetCurrentUgcMissionDescription(active, string1, string2, string3, string4) end
+
+-- _SET_MP_GAMER_TAG_COLOUR  (0x84BD27DDF9575816)
+-- min build: 1207
+---@param gamerTagId number
+---@param colour number
+function _SetMpGamerTagColour(gamerTagId, colour) end
+
+-- _SET_MP_GAMER_TAG_NAME_POSSE  (0x1EA716E0628A6F44)
+-- min build: 1207
+---@param gamerTagId number
+---@param text string
+function _SetMpGamerTagNamePosse(gamerTagId, text) end
+
+-- _SET_MP_GAMER_TAG_SECONDARY_ICON  (0x95384C6CE1526EFF)
+-- Found icons: SPEAKER, THROPY
+-- min build: 1207
+---@param gamerTagId number
+---@param icon number
+function _SetMpGamerTagSecondaryIcon(gamerTagId, icon) end
+
+-- _SET_MP_GAMER_TAG_TOP_ICON  (0x5F57522BC1EB9D9D)
+-- Found icons: https://pastebin.com/xx6rEgiG
+-- min build: 1207
+---@param gamerTagId number
+---@param icon number
+function _SetMpGamerTagTopIcon(gamerTagId, icon) end
+
+-- _SET_MP_GAMER_TAG_TYPE  (0x25B9C78A25105C35)
+-- Found types: GENERIC_PLAYER, DEADDROP, HOTPROPERTY, MINIGAMES
+-- min build: 1207
+---@param gamerTagId number
+---@param type number
+function _SetMpGamerTagType(gamerTagId, type) end
+
+-- _SET_MP_GAMER_TAG_UNK_ALLOW_LOCALIZED  (0xEF7AB1A0E8C86170)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param gamerTagId number
+---@param allow boolean
+function _SetMpGamerTagUnkAllowLocalized(gamerTagId, allow) end
+
+-- _SET_MP_GAMER_TAG_VISIBILITY  (0x93171DDDAB274EB8)
+-- visibility:
+-- enum eUIGamertagVisibility
+-- {
+-- 	UIGAMERTAGVISIBILITY_NONE,
+-- 	UIGAMERTAGVISIBILITY_ICON,
+-- 	UIGAMERTAGVISIBILITY_SIMPLE,
+-- 	UIGAMERTAGVISIBILITY_COMPLEX
+-- };
+-- min build: 1207
+---@param gamerTagId number
+---@param visibility number
+function _SetMpGamerTagVisibility(gamerTagId, visibility) end
+
+-- _SET_TEXT_COLOR  (0x50A41AD966910F03)
+-- This native does nothing since build 1436, use _BG_SET_TEXT_COLOR (0x16FA5CE47F184F1E) instead.
+-- min build: 1207
+---@param r number
+---@param g number
+---@param b number
+---@param a number
+function _SetTextColor(r, g, b, a) end
+
+-- _SHOW_HORSE_CORES  (0xD4EE21B7CC7FD350)
+-- min build: 1207
+---@param state boolean
+function _ShowHorseCores(state) end
+
+-- _SHOW_PLAYER_CORES  (0x50C803A4CD5932C5)
+-- min build: 1207
+---@param state boolean
+function _ShowPlayerCores(state) end
+
+-- _TEXT_BLOCK_DELETE  (0xAA03F130A637D923)
+-- min build: 1207
+---@param textBlock string
+function _TextBlockDelete(textBlock) end
+
+-- _TEXT_BLOCK_IS_STREAMED  (0x3CF96E16265B7DC8)
+-- min build: 1207
+---@param textBlock string
+---@return boolean
+function _TextBlockIsStreamed(textBlock) end
+
+-- _UI_PROMPT_ADD_GROUP_LINK  (0x684C96CC7C66E8EF)
+-- min build: 1207
+---@param p0 any
+---@param prompt number
+---@param p2 any
+function _UiPromptAddGroupLink(p0, prompt, p2) end
+
+-- _UI_PROMPT_ADD_GROUP_RETURN_LINK  (0x837972ED28159536)
+-- min build: 1207
+---@param p0 any
+---@param prompt number
+function _UiPromptAddGroupReturnLink(p0, prompt) end
+
+-- _UI_PROMPT_CLEAR_HORIZONTAL_ORIENTATION  (0x6095358C4142932A)
+-- id is the return value from 0xD9459157EB22C895.
+-- min build: 1207
+---@param id number
+function _UiPromptClearHorizontalOrientation(id) end
+
+-- _UI_PROMPT_CLEAR_PROMPT_PRIORITY_PREFERENCE  (0x51259AE5C72D4A1B)
+-- min build: 1207
+function _UiPromptClearPromptPriorityPreference() end
+
+-- _UI_PROMPT_CONTEXT_SET_POINT  (0xAE84C5EE2C384FB3)
+-- min build: 1207
+---@param prompt number
+---@param x number
+---@param y number
+---@param z number
+function _UiPromptContextSetPoint(prompt, x, y, z) end
+
+-- _UI_PROMPT_CONTEXT_SET_RADIUS  (0x0C718001B77CA468)
+-- min build: 1207
+---@param prompt number
+---@param radius number
+function _UiPromptContextSetRadius(prompt, radius) end
+
+-- _UI_PROMPT_CONTEXT_SET_VOLUME  (0x4D107406667423BE)
+-- Attaches a Volume
+-- min build: 1207
+---@param prompt number
+---@param volume number
+function _UiPromptContextSetVolume(prompt, volume) end
+
+-- _UI_PROMPT_CREATE  (0x29FA7910726C3889)
+-- min build: 1207
+---@param inputHash number
+---@param labelName string
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 number
+---@return number
+function _UiPromptCreate(inputHash, labelName, p2, p3, p4, p5) end
+
+-- _UI_PROMPT_DELETE  (0x00EDE88D4D13CF59)
+-- min build: 1207
+---@param prompt number
+function _UiPromptDelete(prompt) end
+
+-- _UI_PROMPT_DISABLE_PROMPT_TYPE_THIS_FRAME  (0xFC094EF26DD153FA)
+-- min build: 1207
+---@param p0 number
+function _UiPromptDisablePromptTypeThisFrame(p0) end
+
+-- _UI_PROMPT_DISABLE_PROMPTS_THIS_FRAME  (0xF1622CE88A1946FB)
+-- min build: 1207
+function _UiPromptDisablePromptsThisFrame() end
+
+-- _UI_PROMPT_DOES_AMBIENT_GROUP_EXIST  (0xEB550B927B34A1BB)
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _UiPromptDoesAmbientGroupExist(hash) end
+
+-- _UI_PROMPT_ENABLE_PROMPT_TYPE_THIS_FRAME  (0x06565032897BA861)
+-- https://github.com/femga/rdr3_discoveries/tree/master/graphics/HUD/prompts/prompt_types
+-- min build: 1207
+---@param p0 number
+function _UiPromptEnablePromptTypeThisFrame(p0) end
+
+-- _UI_PROMPT_FILTER_CLEAR  (0x6A2F820452017EA2)
+-- min build: 1207
+function _UiPromptFilterClear() end
+
+-- _UI_PROMPT_GET_GROUP_ACTIVE_PAGE  (0xC1FCC36C3F7286C8)
+-- min build: 1207
+---@param hash number
+---@return number
+function _UiPromptGetGroupActivePage(hash) end
+
+-- _UI_PROMPT_GET_GROUP_ID_FOR_SCENARIO_POINT  (0xCB73D7521E7103F0)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@return number
+function _UiPromptGetGroupIdForScenarioPoint(p0, p1) end
+
+-- _UI_PROMPT_GET_GROUP_ID_FOR_TARGET_ENTITY  (0xB796970BD125FCE8)
+-- min build: 1207
+---@param entity number
+---@return number
+function _UiPromptGetGroupIdForTargetEntity(entity) end
+
+-- _UI_PROMPT_GET_MASH_MODE_PROGRESS  (0x8A9585293863B8A5)
+-- min build: 1207
+---@param prompt number
+---@return number
+function _UiPromptGetMashModeProgress(prompt) end
+
+-- _UI_PROMPT_GET_PROGRESS  (0x81801291806DBC50)
+-- min build: 1207
+---@param prompt number
+---@return number
+function _UiPromptGetProgress(prompt) end
+
+-- _UI_PROMPT_GET_URGENT_PULSING_ENABLED  (0x1FBA0DABECDDB52B)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptGetUrgentPulsingEnabled(prompt) end
+
+-- _UI_PROMPT_HAS_HOLD_AUTO_FILL_MODE  (0x8010BEBD0D5ED5BC)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasHoldAutoFillMode(prompt) end
+
+-- _UI_PROMPT_HAS_HOLD_MODE  (0xB60C9F9ED47ABB76)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasHoldMode(prompt) end
+
+-- _UI_PROMPT_HAS_HOLD_MODE_COMPLETED  (0xE0F65F0640EF0617)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasHoldModeCompleted(prompt) end
+
+-- _UI_PROMPT_HAS_MANUAL_MASH_MODE  (0xA6C6A4ADB3BAC409)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasManualMashMode(prompt) end
+
+-- _UI_PROMPT_HAS_MASH_MODE  (0xCD072523791DDC1B)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasMashMode(prompt) end
+
+-- _UI_PROMPT_HAS_MASH_MODE_COMPLETED  (0x845CE958416DC473)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasMashModeCompleted(prompt) end
+
+-- _UI_PROMPT_HAS_MASH_MODE_FAILED  (0x25B18E530CF39D6F)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasMashModeFailed(prompt) end
+
+-- _UI_PROMPT_HAS_MASH_MODE_JUST_PRESSED  (0xB0E8599243B3F568)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasMashModeJustPressed(prompt) end
+
+-- _UI_PROMPT_HAS_PRESSED_TIMED_MODE_COMPLETED  (0x3CE854D250A88DAF)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasPressedTimedModeCompleted(prompt) end
+
+-- _UI_PROMPT_HAS_PRESSED_TIMED_MODE_FAILED  (0x1A17B9ECFF617562)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptHasPressedTimedModeFailed(prompt) end
+
+-- _UI_PROMPT_HAS_STANDARD_MODE_COMPLETED  (0xC92AC953F0A982AE)
+-- Params: p1 is 0
+-- min build: 1207
+---@param prompt number
+---@param p1 number
+---@return boolean
+function _UiPromptHasStandardModeCompleted(prompt, p1) end
+
+-- _UI_PROMPT_IS_ACTIVE  (0x546E342E01DE71CF)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsActive(prompt) end
+
+-- _UI_PROMPT_IS_ENABLED  (0x0D00EDDFB58B7F28)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsEnabled(prompt) end
+
+-- _UI_PROMPT_IS_HOLD_MODE_RUNNING  (0xC7D70EAEF92EFF48)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsHoldModeRunning(prompt) end
+
+-- _UI_PROMPT_IS_JUST_PRESSED  (0x2787CC611D3FACC5)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsJustPressed(prompt) end
+
+-- _UI_PROMPT_IS_JUST_RELEASED  (0x635CC82FA297A827)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsJustReleased(prompt) end
+
+-- _UI_PROMPT_IS_PRESSED  (0x21E60E230086697F)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsPressed(prompt) end
+
+-- _UI_PROMPT_IS_RELEASED  (0xAFC887BA7A7756D6)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsReleased(prompt) end
+
+-- _UI_PROMPT_IS_VALID  (0x347469FBDD1589A9)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptIsValid(prompt) end
+
+-- _UI_PROMPT_REGISTER_BEGIN  (0x04F97DE45A519419)
+-- min build: 1207
+---@return number
+function _UiPromptRegisterBegin() end
+
+-- _UI_PROMPT_REGISTER_END  (0xF7AA2696A22AD8B9)
+-- min build: 1207
+---@param prompt number
+function _UiPromptRegisterEnd(prompt) end
+
+-- _UI_PROMPT_REMOVE_GROUP  (0x4E52C800A28F7BE8)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptRemoveGroup(prompt, p1) end
+
+-- _UI_PROMPT_RESTART_MODES  (0xDC6C55DFA2C24EE5)
+-- min build: 1207
+---@param prompt number
+function _UiPromptRestartModes(prompt) end
+
+-- _UI_PROMPT_SET_ACTIVE_GROUP_THIS_FRAME  (0xC65A45D4453C2627)
+-- Note: you must use VAR_STRING for p1 if string is not part of text database
+-- tabAmount: specifies number of tabs in prompt group
+-- tabDefaultIndex: specifies starting index
+-- p3 if is set > 3 you can no longer press Q to change tab if there are more than one tab set in tabAmount
+-- min build: 1207
+---@param hash number
+---@param name string
+---@param tabAmount number
+---@param tabDefaultIndex number
+---@param p4 number
+---@param prompt number
+---@return any
+function _UiPromptSetActiveGroupThisFrame(hash, name, tabAmount, tabDefaultIndex, p4, prompt) end
+
+-- _UI_PROMPT_SET_ALLOWED_ACTION  (0x565C1CE183CB0EAF)
+-- min build: 1207
+---@param prompt number
+---@param action number
+function _UiPromptSetAllowedAction(prompt, action) end
+
+-- _UI_PROMPT_SET_AMBIENT_GROUP_THIS_FRAME  (0x315C81D760609108)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param name string
+---@param p6 number
+---@return any
+function _UiPromptSetAmbientGroupThisFrame(entity, p1, p2, p3, p4, name, p6) end
+
+-- _UI_PROMPT_SET_ATTRIBUTE  (0x560E76D5E2E1803F)
+-- attribute: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eUIPromptAttribute
+-- min build: 1207
+---@param prompt number
+---@param attribute number
+---@param enabled boolean
+function _UiPromptSetAttribute(prompt, attribute, enabled) end
+
+-- _UI_PROMPT_SET_BEAT_MODE  (0xF957A1654C6322FE)
+-- min build: 1207
+---@param prompt number
+---@param toggle boolean
+function _UiPromptSetBeatMode(prompt, toggle) end
+
+-- _UI_PROMPT_SET_BEAT_MODE_GRAYED_OUT  (0xB487A4936FBF40AC)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptSetBeatModeGrayedOut(prompt, p1) end
+
+-- _UI_PROMPT_SET_CONTROL_ACTION  (0xB5352B7494A08258)
+-- min build: 1207
+---@param prompt number
+---@param action number
+---@return any
+function _UiPromptSetControlAction(prompt, action) end
+
+-- _UI_PROMPT_SET_ENABLED  (0x8A0FB4D03A630D21)
+-- min build: 1207
+---@param prompt number
+---@param toggle boolean
+function _UiPromptSetEnabled(prompt, toggle) end
+
+-- _UI_PROMPT_SET_GROUP  (0x2F11D3A254169EA4)
+-- tabIndex: specifies tab of prompt
+-- min build: 1207
+---@param prompt number
+---@param groupId number
+---@param tabIndex number
+function _UiPromptSetGroup(prompt, groupId, tabIndex) end
+
+-- _UI_PROMPT_SET_HOLD_AUTO_FILL_MODE  (0x3CE932E737C145D6)
+-- min build: 1207
+---@param prompt number
+---@param autoFillTimeMs number
+---@param holdTimeMs number
+function _UiPromptSetHoldAutoFillMode(prompt, autoFillTimeMs, holdTimeMs) end
+
+-- _UI_PROMPT_SET_HOLD_AUTO_FILL_WITH_DECAY_MODE  (0xA3F2149AA24F3D8E)
+-- min build: 1207
+---@param prompt number
+---@param autoFillTimeMs number
+---@param holdTimeMs number
+function _UiPromptSetHoldAutoFillWithDecayMode(prompt, autoFillTimeMs, holdTimeMs) end
+
+-- _UI_PROMPT_SET_HOLD_INDEFINITELY_MODE  (0xEA5CCF4EEB2F82D1)
+-- min build: 1207
+---@param prompt number
+function _UiPromptSetHoldIndefinitelyMode(prompt) end
+
+-- _UI_PROMPT_SET_HOLD_MODE  (0x94073D5CA3F16B7B)
+-- Params: p2 is 304000 in R* SP Script coachrobberies
+-- min build: 1207
+---@param prompt number
+---@param holdTimeMs number
+function _UiPromptSetHoldMode(prompt, holdTimeMs) end
+
+-- _UI_PROMPT_SET_MANUAL_RESOLVED  (0xA520C7B05FA4EB2A)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptSetManualResolved(prompt, p1) end
+
+-- _UI_PROMPT_SET_MASH_AUTO_FILL_MODE  (0x6C39587D7CC66801)
+-- min build: 1207
+---@param prompt number
+---@param autoFillTimeMs number
+---@param mashes number
+function _UiPromptSetMashAutoFillMode(prompt, autoFillTimeMs, mashes) end
+
+-- _UI_PROMPT_SET_MASH_INDEFINITELY_MODE  (0x7B66E89312727274)
+-- min build: 1207
+---@param prompt number
+function _UiPromptSetMashIndefinitelyMode(prompt) end
+
+-- _UI_PROMPT_SET_MASH_MANUAL_CAN_FAIL_MODE  (0x179DCF71F705DA20)
+-- min build: 1207
+---@param prompt number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 any
+function _UiPromptSetMashManualCanFailMode(prompt, p1, p2, p3, p4) end
+
+-- _UI_PROMPT_SET_MASH_MANUAL_MODE  (0x32DF729D8BD3C1C6)
+-- min build: 1207
+---@param prompt number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 any
+function _UiPromptSetMashManualMode(prompt, p1, p2, p3, p4) end
+
+-- _UI_PROMPT_SET_MASH_MANUAL_MODE_DECAY_SPEED  (0x7D393C247FB9B431)
+-- standard (prompt not held) rate: 0.035f
+-- fast (prompt held) rate: 0.015f
+-- punitive (been hit) rate: 0.14f
+-- min build: 1207
+---@param prompt number
+---@param speed number
+function _UiPromptSetMashManualModeDecaySpeed(prompt, speed) end
+
+-- _UI_PROMPT_SET_MASH_MANUAL_MODE_INCREASE_PER_PRESS  (0xA0D1D79C6036A855)
+-- standard (prompt not held) rate: (1f / 128f)
+-- fast (prompt held) rate: (1f / 64f)
+-- punitive (been hit) rate: (1f / 128f)
+-- min build: 1207
+---@param prompt number
+---@param rate number
+function _UiPromptSetMashManualModeIncreasePerPress(prompt, rate) end
+
+-- _UI_PROMPT_SET_MASH_MANUAL_MODE_PRESSED_GROWTH_SPEED  (0x56DBB26F98582C29)
+-- min build: 1207
+---@param prompt number
+---@param speed number
+function _UiPromptSetMashManualModePressedGrowthSpeed(prompt, speed) end
+
+-- _UI_PROMPT_SET_MASH_MODE  (0xDF6423BF071C7F71)
+-- min build: 1207
+---@param prompt number
+---@param mashes number
+function _UiPromptSetMashMode(prompt, mashes) end
+
+-- _UI_PROMPT_SET_MASH_WITH_RESISTANCE_CAN_FAIL_MODE  (0xDC0CB602DEADBA53)
+-- Sets the mode for the given prompt to mash mode.
+-- decreaseSpeed: 0.0f will result in the prompt not showing the mash progress at all. 0.01f - ?.0f. At speeds around 7.0f to 8.0f the prompt basically fails immediately if you don't start mashing right away.
+-- startProgress: 0.0f - 1.0f is a percentage value, so 0.5f = 50% progress. Range: 0.0f - 1.0f 
+-- min build: 1207
+---@param prompt number
+---@param mashes number
+---@param decreaseSpeed number
+---@param startProgress number
+function _UiPromptSetMashWithResistanceCanFailMode(prompt, mashes, decreaseSpeed, startProgress) end
+
+-- _UI_PROMPT_SET_MASH_WITH_RESISTANCE_MODE  (0xCD1BDFF15EFA79F5)
+-- min build: 1207
+---@param prompt number
+---@param mashes number
+---@param p2 number
+---@param p3 number
+function _UiPromptSetMashWithResistanceMode(prompt, mashes, p2, p3) end
+
+-- _UI_PROMPT_SET_ORDERING_AS_INPUT_TYPE  (0x2F385ECC5200938D)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptSetOrderingAsInputType(prompt, p1) end
+
+-- _UI_PROMPT_SET_PRESSED_TIMED_MODE  (0x1473D3AF51D54276)
+-- min build: 1207
+---@param prompt number
+---@param depletionTimeMs number
+function _UiPromptSetPressedTimedMode(prompt, depletionTimeMs) end
+
+-- _UI_PROMPT_SET_PRIORITY  (0xCA24F528D0D16289)
+-- priority: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ePromptPriority
+-- min build: 1207
+---@param prompt number
+---@param priority number
+function _UiPromptSetPriority(prompt, priority) end
+
+-- _UI_PROMPT_SET_PROMPT_PRIORITY_PREFERENCE  (0x530A428705BE5DEF)
+-- min build: 1207
+---@param ped number
+function _UiPromptSetPromptPriorityPreference(ped) end
+
+-- _UI_PROMPT_SET_REGISTER_HORIZONTAL_ORIENTATION  (0xD9459157EB22C895)
+-- This returns an id that can be used with 0x6095358C4142932A.
+-- min build: 1207
+---@return number
+function _UiPromptSetRegisterHorizontalOrientation() end
+
+-- _UI_PROMPT_SET_ROTATE_MODE  (0x7ABE7095FB3D2581)
+-- Used for controllers
+-- min build: 1207
+---@param prompt number
+---@param p1 number
+---@param counterclockwise boolean
+function _UiPromptSetRotateMode(prompt, p1, counterclockwise) end
+
+-- _UI_PROMPT_SET_SPINNER_POSITION  (0x832CB510DE546282)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptSetSpinnerPosition(prompt, p1) end
+
+-- _UI_PROMPT_SET_SPINNER_SPEED  (0xAC6586A7FDCD4B68)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptSetSpinnerSpeed(prompt, p1) end
+
+-- _UI_PROMPT_SET_STANDARD_MODE  (0xCC6656799977741B)
+-- min build: 1207
+---@param prompt number
+---@param releaseMode boolean
+function _UiPromptSetStandardMode(prompt, releaseMode) end
+
+-- _UI_PROMPT_SET_STANDARDIZED_HOLD_MODE  (0x74C7D7B72ED0D3CF)
+-- holdType: SHORT_TIMED_EVENT_MP, SHORT_TIMED_EVENT, MEDIUM_TIMED_EVENT, LONG_TIMED_EVENT, RUSTLING_CALM_TIMING, PLAYER_FOCUS_TIMING, PLAYER_REACTION_TIMING
+-- min build: 1207
+---@param prompt number
+---@param holdType number
+function _UiPromptSetStandardizedHoldMode(prompt, holdType) end
+
+-- _UI_PROMPT_SET_TAG  (0xDEC85C174751292B)
+-- min build: 1207
+---@param prompt number
+---@param p1 any
+function _UiPromptSetTag(prompt, p1) end
+
+-- _UI_PROMPT_SET_TARGET_MODE  (0x5F6503D9CD2754EB)
+-- min build: 1207
+---@param prompt number
+---@param p1 number
+---@param p2 number
+---@param p3 any
+function _UiPromptSetTargetMode(prompt, p1, p2, p3) end
+
+-- _UI_PROMPT_SET_TARGET_MODE_PROGRESS  (0x00123054BEC8A30F)
+-- min build: 1207
+---@param prompt number
+---@param progress number
+function _UiPromptSetTargetModeProgress(prompt, progress) end
+
+-- _UI_PROMPT_SET_TARGET_MODE_TARGET  (0x5E019C45DD3B6A14)
+-- min build: 1207
+---@param prompt number
+---@param p1 number
+---@param p2 number
+function _UiPromptSetTargetModeTarget(prompt, p1, p2) end
+
+-- _UI_PROMPT_SET_TEXT  (0x5DD02A8318420DD7)
+-- min build: 1207
+---@param prompt number
+---@param text string
+function _UiPromptSetText(prompt, text) end
+
+-- _UI_PROMPT_SET_TRANSPORT_MODE  (0x876E4A35C73A6655)
+-- TM_ANY = 0,
+-- TM_ON_FOOT,
+-- TM_IN_VEHICLE
+-- min build: 1207
+---@param prompt number
+---@param mode number
+function _UiPromptSetTransportMode(prompt, mode) end
+
+-- _UI_PROMPT_SET_TYPE  (0xF4A5C4509BF923B1)
+-- Params: type = mostly 0, 6 (net_mission_intro_story_gvo), 7 (fm_mission_controller), 14 (net_ugc_end_flow_transition_online), 15 (net_main_[tlg_]offline)
+-- min build: 1207
+---@param prompt number
+---@param type number
+function _UiPromptSetType(prompt, type) end
+
+-- _UI_PROMPT_SET_URGENT_PULSING_ENABLED  (0xC5F428EE08FA7F2C)
+-- min build: 1207
+---@param prompt number
+---@param toggle boolean
+function _UiPromptSetUrgentPulsingEnabled(prompt, toggle) end
+
+-- _UI_PROMPT_SET_VISIBLE  (0x71215ACCFDE075EE)
+-- min build: 1207
+---@param prompt number
+---@param toggle boolean
+function _UiPromptSetVisible(prompt, toggle) end
+
+-- _UI_PROMPT_WAS_BEAT_MODE_PRESSED_IN_TIME_WINDOW  (0x1FE4788AB1430C55)
+-- min build: 1207
+---@param prompt number
+---@return boolean
+function _UiPromptWasBeatModePressedInTimeWindow(prompt) end
+
+-- ALLOW_PAUSE_WHEN_NOT_IN_STATE_OF_PLAY_THIS_FRAME  (0x30996422DF1EE561)
+-- Old name: _ALLOW_PAUSE_MENU_WHEN_DEAD_THIS_FRAME
+-- min build: 1207
+function AllowPauseWhenNotInStateOfPlayThisFrame() end
+
+-- BUSYSPINNER_IS_ON  (0x823BF7B1DF613A21)
+-- min build: 1207
+---@return boolean
+function BusyspinnerIsOn() end
+
+-- BUSYSPINNER_OFF  (0x58F441B90EA84D06)
+-- Removes the loading prompt at the bottom right of the screen.
+-- min build: 1207
+function BusyspinnerOff() end
+
+-- CLEAR_ALL_HELP_MESSAGES  (0x916ED8321F087059)
+-- min build: 1207
+function ClearAllHelpMessages() end
+
+-- CREATE_FAKE_MP_GAMER_TAG  (0x53CB4B502E1C57EA)
+-- min build: 1207
+---@param ped number
+---@param username string
+---@param pointedClanTag boolean
+---@param isRockstarClan boolean
+---@param clanTag string
+---@param clanFlag number
+---@return number
+function CreateFakeMpGamerTag(ped, username, pointedClanTag, isRockstarClan, clanTag, clanFlag) end
+
+-- DISABLE_FRONTEND_THIS_FRAME  (0x56CE42A528156A67)
+-- min build: 1207
+function DisableFrontendThisFrame() end
+
+-- DISPLAY_HUD  (0xD63FE3AF9FB3D53F)
+-- If Hud should be displayed
+-- min build: 1207
+---@param toggle boolean
+function DisplayHud(toggle) end
+
+-- DOES_TEXT_LABEL_EXIST  (0x73C258C68D6F55B6)
+-- Checks if the passed gxt name exists in the game files.
+-- min build: 1207
+---@param label string
+---@return boolean
+function DoesTextLabelExist(label) end
+
+-- GET_CHARACTER_FROM_AUDIO_CONVERSATION_FILENAME  (0x9D7E12EC6A1EE4E5)
+-- Note: you must use VAR_STRING. Byte code very similar to TEXT_COMMAND_DISPLAY_TEXT in V
+-- Old name: _GET_TEXT_SUBSTRING
+-- min build: 1207
+---@param text string
+---@param position number
+---@param length number
+---@return string
+function GetCharacterFromAudioConversationFilename(text, position, length) end
+
+-- GET_FILENAME_FOR_AUDIO_CONVERSATION  (0xCFEDCCAD3C5BA90D)
+-- Gets a string literal from a label name.
+-- 
+-- Old name: _GET_LABEL_TEXT
+-- min build: 1207
+---@param labelName string
+---@return string
+function GetFilenameForAudioConversation(labelName) end
+
+-- GET_HUD_SCREEN_POSITION_FROM_WORLD_POSITION  (0xB39C81628EF10B42)
+-- min build: 1207
+---@param worldX number
+---@param worldY number
+---@param worldZ number
+---@return number
+---@return number
+---@return number
+function GetHudScreenPositionFromWorldPosition(worldX, worldY, worldZ) end
+
+-- GET_LENGTH_OF_LITERAL_STRING  (0x481FBF588B0B76DB)
+-- Returns the length of the string passed (much like strlen).
+-- min build: 1207
+---@param string string
+---@return number
+function GetLengthOfLiteralString(string) end
+
+-- GET_LENGTH_OF_LITERAL_STRING_IN_BYTES  (0xDC5AD6B7AB8184F5)
+-- min build: 1207
+---@param string string
+---@return number
+function GetLengthOfLiteralStringInBytes(string) end
+
+-- GET_NAMED_RENDERTARGET_RENDER_ID  (0xB6762A85EE29AA60)
+-- min build: 1207
+---@param name string
+---@return number
+function GetNamedRendertargetRenderId(name) end
+
+-- GET_STRING_FROM_HASH_KEY  (0xBD5DD5EAE2B6CE14)
+-- Returns the label text given the hash.
+-- 
+-- Old name: _GET_LABEL_TEXT_BY_HASH
+-- min build: 1207
+---@param labelHash number
+---@return string
+function GetStringFromHashKey(labelHash) end
+
+-- HIDE_HUD_AND_RADAR_THIS_FRAME  (0x36CDD81627A6FCD2)
+-- min build: 1207
+function HideHudAndRadarThisFrame() end
+
+-- HIDE_LOADING_ON_FADE_THIS_FRAME  (0xEA600AABAF4B9084)
+-- min build: 1207
+function HideLoadingOnFadeThisFrame() end
+
+-- IS_HUD_HIDDEN  (0x71B72B478F8189DC)
+-- min build: 1207
+---@return boolean
+function IsHudHidden() end
+
+-- IS_MP_GAMER_TAG_ACTIVE  (0x6E1C31E14C7A5F97)
+-- min build: 1207
+---@param gamerTagId number
+---@return boolean
+function IsMpGamerTagActive(gamerTagId) end
+
+-- IS_NAMED_RENDERTARGET_LINKED  (0x707032835FF09AE7)
+-- min build: 1207
+---@param modelHash number
+---@return boolean
+function IsNamedRendertargetLinked(modelHash) end
+
+-- IS_NAMED_RENDERTARGET_REGISTERED  (0x3EE32F7964C40FE6)
+-- min build: 1207
+---@param name string
+---@return boolean
+function IsNamedRendertargetRegistered(name) end
+
+-- IS_PAUSE_MENU_ACTIVE  (0x535384D6067BA42E)
+-- Returns true when either Pause Menu, a Frontend Menu, Online Policies menu or Social Club menu is active.
+-- min build: 1207
+---@return boolean
+function IsPauseMenuActive() end
+
+-- IS_RADAR_HIDDEN  (0x1B82FD5FFA4D666E)
+-- min build: 1207
+---@return boolean
+function IsRadarHidden() end
+
+-- IS_RADAR_HIDDEN_BY_SCRIPT  (0x66F35DD9D2B58579)
+-- min build: 1207
+---@return boolean
+function IsRadarHiddenByScript() end
+
+-- IS_RADAR_PREFERENCE_SWITCHED_ON  (0x81E47F0EE1F2B21E)
+-- min build: 1207
+---@return boolean
+function IsRadarPreferenceSwitchedOn() end
+
+-- IS_SUBTITLE_PREFERENCE_SWITCHED_ON  (0x7C4AC9573587F2DF)
+-- min build: 1355
+---@return boolean
+function IsSubtitlePreferenceSwitchedOn() end
+
+-- LINK_NAMED_RENDERTARGET  (0x2F506B8556242DDB)
+-- min build: 1207
+---@param modelHash number
+function LinkNamedRendertarget(modelHash) end
+
+-- REGISTER_NAMED_RENDERTARGET  (0x98AF2BB6F62BD588)
+-- min build: 1207
+---@param name string
+---@param p1 boolean
+---@return boolean
+function RegisterNamedRendertarget(name, p1) end
+
+-- RELEASE_NAMED_RENDERTARGET  (0x0E692EE61761361F)
+-- min build: 1207
+---@param name string
+---@return boolean
+function ReleaseNamedRendertarget(name) end
+
+-- REMOVE_MP_GAMER_TAG  (0x839BFD7D7E49FE09)
+-- min build: 1207
+---@param gamerTagId number
+function RemoveMpGamerTag(gamerTagId) end
+
+-- SET_FRONTEND_ACTIVE  (0xCE47C21C0687EBC2)
+-- min build: 1207
+---@param active boolean
+function SetFrontendActive(active) end
+
+-- SET_MISSION_NAME  (0x402669A4BDAA72DA)
+-- min build: 1207
+---@param p0 boolean
+---@param name string
+function SetMissionName(p0, name) end
+
+-- SET_MISSION_NAME_FOR_UGC_MISSION  (0xD98630CE73C61E98)
+-- min build: 1207
+---@param p0 boolean
+---@param name string
+function SetMissionNameForUgcMission(p0, name) end
+
+-- SET_MP_GAMER_TAG_BIG_TEXT  (0xA0D7CE5F83259663)
+-- min build: 1207
+---@param gamerTagId number
+---@param string string
+function SetMpGamerTagBigText(gamerTagId, string) end
+
+-- SET_MP_GAMER_TAG_NAME  (0xEA6F4B8D4B4B5B3E)
+-- min build: 1207
+---@param gamerTagId number
+---@param string string
+function SetMpGamerTagName(gamerTagId, string) end
+
+-- SET_TEXT_RENDER_ID  (0xE550CDE128D56757)
+-- min build: 1207
+---@param renderId number
+function SetTextRenderId(renderId) end
+
+-- TEXT_BLOCK_IS_LOADED  (0xD0976CC34002DB57)
+-- min build: 1207
+---@param textBlock string
+---@return boolean
+function TextBlockIsLoaded(textBlock) end
+
+-- TEXT_BLOCK_REQUEST  (0xF66090013DE648D5)
+-- min build: 1207
+---@param textBlock string
+function TextBlockRequest(textBlock) end
+
+-- UI_GET_SCENE_UIOBJECT  (0xBE1067CD1C9570F6)
+-- min build: 1207
+---@param p0 any
+---@return any
+function UiGetSceneUiobject(p0) end
+
+-- UI_MOVIEVIEW_SET_RENDER_TARGET  (0x51DE09A2196BD951)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function UiMovieviewSetRenderTarget(p0, p1) end
+
+-- UI_PROMPT_IS_CONTROL_ACTION_ACTIVE  (0x1BE19185B8AFE299)
+-- min build: 1207
+---@param controlAction number
+---@return boolean
+function UiPromptIsControlActionActive(controlAction) end
+
+-- UI_REQUEST_SCENE  (0xB6857100F8FD433C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function UiRequestScene(p0, p1) end

--- a/.luals/redm-natives/IK.lua
+++ b/.luals/redm-natives/IK.lua
@@ -1,0 +1,107 @@
+---@meta
+
+-- RDR3 namespace: IK -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _IK_SET_FOCUS_ENTITY_FOR_PED  (0x873C792E07A32C8B)
+-- Sets or clears the ped's current IK focus/target entity reference.
+-- 
+-- Notes:
+-- - Pass 0 as targetEntity to clear/reset the current IK focus entity.
+-- - Commonly used alongside look-at / anim-scene transitions / TASK_CLEAR_LOOK_AT.
+-- - Scripts often set this to the player ped when the actor should focus the player, and reset it back to 0 when leaving that state.
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+function _IkSetFocusEntityForPed(ped, targetEntity) end
+
+-- _INVERSE_KINEMATICS_IS_ACTIVE  (0x6098139150DCC745)
+-- Returns whether a specific IK index is currently active on the ped.
+-- 
+-- Notes:
+-- - ikIndex is the IK index to query.
+-- - Example research usage: index 6 is used for head/look-at IK and returns true while that IK is active.
+-- min build: 1207
+---@param ped number
+---@param ikIndex number
+---@return boolean
+function _InverseKinematicsIsActive(ped, ikIndex) end
+
+-- _INVERSE_KINEMATICS_POINT_AT  (0x0B9F7A01EC50448D)
+-- Makes the ped point at a target with an arm. Must be called every frame while the point-at behavior should remain active.
+-- 
+-- args:
+-- struct PointAtParams
+-- {
+-- 	alignas(8) BOOL   isRightHand;
+-- 	alignas(8) float  offsetX;
+-- 	alignas(8) float  offsetY;
+-- 	alignas(8) float  offsetZ;
+-- 	alignas(8) Entity entity;
+-- 	alignas(8) int    boneIndex;
+-- 	alignas(8) int    flags;     // (1 << 22) attaches the point-at to the target
+-- 	alignas(8) int    p6;        // observed 1..5
+-- 	alignas(8) int    p7;        // observed 1..2
+-- };
+-- min build: 1207
+---@param ped number
+---@return any
+function _InverseKinematicsPointAt(ped) end
+
+-- _INVERSE_KINEMATICS_REQUEST_LOOK_AT  (0x66F9EB44342BB4C5)
+-- Requests a look-at IK action for the ped using a script arg struct.
+-- 
+-- args:
+-- struct IkRequestLookAtArgs
+-- {
+-- 	alignas(8) float  x;
+-- 	alignas(8) float  y;
+-- 	alignas(8) float  z;
+-- 	alignas(8) Entity targetEntity;
+-- 	alignas(8) int    targetBone;    // often 21030 (head) or -1
+-- 	alignas(8) int    flags;         // bitfield
+-- 	alignas(8) int    p6;
+-- 	alignas(8) int    durationMs;    // often 500
+-- 	alignas(8) int    p8;
+-- 	alignas(8) int    p9;
+-- 	alignas(8) int    p10;
+-- 	alignas(8) int    p11;
+-- 	alignas(8) int    p12;
+-- 	alignas(8) int    p13;
+-- 	alignas(8) int    p14;
+-- 	alignas(8) int    p15;
+-- 	alignas(8) int    p16;
+-- 	alignas(8) int    p17;
+-- 	alignas(8) int    p18;
+-- 	alignas(8) int    p19;
+-- 	alignas(8) int    p20;
+-- 	alignas(8) int    p21;
+-- 	alignas(8) int    p22;
+-- };
+-- 
+-- static_assert(sizeof(IkRequestLookAtArgs) == 0xB8, "incorrect IkRequestLookAtArgs size");
+-- 
+-- Notes:
+-- - Scripts use this both for entity look-at and world-position/offset look-at.
+-- - Common observed fields: targetEntity, targetBone, durationMs, plus mode/priority-like fields p8 and p17..p22.
+-- - If ped == 0 while a task sequence is active, the native queues an internal look-at IK task into the current sequence instead of applying immediately.
+-- - Pairs naturally with _INVERSE_KINEMATICS_IS_ACTIVE / _INVERSE_KINEMATICS_SET_DISABLED_FOR_PED.
+-- min build: 1207
+---@param ped number
+---@return any
+function _InverseKinematicsRequestLookAt(ped) end
+
+-- _INVERSE_KINEMATICS_SET_DISABLED_FOR_PED  (0x0EABF182FBB63D72)
+-- Enables/disables a specific IK index on the ped.
+-- 
+-- Notes:
+-- - ikIndex is not a raw bit index; it maps to one or more internal IK flags.
+-- - Observed script usage commonly passes ikIndex = 1 during wardrobe/shop-style interactions.
+-- - Valid observed ikIndex range from code: 0..8.
+-- - Pairs naturally with _INVERSE_KINEMATICS_IS_ACTIVE.
+-- min build: 1207
+---@param ped number
+---@param ikIndex number
+---@param disabled boolean
+---@return boolean
+function _InverseKinematicsSetDisabledForPed(ped, ikIndex, disabled) end

--- a/.luals/redm-natives/INTERACTION.lua
+++ b/.luals/redm-natives/INTERACTION.lua
@@ -1,0 +1,49 @@
+---@meta
+
+-- RDR3 namespace: INTERACTION -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _POINTER_IS_BEING_MOVED  (0x2B8B605F2A9E64BF)
+-- Returns true if player is moving mouse while cursor is active
+-- _PI* - _PO*
+-- min build: 1311
+---@return boolean
+function _PointerIsBeingMoved() end
+
+-- _POINTER_IS_LEFT_BUTTON_HELD  (0x61CAE9D1FD055E44)
+-- Returns true if player is holding LMB while cursor is active
+-- _PI* - _PO*
+-- min build: 1207
+---@return boolean
+function _PointerIsLeftButtonHeld() end
+
+-- _POINTER_IS_LEFT_BUTTON_JUST_RELEASED  (0xF7F51A57349739F2)
+-- Returns true if player releases LMB if cursor is active
+-- _PI* - _PO*
+-- min build: 1207
+---@return boolean
+function _PointerIsLeftButtonJustReleased() end
+
+-- _SET_ALLOW_FIRST_PERSON_MOUSE_CAMERA_MOVEMENT  (0x0546B117BB17548B)
+-- Allows camera to be moved if middle mouse button is held while in first person
+-- Must be called every frame
+-- _SET*
+-- min build: 1232
+function _SetAllowFirstPersonMouseCameraMovement() end
+
+-- SET_MOUSE_CURSOR_STYLE  (0x7F5858AAB5A58CCE)
+-- Changes the mouse cursor's sprite.
+-- 
+-- spriteId's: https://github.com/femga/rdr3_discoveries/tree/master/graphics/HUD/cursor_sprites#readme
+-- 
+-- Old name: _SET_MOUSE_CURSOR_SPRITE
+-- min build: 1207
+---@param spriteId number
+function SetMouseCursorStyle(spriteId) end
+
+-- SET_MOUSE_CURSOR_THIS_FRAME  (0xF12E4CCAF249DC10)
+-- Shows the cursor on screen for one frame.
+-- 
+-- Old name: _SET_MOUSE_CURSOR_ACTIVE_THIS_FRAME
+-- min build: 1207
+function SetMouseCursorThisFrame() end

--- a/.luals/redm-natives/INTERIOR.lua
+++ b/.luals/redm-natives/INTERIOR.lua
@@ -1,0 +1,205 @@
+---@meta
+
+-- RDR3 namespace: INTERIOR -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x2533F2AB0EB9C6F9  (0x2533F2AB0EB9C6F9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x2533F2AB0EB9C6F9(p0, p1) end
+
+-- _0xFE2B3D5500B1B2E4  (0xFE2B3D5500B1B2E4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFE2B3D5500B1B2E4(p0, p1) end
+
+-- _GET_INTERIOR_MINIMAP_HASH  (0x3039BE60B3749716)
+-- min build: 1207
+---@param interior number
+---@return number
+function _GetInteriorMinimapHash(interior) end
+
+-- _GET_INTERIOR_POSITION  (0x2C9746D0CA15BE1C)
+-- min build: 1207
+---@param interior number
+---@return vector3
+function _GetInteriorPosition(interior) end
+
+-- _IS_INTERIOR_ENTITY_SET_VALID  (0xD56FF170710FC826)
+-- min build: 1207
+---@param interior number
+---@param entitySetName string
+---@return boolean
+function _IsInteriorEntitySetValid(interior, entitySetName) end
+
+-- ACTIVATE_INTERIOR_ENTITY_SET  (0x174D0AAB11CED739)
+-- https://github.com/femga/rdr3_discoveries/tree/master/interiors/interior_sets
+-- min build: 1207
+---@param interior number
+---@param entitySetName string
+---@param p2 number
+function ActivateInteriorEntitySet(interior, entitySetName, p2) end
+
+-- CLEAR_ROOM_FOR_ENTITY  (0xA1762D5BBFCA13A8)
+-- min build: 1207
+---@param entity number
+function ClearRoomForEntity(entity) end
+
+-- CLEAR_ROOM_FOR_GAME_VIEWPORT  (0x951A049765E0D450)
+-- min build: 1207
+function ClearRoomForGameViewport() end
+
+-- DEACTIVATE_INTERIOR_ENTITY_SET  (0x33B81A2C07A51FFF)
+-- min build: 1207
+---@param interior number
+---@param entitySetName string
+---@param p2 boolean
+function DeactivateInteriorEntitySet(interior, entitySetName, p2) end
+
+-- DISABLE_INTERIOR  (0x3C2B92A1A07D4FCE)
+-- min build: 1207
+---@param interior number
+---@param toggle boolean
+function DisableInterior(interior, toggle) end
+
+-- FORCE_ROOM_FOR_ENTITY  (0xBC29A9894C976945)
+-- min build: 1207
+---@param entity number
+---@param interior number
+---@param roomHashKey number
+function ForceRoomForEntity(entity, interior, roomHashKey) end
+
+-- FORCE_ROOM_FOR_GAME_VIEWPORT  (0x115B4AA8FB28AB43)
+-- min build: 1207
+---@param interiorID number
+---@param roomHashKey number
+function ForceRoomForGameViewport(interiorID, roomHashKey) end
+
+-- GET_INTERIOR_AT_COORDS  (0xCDD36C9E5C469070)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function GetInteriorAtCoords(x, y, z) end
+
+-- GET_INTERIOR_AT_COORDS_WITH_TYPE  (0xAAD6170AA33B13C0)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param interiorType string
+---@return number
+function GetInteriorAtCoordsWithType(x, y, z, interiorType) end
+
+-- GET_INTERIOR_AT_COORDS_WITH_TYPEHASH  (0x3543AEA1816D1D2B)
+-- Hashed version of GET_INTERIOR_AT_COORDS_WITH_TYPE
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param typeHash number
+---@return number
+function GetInteriorAtCoordsWithTypehash(x, y, z, typeHash) end
+
+-- GET_INTERIOR_FROM_COLLISION  (0x5054D1A5218FA696)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function GetInteriorFromCollision(x, y, z) end
+
+-- GET_INTERIOR_FROM_ENTITY  (0xB417689857646F61)
+-- Returns the handle of the interior that the entity is in. Returns 0 if outside.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetInteriorFromEntity(entity) end
+
+-- GET_INTERIOR_FROM_PRIMARY_VIEW  (0xBC8A281FF125C655)
+-- min build: 1207
+---@return number
+function GetInteriorFromPrimaryView() end
+
+-- GET_INTERIOR_LOCATION_AND_NAMEHASH  (0x8451E87D3C2B0286)
+-- min build: 1207
+---@param interior number
+---@return vector3
+---@return number
+function GetInteriorLocationAndNamehash(interior) end
+
+-- GET_KEY_FOR_ENTITY_IN_ROOM  (0x27D7B6F79E1F4603)
+-- Seems to do the exact same as INTERIOR::GET_ROOM_KEY_FROM_ENTITY
+-- min build: 1207
+---@param entity number
+---@return number
+function GetKeyForEntityInRoom(entity) end
+
+-- GET_ROOM_KEY_FROM_ENTITY  (0x076E46E0EB52AFC6)
+-- Gets the room hash key from the room that the specified entity is in. Each room in every interior has a unique key. Returns 0 if the entity is outside.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetRoomKeyFromEntity(entity) end
+
+-- IS_COLLISION_MARKED_OUTSIDE  (0xF291396B517E25B2)
+-- Returns true if the collision at the specified coords is marked as being outside (false if there's an interior)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function IsCollisionMarkedOutside(x, y, z) end
+
+-- IS_INTERIOR_ENTITY_SET_ACTIVE  (0x32810CA2125F5842)
+-- min build: 1207
+---@param interior number
+---@param entitySetName string
+---@return boolean
+function IsInteriorEntitySetActive(interior, entitySetName) end
+
+-- IS_INTERIOR_READY  (0x941560D2D45DBFC8)
+-- min build: 1207
+---@param interior number
+---@return boolean
+function IsInteriorReady(interior) end
+
+-- IS_INTERIOR_SCENE  (0x4200F14D6F840A9A)
+-- min build: 1207
+---@return boolean
+function IsInteriorScene() end
+
+-- IS_VALID_INTERIOR  (0x017C1B3159F79F6C)
+-- min build: 1207
+---@param interior number
+---@return boolean
+function IsValidInterior(interior) end
+
+-- PIN_INTERIOR_IN_MEMORY  (0xBD3D33EABF680168)
+-- min build: 1207
+---@param interior number
+function PinInteriorInMemory(interior) end
+
+-- RETAIN_ENTITY_IN_INTERIOR  (0x5BD616735F16BF5C)
+-- min build: 1207
+---@param entity number
+---@param interior number
+function RetainEntityInInterior(entity, interior) end
+
+-- SET_INTERIOR_IN_USE  (0xB5EF6FEF2DC9EBED)
+-- Actually returns void in IDA but the script header defines a BOOL return type
+-- min build: 1207
+---@param interior number
+---@return boolean
+function SetInteriorInUse(interior) end
+
+-- UNPIN_INTERIOR  (0x07FD1A0B814F6055)
+-- Does something similar to INTERIOR::DISABLE_INTERIOR.
+-- 
+-- You don't fall through the floor but everything is invisible inside and looks the same as when INTERIOR::DISABLE_INTERIOR is used. Peds behaves normally inside.
+-- min build: 1207
+---@param interior number
+function UnpinInterior(interior) end

--- a/.luals/redm-natives/INVENTORY.lua
+++ b/.luals/redm-natives/INVENTORY.lua
@@ -1,0 +1,712 @@
+---@meta
+
+-- RDR3 namespace: INVENTORY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0349404A22736740  (0x0349404A22736740)
+-- Params: p0 is only 0 or 1
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param p0 boolean
+---@param inventoryId number
+---@return any
+function N_0x0349404A22736740(p0, inventoryId) end
+
+-- _0x46DB71883EE9D5AF  (0x46DB71883EE9D5AF)
+-- Returns databindingEntryId to be used with 0x951847CEF3D829FF (p0)
+-- min build: 1207
+---@param data any
+---@param stats string
+---@param ped number
+---@return number
+---@return any
+function N_0x46DB71883EE9D5AF(data, stats, ped) end
+
+-- _0x6862E4D93F64CF01  (0x6862E4D93F64CF01)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param inventoryId number
+---@param p2 number
+---@return boolean
+---@return any
+---@return any
+function N_0x6862E4D93F64CF01(inventoryId, p2) end
+
+-- _0x6968CE7AC32F6788  (0x6968CE7AC32F6788)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param inventoryId number
+function N_0x6968CE7AC32F6788(inventoryId) end
+
+-- _0x75CFAC49301E134F  (0x75CFAC49301E134F)
+-- p0: value returned by 0x9D21B185ABC2DBC4
+-- p1, p2: false
+-- min build: 1207
+---@param databindingEntryId number
+---@param p1 boolean
+---@param p2 boolean
+function N_0x75CFAC49301E134F(databindingEntryId, p1, p2) end
+
+-- _0x951847CEF3D829FF  (0x951847CEF3D829FF)
+-- p0: value returned by 0x46DB71883EE9D5AF
+-- min build: 1207
+---@param p0 any
+---@param ped number
+---@return any
+function N_0x951847CEF3D829FF(p0, ped) end
+
+-- _0x9B4E793B1CB6550A  (0x9B4E793B1CB6550A)
+-- Used in function SET_SHOP_BEING_ROBBED and many other shop related scripts and functions.
+-- INVENTORY_A*
+-- min build: 1207
+function N_0x9B4E793B1CB6550A() end
+
+-- _0x9E58207B194488AC  (0x9E58207B194488AC)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x9E58207B194488AC(ped, p1) end
+
+-- _0xB1DD74A1F5536622  (0xB1DD74A1F5536622)
+-- min build: 1311
+---@param inventoryId number
+---@return boolean
+---@return any
+function N_0xB1DD74A1F5536622(inventoryId) end
+
+-- _0xD08685BA892DBFAB  (0xD08685BA892DBFAB)
+-- Params: p3 returns an int between 0 and 20 (?)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param inventoryId number
+---@return boolean
+---@return any
+---@return number
+---@return number
+function N_0xD08685BA892DBFAB(inventoryId) end
+
+-- _0xE1F45A67A9F0DCBC  (0xE1F45A67A9F0DCBC)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param inventoryId number
+function N_0xE1F45A67A9F0DCBC(inventoryId) end
+
+-- _GET_DEFAULT_ITEM_SLOT_INFO  (0x6452B1D357D81742)
+-- p1: WARDROBE, KIT_CAMP, CHARACTER, KIT_MOONSHINER_PROPERTY
+-- Returns slot hash
+-- min build: 1207
+---@param item number
+---@param p1 number
+---@return number
+function _GetDefaultItemSlotInfo(item, p1) end
+
+-- _GET_ITEM_ROLE_MAX_LEVEL_COUNT  (0xADDD1E7C0ECF7D95)
+-- min build: 1207
+---@param inventoryId number
+---@param eRoleMaxLevel number
+---@return number
+function _GetItemRoleMaxLevelCount(inventoryId, eRoleMaxLevel) end
+
+-- _GET_ITEM_SLOT_MAX_COUNT  (0xE80E50BEE276A54A)
+-- min build: 1207
+---@param provision number
+---@param slotId number
+---@return number
+function _GetItemSlotMaxCount(provision, slotId) end
+
+-- _INVENTORY_ADD_ITEM_WITH_GUID  (0xCB5D11F9508A928D)
+-- inventoryItemSlotHash: https://pastebin.com/P6fyr3vr
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+---@param inventoryItemSlot number
+---@param p5 number
+---@param addReason number
+---@return boolean
+---@return any
+---@return any
+function _InventoryAddItemWithGuid(inventoryId, item, inventoryItemSlot, p5, addReason) end
+
+-- _INVENTORY_APPLY_WEAPON_STATS_TO_ENTRY  (0x75CFAC49301E134E)
+-- Applies weapon stats to the 'CatalogItemInspection' stats entry id.
+-- p0: value returned by 0x9D21B185ABC2DBC5
+-- _INVENTORY_GET*
+-- min build: 1207
+---@param databindingEntryId number
+---@param p1 boolean
+---@param ped number
+function _InventoryApplyWeaponStatsToEntry(databindingEntryId, p1, ped) end
+
+-- _INVENTORY_ARE_LOCAL_CHANGES_ALLOWED  (0x0FBBFFC891A97C81)
+-- inventoryId: see _INVENTORY_GET_PED_INVENTORY_ID
+-- min build: 1207
+---@param inventoryId number
+---@return boolean
+function _InventoryAreLocalChangesAllowed(inventoryId) end
+
+-- _INVENTORY_COMPARE_GUIDS  (0x4C543D5DFCD2DAFD)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _InventoryCompareGuids() end
+
+-- _INVENTORY_COPY_ITEM_TO_INVENTORY  (0xC04F47D488EF9EBA)
+-- min build: 1207
+---@param inventoryId number
+---@param inventoryIdCloned number
+---@param p3 any
+---@return any
+function _InventoryCopyItemToInventory(inventoryId, inventoryIdCloned, p3) end
+
+-- _INVENTORY_COPY_ITEM_TO_MISSION_INVENTORY  (0x3112ADB9D5F3426B)
+-- min build: 1207
+---@param p1 boolean
+---@return any
+function _InventoryCopyItemToMissionInventory(p1) end
+
+-- _INVENTORY_CREATE_CATALOG_ITEM_INSPECTION_EFFECTS_ENTRY  (0x9D21B185ABC2DBC4)
+-- data: return value of DATABINDING::_DATABINDING_ADD_DATA_CONTAINER(..., 'CatalogItemInspection');
+-- name: effects
+-- p2, p3: false
+-- 
+-- Returns databindingEntryId of 'CatalogItemInspection' container to be used with 0x75CFAC49301E134F (p0)
+-- min build: 1207
+---@param data number
+---@param name string
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+function _InventoryCreateCatalogItemInspectionEffectsEntry(data, name, p2, p3) end
+
+-- _INVENTORY_CREATE_CATALOG_ITEM_INSPECTION_STATS_ENTRY  (0x9D21B185ABC2DBC5)
+-- data: return value of DATABINDING::_DATABINDING_ADD_DATA_CONTAINER(..., 'CatalogItemInspection');
+-- name: stats, compareStats
+-- p2: 0
+-- p3: -1
+-- 
+-- Returns databindingEntryId of 'CatalogItemInspection' container to be used with 0x75CFAC49301E134E (p0)
+-- min build: 1207
+---@param data number
+---@param name string
+---@param p2 number
+---@param p3 number
+---@return number
+function _InventoryCreateCatalogItemInspectionStatsEntry(data, name, p2, p3) end
+
+-- _INVENTORY_CREATE_ITEM_COLLECTION  (0x80D78BDC9D88EF07)
+-- filterName (collections): "ALL", "ALL SATCHEL", "ALL HORSES", "ALL COACHES", "ALL MOUNTS", "ALL CLOTHING", "ALL WEAPONS", "ALL SATCHEL EXCLUDING CLOTHING", "ALL EXCLUDING CLOTHING"
+-- slotId: -1591664384
+-- p3: outCollectionSize (?)
+-- Returns collectionId
+-- min build: 1207
+---@param inventoryId number
+---@param filterName string
+---@param slotId number
+---@return number
+---@return number
+function _InventoryCreateItemCollection(inventoryId, filterName, slotId) end
+
+-- _INVENTORY_CREATE_ITEM_COLLECTION_2  (0x97A3646645727F42)
+-- Returns collectionId
+-- min build: 1232
+---@return number
+---@return number
+function _InventoryCreateItemCollection2() end
+
+-- _INVENTORY_CREATE_ITEM_COLLECTION_WITH_FILTER  (0x640F890C3E5A3FFD)
+-- min build: 1207
+---@param inventoryId number
+---@return number
+---@return any
+---@return number
+function _InventoryCreateItemCollectionWithFilter(inventoryId) end
+
+-- _INVENTORY_CREATE_SORTED_COLLECTION  (0xBB7F968675B34B0C)
+-- p1: 32
+-- Returns collectionId
+-- min build: 1311
+---@param inventoryId number
+---@param p1 number
+---@return number
+---@return number
+function _InventoryCreateSortedCollection(inventoryId, p1) end
+
+-- _INVENTORY_DISABLE_ITEM  (0x766315A564594401)
+-- Example: (1, WEAPON_REVOLVER_CATTLEMAN, 0) - disables cattleman revolver on weapon wheel
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+---@param gtxReason number
+function _InventoryDisableItem(inventoryId, item, gtxReason) end
+
+-- _INVENTORY_DISABLE_WEAPONS  (0xE3A46370F70F3607)
+-- Params: p1 = 0
+-- min build: 1207
+---@param inventoryId number
+---@param p1 any
+function _InventoryDisableWeapons(inventoryId, p1) end
+
+-- _INVENTORY_DOES_ITEM_OWN_EQUIPMENT  (0x88B58B83A43A8CAB)
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+---@return boolean
+---@return any
+function _InventoryDoesItemOwnEquipment(inventoryId, item) end
+
+-- _INVENTORY_ENABLE_ITEM  (0x6A564540FAC12211)
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+function _InventoryEnableItem(inventoryId, item) end
+
+-- _INVENTORY_ENABLE_WEAPONS  (0xD5D72F1624F3BA7C)
+-- min build: 1207
+---@param inventoryId number
+function _InventoryEnableWeapons(inventoryId) end
+
+-- _INVENTORY_EQUIP_ITEM_WITH_GUID  (0x734311E2852760D0)
+-- min build: 1207
+---@param inventoryId number
+---@param bEquipped boolean
+---@return boolean
+---@return any
+function _InventoryEquipItemWithGuid(inventoryId, bEquipped) end
+
+-- _INVENTORY_FITS_SLOT_ID  (0x780C5B9AE2819807)
+-- min build: 1207
+---@param item number
+---@param slotId number
+---@return boolean
+function _InventoryFitsSlotId(item, slotId) end
+
+-- _INVENTORY_GET_CHILDREN_COUNT  (0xE843D21A8E2498AA)
+-- min build: 1207
+---@param inventoryId number
+---@return number
+---@return any
+function _InventoryGetChildrenCount(inventoryId) end
+
+-- _INVENTORY_GET_FULL_INVENTORY_ITEM_DATA  (0x025A1B1FB03FBF61)
+-- min build: 1207
+---@param inventoryId number
+---@param p3 number
+---@param p4 number
+---@return boolean
+---@return any
+---@return any
+function _InventoryGetFullInventoryItemData(inventoryId, p3, p4) end
+
+-- _INVENTORY_GET_INVENTORY_ID_FROM_PED  (0x13D234A2A3F66E63)
+-- Returns a unique inventory ID for this ped.
+-- For the local player ped, it is an eInventories value.
+-- For other peds, it is the inventory address casted to unsigned int.
+-- 
+-- enum eInventories
+-- {
+-- 	INVENTORY_INVALID,
+-- 	INVENTORY_SP_PLAYER,
+-- 	INVENTORY_MP_PLAYER,
+-- 	INVENTORY_MP_MISSION,
+-- 	INVENTORY_SECOND_SCREEN,
+-- 	INVENTORY_SP_BACKUP,
+-- 	INVENTORY_SP_SNAPSHOT,
+-- 	INVENTORY_0xDE2AE452,
+-- 	INVENTORY_0x399D9B3A,
+-- 	INVENTORY_0x4BD43FA7,
+-- 	INVENTORY_0x9529D251,
+-- 	INVENTORY_0xA75776AC,
+-- 	INVENTORY_MAX_ID = 11,
+-- 	INVENTORY_IDS_COUNT
+-- };
+-- min build: 1207
+---@param ped number
+---@return number
+function _InventoryGetInventoryIdFromPed(ped) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_CHILD  (0xCD9A485F2B383B44)
+-- min build: 1207
+---@param inventoryId number
+---@param childIndex any
+---@return boolean
+---@return any
+---@return any
+function _InventoryGetInventoryItemChild(inventoryId, childIndex) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_COMPATIBLE_SLOTS  (0x9AC53CB6907B4428)
+-- Writes up to maxResults compatible SLOTID_* hashes for item into outSlotIds (int32 array; unused entries are 0). Commonly used to gather valid equip slots for component/decoration items. Returns true on success.
+-- Example (C++):
+-- 	Hash item = joaat("horse_equipment_western_04_stock_new_saddle_005");
+-- 	int out[30] = {};
+-- 	if (INVENTORY::_INVENTORY_GET_INVENTORY_ITEM_COMPATIBLE_SLOTS(item, out, 30)) {
+-- 		for (int i = 0; i < 30 && out[i] != 0; ++i) {
+-- 			printf("slot[%d] = 0x%08X\n", i + 1, (unsigned)out[i]);
+-- 		}
+-- 	}
+-- Typical result for the sample item includes: SLOTID_HORSE_SADDLEBAG, SLOTID_HORSE_BEDROLL, SLOTID_HORSE_HORN, SLOTID_HORSE_STIRRUP, SLOTID_HORSE_BLANKET, SLOTID_HORSE_REINS, SLOTID_HORSE_SEAT, SLOTID_HORSE_FENDER, SLOTID_HORSE_SKIRT, SLOTID_HORSE_CANTLE, SLOTID_HORSE_LANTERN, SLOTID_HORSE_MASK. Note (FiveM DataView): read each int at an 8-byte stride (i*8).
+-- min build: 1207
+---@param item number
+---@param maxResults number
+---@return boolean
+---@return number
+function _InventoryGetInventoryItemCompatibleSlots(item, maxResults) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_COUNT_WITH_GUID  (0xC97E0D2302382211)
+-- min build: 1207
+---@param inventoryId number
+---@param p2 boolean
+---@return number
+---@return any
+function _InventoryGetInventoryItemCountWithGuid(inventoryId, p2) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_COUNT_WITH_ITEMID  (0xE787F05DFC977BDE)
+-- min build: 1207
+---@param inventoryId number
+---@param eInventoryItem number
+---@param p2 boolean
+---@return number
+function _InventoryGetInventoryItemCountWithItemid(inventoryId, eInventoryItem, p2) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_DESCRIPTION_HASH  (0xA4550FE9C512E3DD)
+-- min build: 1207
+---@param item number
+---@return number
+function _InventoryGetInventoryItemDescriptionHash(item) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_EQUIPPED_IN_SLOT  (0xBE012571B25F5ACA)
+-- min build: 1207
+---@param inventoryId number
+---@param slotId number
+---@param p3 number
+---@return number
+---@return any
+---@return any
+function _InventoryGetInventoryItemEquippedInSlot(inventoryId, slotId, p3) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_EQUIPPED_IN_SLOT_BY_REF  (0x22E590F108289A9D)
+-- min build: 1207
+---@param inventoryId number
+---@param slotId number
+---@return boolean
+---@return any
+---@return any
+function _InventoryGetInventoryItemEquippedInSlotByRef(inventoryId, slotId) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_FIT_SLOT  (0xB991FE166FAF84FD)
+-- min build: 1207
+---@param p0 number
+---@param p2 number
+---@return boolean
+---@return any
+function _InventoryGetInventoryItemFitSlot(p0, p2) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_HIDDEN  (0xF9933164965533B7)
+-- min build: 1207
+---@param inventoryId number
+---@return boolean
+---@return any
+function _InventoryGetInventoryItemHidden(inventoryId) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_IN_USE  (0x70E3A884ED000A01)
+-- min build: 1311
+---@param inventoryId number
+---@return boolean
+---@return any
+function _InventoryGetInventoryItemInUse(inventoryId) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_INSPECTION_INFO  (0x0C093C1787F18519)
+-- min build: 1207
+---@param item number
+---@return boolean
+---@return any
+function _InventoryGetInventoryItemInspectionInfo(item) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_IS_ANIMAL_PELT  (0x4AEF1FB5B9011D75)
+-- min build: 1207
+---@param item number
+---@return boolean
+function _InventoryGetInventoryItemIsAnimalPelt(item) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_LAST_CREATION  (0x112BCA290D2EB53C)
+-- Outputs the last creation date of the item for the selected inventory. Returns true if successful, false otherwise.
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+---@return boolean
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+function _InventoryGetInventoryItemLastCreation(inventoryId, item) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_SOUND  (0x2E1CDC1FF3B8473E)
+-- soundType: see 0x2BAE4880DCDD560B
+-- Returns item Hash to be used with _IS_SCRIPTED_AUDIO_CUSTOM and _PLAY_SOUND_FROM_ITEM (p0)
+-- min build: 1207
+---@param item number
+---@param soundType number
+---@return number
+function _InventoryGetInventoryItemSound(item, soundType) end
+
+-- _INVENTORY_GET_INVENTORY_ITEM_WEAPON_COPY_ID  (0xAB5F12746A099A0E)
+-- Returns CopyID
+-- min build: 1207
+---@param inventoryId number
+---@return number
+---@return any
+function _InventoryGetInventoryItemWeaponCopyId(inventoryId) end
+
+-- _INVENTORY_GET_IS_INVENTORY_ITEM_SOUND_VALID  (0x2BAE4880DCDD560B)
+-- soundType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CItemInfoSoundsInterface__sSoundsInfo__eSoundType
+-- min build: 1207
+---@param item number
+---@param soundType number
+---@return boolean
+function _InventoryGetIsInventoryItemSoundValid(item, soundType) end
+
+-- _INVENTORY_GET_ITEM_EXPIRY_TIME  (0x4A606C17276E1BCC)
+-- min build: 1232
+---@return number
+---@return any
+function _InventoryGetItemExpiryTime() end
+
+-- _INVENTORY_GET_ITEM_FROM_COLLECTION_INDEX  (0x82FA24C3D3FCD9B7)
+-- collectionId is < outCollectionSize
+-- min build: 1207
+---@param collectionId number
+---@param itemIndex number
+---@return boolean
+---@return any
+function _InventoryGetItemFromCollectionIndex(collectionId, itemIndex) end
+
+-- _INVENTORY_IS_GUID_VALID  (0xB881CA836CC4B6D4)
+-- min build: 1207
+---@return boolean
+---@return any
+function _InventoryIsGuidValid() end
+
+-- _INVENTORY_IS_INVENTORY_ITEM_EQUIPPED  (0x3D10D7179D7034AF)
+-- Alternative Name: _INVENTORY_IS_ITEM_DISABLED
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+---@param p2 boolean
+---@return boolean
+function _InventoryIsInventoryItemEquipped(inventoryId, item, p2) end
+
+-- _INVENTORY_IS_INVENTORY_ITEM_FLAG_ENABLED  (0x245D07651B1D183B)
+-- flag: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ItemDatabaseItemFlags
+-- 2097152 (is item read?), 8388608 (is item sent/received/mailable?), 16777216 (is item consumable?)
+-- min build: 1207
+---@param item number
+---@param flag number
+---@return boolean
+function _InventoryIsInventoryItemFlagEnabled(item, flag) end
+
+-- _INVENTORY_IS_ITEM_EXPIRED  (0x0137C77A2EC64536)
+-- min build: 1232
+---@return boolean
+---@return any
+function _InventoryIsItemExpired() end
+
+-- _INVENTORY_IS_PLAYER_INVENTORY_MIRRORING_TRANSACTIONS  (0xFC7563F482781A3D)
+-- min build: 1207
+---@return boolean
+function _InventoryIsPlayerInventoryMirroringTransactions() end
+
+-- _INVENTORY_IS_USING_BACKUP_INVENTORY  (0x7C7E4AB748EA3B07)
+-- min build: 1207
+---@return boolean
+function _InventoryIsUsingBackupInventory() end
+
+-- _INVENTORY_MOVE_INVENTORY_ITEM  (0xDCCAA7C3BFD88862)
+-- guid1: old parent GUID
+-- guid2: new parent GUID
+-- guid3: new item GUID (out param)
+-- min build: 1207
+---@param inventoryId number
+---@param slotId number
+---@param quantity number
+---@return boolean
+---@return any
+---@return any
+---@return any
+function _InventoryMoveInventoryItem(inventoryId, slotId, quantity) end
+
+-- _INVENTORY_RELEASE_ITEM_COLLECTION  (0x42A2F33A1942E865)
+-- Max num of collections is 5, so release your unused ones.
+-- min build: 1207
+---@param collectionId number
+---@return boolean
+function _InventoryReleaseItemCollection(collectionId) end
+
+-- _INVENTORY_REMOVE_INVENTORY_ITEM_WITH_GUID  (0x3E4E811480B3AE79)
+-- min build: 1207
+---@param inventoryId number
+---@param quantity number
+---@param removeReason number
+---@return boolean
+---@return any
+function _InventoryRemoveInventoryItemWithGuid(inventoryId, quantity, removeReason) end
+
+-- _INVENTORY_REMOVE_INVENTORY_ITEM_WITH_ITEMID  (0xB4158C8C9A3B5DCE)
+-- min build: 1207
+---@param inventoryId number
+---@param item number
+---@param quantity number
+---@param removeReason number
+---@return boolean
+function _InventoryRemoveInventoryItemWithItemid(inventoryId, item, quantity, removeReason) end
+
+-- _INVENTORY_REMOVE_INVENTORY_ITEMS  (0x5D6182F3BCE1333B)
+-- removeReason: REMOVE_REASON_DEFAULT (eRemoveItemReason)
+-- Example: INVENTORY::_0x5D6182F3BCE1333B(1, joaat("REMOVE_REASON_DEFAULT")); -> clears weapon wheel
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param inventoryId number
+---@param removeReason number
+---@return boolean
+function _InventoryRemoveInventoryItems(inventoryId, removeReason) end
+
+-- _INVENTORY_SET_INVENTORY_ITEM_HIDDEN  (0x9A113C660AEA3832)
+-- Used with CClothingItem
+-- min build: 1207
+---@param inventoryId number
+---@param hidden boolean
+---@return any
+function _InventorySetInventoryItemHidden(inventoryId, hidden) end
+
+-- _INVENTORY_SET_INVENTORY_ITEM_HIDDEN_2  (0xD740F11FBC8AEF43)
+-- Used with CSatchelItem, R* Script usage: fisihing_core
+-- min build: 1207
+---@param inventoryId number
+---@param hidden boolean
+---@return any
+function _InventorySetInventoryItemHidden2(inventoryId, hidden) end
+
+-- _INVENTORY_SET_INVENTORY_ITEM_IN_USE  (0x65A5F70F4A292EBE)
+-- Only works on CClothingItem
+-- min build: 1207
+---@param inventoryId number
+---@param inUse boolean
+---@return any
+function _InventorySetInventoryItemInUse(inventoryId, inUse) end
+
+-- _INVENTORY_SET_INVENTORY_ITEM_INSPECTION_ENABLED  (0x227522FD59DDB7E8)
+-- min build: 1207
+---@param inventoryId number
+---@param enabled boolean
+---@return boolean
+---@return any
+function _InventorySetInventoryItemInspectionEnabled(inventoryId, enabled) end
+
+-- _INVENTORY_SET_INVENTORY_ITEM_WEATHER_EFFECTIVENESS  (0x6D2F987736A42D4C)
+-- OWE_INVALID = -1,
+-- OWE_GOOD_IN_HOT
+-- OWE_GOOD_IN_NONE
+-- OWE_GOOD_IN_COLD
+-- OWE_GOOD_IN_ALL
+-- min build: 1207
+---@param inventoryId number
+---@param weatherEffectiveness number
+---@return any
+function _InventorySetInventoryItemWeatherEffectiveness(inventoryId, weatherEffectiveness) end
+
+-- _INVENTORY_SWAP_INVENTORY_ITEM  (0xF2753D691BCDA314)
+-- min build: 1207
+---@param inventoryId number
+---@return boolean
+---@return any
+---@return any
+function _InventorySwapInventoryItem(inventoryId) end
+
+-- _INVENTORY_UPDATE_INVENTORY_ITEM  (0xD80A8854DB5CFBA5)
+-- Getter: _INVENTORY_GET_FULL_INVENTORY_ITEM_DATA
+-- min build: 1207
+---@param inventoryId number
+---@param p3 number
+---@return boolean
+---@return any
+---@return any
+function _InventoryUpdateInventoryItem(inventoryId, p3) end
+
+-- _INVENTORY_USE_BACKUP_INVENTORY  (0xE36D4A38D28D9CFB)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param p0 boolean
+function _InventoryUseBackupInventory(p0) end
+
+-- _INVENTORY_USE_MISSION_INVENTORY  (0xA6AA9F56BC6CFF58)
+-- min build: 1207
+---@param enable boolean
+---@param mirrorTransactions boolean
+function _InventoryUseMissionInventory(enable, mirrorTransactions) end
+
+-- _INVENTORY_USE_SATCHEL_ITEM  (0x46743BBFEDBC859E)
+-- eInventoryItem: CLOTHING_FANCY_SUIT, CLOTHING_GUNSLINGER_OUTFIT, etc.
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param inventoryId number
+---@param eInventoryItem number
+---@param p2 boolean
+function _InventoryUseSatchelItem(inventoryId, eInventoryItem, p2) end
+
+-- _SET_CARRIABLE_CARRY_ACTION_PROMPT_OVERRIDE  (0xF666EF30F4F0AC4E)
+-- min build: 1207
+---@return any
+function _SetCarriableCarryActionPromptOverride() end
+
+-- _SET_ITEM_PROMPT_INFO_REQUEST  (0xFD41D1D4350F6413)
+-- min build: 1207
+---@return any
+function _SetItemPromptInfoRequest() end
+
+-- _SET_USE_MISSION_INVENTORY  (0x597F571DDEE3FFAC)
+-- This native has no functionality.
+-- min build: 1207
+---@param toggle boolean
+function _SetUseMissionInventory(toggle) end
+
+-- INVENTORY_COPY_MP_INVENTORY_TO_MISSION_INVENTORY  (0x644CCB76A76CFBD6)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+---@param bCopySatchelItems boolean
+---@param bCopyEmotes boolean
+---@param bCopyHorse boolean
+---@param p5 boolean
+function InventoryCopyMpInventoryToMissionInventory(p0, p1, bCopySatchelItems, bCopyEmotes, bCopyHorse, p5) end
+
+-- INVENTORY_DISABLE_MISSION_INVENTORY_PICKUPS  (0xE1F389F03DC83673)
+-- min build: 1311
+function InventoryDisableMissionInventoryPickups() end
+
+-- INVENTORY_GET_CHILDREN_IN_SLOT_COUNT  (0x033EE4B89F3AC545)
+-- min build: 1207
+---@param inventoryId number
+---@param slotId number
+---@return number
+---@return any
+function InventoryGetChildrenInSlotCount(inventoryId, slotId) end
+
+-- INVENTORY_GET_GUID_FROM_ITEMID  (0x886DFD3E185C8A89)
+-- min build: 1207
+---@param inventoryId number
+---@param p2 number
+---@param slotId number
+---@return boolean
+---@return any
+---@return any
+function InventoryGetGuidFromItemid(inventoryId, p2, slotId) end
+
+-- INVENTORY_GET_INVENTORY_ITEM  (0x9700E8EFC4AB9089)
+-- min build: 1207
+---@param inventoryId number
+---@param p3 boolean
+---@return boolean
+---@return any
+---@return any
+function InventoryGetInventoryItem(inventoryId, p3) end

--- a/.luals/redm-natives/ITEMDATABASE.lua
+++ b/.luals/redm-natives/ITEMDATABASE.lua
@@ -1,0 +1,711 @@
+---@meta
+
+-- RDR3 namespace: ITEMDATABASE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x17721003A66C72BF  (0x17721003A66C72BF)
+-- min build: 1207
+---@param shopType number
+---@param key number
+---@return boolean
+---@return any
+function N_0x17721003A66C72BF(shopType, key) end
+
+-- _0x537A0555F62CA01A  (0x537A0555F62CA01A)
+-- min build: 1436
+---@param key number
+---@param p1 number
+---@return boolean
+function N_0x537A0555F62CA01A(key, p1) end
+
+-- _0x799FCD53358ED5FA  (0x799FCD53358ED5FA)
+-- Returns Item Count
+-- min build: 1355
+---@param bundle any
+---@param p1 any
+---@return number
+function N_0x799FCD53358ED5FA(bundle, p1) end
+
+-- _0x8870895BA5ED9385  (0x8870895BA5ED9385)
+-- min build: 1232
+---@param key number
+---@param tagType number
+---@return number
+---@return any
+function N_0x8870895BA5ED9385(key, tagType) end
+
+-- _0xC4146375D8A0B374  (0xC4146375D8A0B374)
+-- min build: 1355
+---@param bundle any
+---@param p1 any
+---@param index number
+---@param p3 any
+---@return boolean
+function N_0xC4146375D8A0B374(bundle, p1, index, p3) end
+
+-- _ITEMDATABASE_CAN_EQUIP_ITEM_ON_CATEGORY  (0x856FF92C57742AE5)
+-- min build: 1207
+---@param key number
+---@param category number
+---@param slotId number
+---@return boolean
+function _ItemdatabaseCanEquipItemOnCategory(key, category, slotId) end
+
+-- _ITEMDATABASE_CREATE_ITEM_COLLECTION  (0x71EFA7999AE79408)
+-- Returns collectionId to be used with 0x8750F69A720C2E41 (p0) and 0xCBB7B6EDFA933ADE (p0)
+-- struct ItemCollectionFilter
+-- {
+-- 	alignas(8) Hash slotId;
+-- 	alignas(8) Hash slotId2;
+-- 	alignas(8) Hash tag;
+-- 	alignas(8) Hash ciCategory;
+-- 	alignas(8) Hash cost;
+-- 	alignas(8) Hash unk5;
+-- 	alignas(8) int  flags;
+-- 	alignas(8) Hash itemType;
+-- 	alignas(8) Hash ciTag;
+-- };
+-- min build: 1207
+---@param comparisonType number
+---@return number
+---@return any
+---@return number
+function _ItemdatabaseCreateItemCollection(comparisonType) end
+
+-- _ITEMDATABASE_DOES_BUNDLE_HAVE_TAG  (0x99C6EA66DFE73757)
+-- Params: tag = TAG_ITEM_PROPERTY (tagType(?))
+-- min build: 1207
+---@param bundle number
+---@param tag number
+---@param tagType number
+---@return boolean
+function _ItemdatabaseDoesBundleHaveTag(bundle, tag, tagType) end
+
+-- _ITEMDATABASE_DOES_ITEM_HAVE_TAG  (0xFF5FB5605AD56856)
+-- min build: 1207
+---@param item number
+---@param tag number
+---@param tagType number
+---@return boolean
+function _ItemdatabaseDoesItemHaveTag(item, tag, tagType) end
+
+-- _ITEMDATABASE_FILLOUT_ACQUIRE_COST  (0x74F7928816E4E181)
+-- min build: 1207
+---@param key number
+---@param costtype number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutAcquireCost(key, costtype) end
+
+-- _ITEMDATABASE_FILLOUT_AWARD_ACQUIRE_COST  (0xF27F01BBF5ACD3F3)
+-- min build: 1232
+---@param award number
+---@param costtype number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutAwardAcquireCost(award, costtype, index) end
+
+-- _ITEMDATABASE_FILLOUT_AWARD_ITEM_INFO  (0x121D2005DD64496B)
+-- min build: 1207
+---@param award number
+---@param index number
+---@return boolean
+---@return number
+function _ItemdatabaseFilloutAwardItemInfo(award, index) end
+
+-- _ITEMDATABASE_FILLOUT_AWARD_UNLOCK_FLAG  (0x8D029948CA29409B)
+-- Fills out unlock-flag data for an award entry.
+-- 
+-- outData:
+-- struct AwardUnlockFlag
+-- {
+-- 	alignas(8) Hash item;
+-- 	alignas(8) int  p1;
+-- 	alignas(8) Hash unlockFlag; // e.g. UF_VISIBLE
+-- };
+-- min build: 1207
+---@param award number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutAwardUnlockFlag(award, index) end
+
+-- _ITEMDATABASE_FILLOUT_BUNDLE  (0xB542632693D53408)
+-- min build: 1232
+---@param bundle number
+---@param costtype number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutBundle(bundle, costtype, index) end
+
+-- _ITEMDATABASE_FILLOUT_BUNDLE_UI_DATA  (0x74C3B1093728D263)
+-- min build: 1207
+---@param bundle number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutBundleUiData(bundle) end
+
+-- _ITEMDATABASE_FILLOUT_BUY_AWARD_ACQUIRE_COSTS  (0xB52E20F6767A09A2)
+-- min build: 1207
+---@param award number
+---@param p3 number
+---@return boolean
+---@return any
+---@return number
+function _ItemdatabaseFilloutBuyAwardAcquireCosts(award, p3) end
+
+-- _ITEMDATABASE_FILLOUT_BUY_AWARD_UI_DATA  (0xF8D09EF8CE61D7BF)
+-- min build: 1207
+---@param award number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutBuyAwardUiData(award) end
+
+-- _ITEMDATABASE_FILLOUT_ITEM  (0xAD73B614DF26CF8A)
+-- min build: 1232
+---@param key number
+---@param costtype number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutItem(key, costtype, index) end
+
+-- _ITEMDATABASE_FILLOUT_ITEM_EFFECT_IDS  (0x9379BE60DC55BBE6)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutItemEffectIds(key) end
+
+-- _ITEMDATABASE_FILLOUT_MODIFIER  (0x60614A0AB580A2B5)
+-- min build: 1207
+---@param key number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutModifier(key, index) end
+
+-- _ITEMDATABASE_FILLOUT_PRICE_MODIFIER_BY_KEY  (0x40C5D95818823C94)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutPriceModifierByKey(key) end
+
+-- _ITEMDATABASE_FILLOUT_SATCHEL_DATA  (0x4776EFD78F75C23F)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return number
+function _ItemdatabaseFilloutSatchelData(key) end
+
+-- _ITEMDATABASE_FILLOUT_SELL_PRICE  (0x7A62A2EEDE1C3766)
+-- Params: sellType = SELL_SHOP_DEFAULT
+-- min build: 1207
+---@param key number
+---@param sellType number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutSellPrice(key, sellType) end
+
+-- _ITEMDATABASE_FILLOUT_TAG_DATA  (0x5A11D6EEA17165B0)
+-- min build: 1207
+---@param key number
+---@param p3 number
+---@return boolean
+---@return any
+---@return number
+function _ItemdatabaseFilloutTagData(key, p3) end
+
+-- _ITEMDATABASE_FILLOUT_UI_DATA  (0xB86F7CC2DC67AC60)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function _ItemdatabaseFilloutUiData(key) end
+
+-- _ITEMDATABASE_GET_ACQUIRE_COST  (0x6772A83C67A25775)
+-- min build: 1207
+---@param key number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetAcquireCost(key, index) end
+
+-- _ITEMDATABASE_GET_ACQUIRE_COSTS_COUNT  (0x01FDDAD392D04144)
+-- Returns the number of <Item>s <acquirecosts> has from the key in catalog_sp.ymt
+-- min build: 1207
+---@param key number
+---@return number
+function _ItemdatabaseGetAcquireCostsCount(key) end
+
+-- _ITEMDATABASE_GET_ACQUIRE_COSTS_COUNT_FROM_COST_TYPE  (0xDEE7B3C76ED664BE)
+-- min build: 1232
+---@param key number
+---@param costtype number
+---@return number
+function _ItemdatabaseGetAcquireCostsCountFromCostType(key, costtype) end
+
+-- _ITEMDATABASE_GET_AWARD_ACQUIRE_COST  (0x1FC25AEB5F76B38D)
+-- min build: 1311
+---@param award number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetAwardAcquireCost(award, index) end
+
+-- _ITEMDATABASE_GET_AWARD_ACQUIRE_COST_COUNT  (0x12DF9C58201DD19A)
+-- min build: 1311
+---@param key number
+---@return number
+function _ItemdatabaseGetAwardAcquireCostCount(key) end
+
+-- _ITEMDATABASE_GET_AWARD_ACQUIRE_COST_COUNT_FROM_COST_TYPE  (0xF540239F9937033B)
+-- min build: 1232
+---@param award number
+---@param costtype number
+---@return number
+function _ItemdatabaseGetAwardAcquireCostCountFromCostType(award, costtype) end
+
+-- _ITEMDATABASE_GET_AWARD_COST_MODIFIERS  (0xE81D0378A384E755)
+-- min build: 1232
+---@param award number
+---@return boolean
+---@return any
+function _ItemdatabaseGetAwardCostModifiers(award) end
+
+-- _ITEMDATABASE_GET_AWARD_INFO  (0xD076DB9B96FAADF1)
+-- min build: 1311
+---@param award number
+---@return boolean
+---@return any
+function _ItemdatabaseGetAwardInfo(award) end
+
+-- _ITEMDATABASE_GET_AWARD_ITEM_COUNT  (0x3FAA928A79591761)
+-- Returns iAwardItemCount
+-- min build: 1207
+---@param award number
+---@return number
+function _ItemdatabaseGetAwardItemCount(award) end
+
+-- _ITEMDATABASE_GET_AWARD_UNLOCK_FLAG_COUNT  (0x48229CE0C7938237)
+-- Returns the count of unlock flags for an award.
+-- min build: 1207
+---@param award number
+---@return number
+function _ItemdatabaseGetAwardUnlockFlagCount(award) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ACQUIRE_COST  (0x3A0B667ABFF87F6E)
+-- Fills out acquire-cost data for a bundle entry.
+-- Use index with _ITEMDATABASE_GET_BUNDLE_ACQUIRE_COSTS_COUNT.
+-- 
+-- outData:
+-- struct AcquireCost
+-- {
+-- 	alignas(8) Hash cost;
+-- 	alignas(8) Any  p1;
+-- 	alignas(8) Hash costType;
+-- 	alignas(8) int  numCosts;
+-- 	alignas(8) int  p4;
+-- 	alignas(8) Any* costs; // array of Cost entries
+-- };
+-- 
+-- struct Cost
+-- {
+-- 	alignas(8) Hash currency;
+-- 	alignas(8) int  amount;
+-- };
+-- min build: 1207
+---@param bundle number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetBundleAcquireCost(bundle, index) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ACQUIRE_COST_MODIFIERS  (0xA97EE5E4589FCF5A)
+-- min build: 1207
+---@param bundle number
+---@return boolean
+---@return any
+function _ItemdatabaseGetBundleAcquireCostModifiers(bundle) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ACQUIRE_COSTS_COUNT  (0x7A35A72A692BE9DB)
+-- Returns the count of acquire costs in a bundle.
+-- min build: 1207
+---@param bundle number
+---@return number
+function _ItemdatabaseGetBundleAcquireCostsCount(bundle) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ACQUIRE_COSTS_COUNT_FROM_COST  (0x388088BFF3681189)
+-- Returns the number of currencies/cost entries available for a bundle and cost hash.
+-- Use with _ITEMDATABASE_FILLOUT_BUNDLE; research notes that several docs call this parameter costtype, but scripts indicate it is the actual cost hash such as COST_GOLD or COST_CRAFTING_MP.
+-- min build: 1232
+---@param bundle number
+---@param cost number
+---@return number
+function _ItemdatabaseGetBundleAcquireCostsCountFromCost(bundle, cost) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ID  (0x891A45960B6B768A)
+-- min build: 1207
+---@param bundle number
+---@return number
+function _ItemdatabaseGetBundleId(bundle) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ITEM_COUNT  (0x3332695B01015DF9)
+-- min build: 1207
+---@param bundleId number
+---@return number
+---@return any
+function _ItemdatabaseGetBundleItemCount(bundleId) end
+
+-- _ITEMDATABASE_GET_BUNDLE_ITEM_INFO  (0x5D48A77E4B668B57)
+-- Outputs bundle item info.
+-- struct BundleItemInfo
+-- {
+-- 	alignas(8) Hash item;
+-- 	alignas(8) Hash slotId;
+-- 	alignas(8) int  unk2;
+-- 	alignas(8) int  unk3;
+-- };
+-- min build: 1207
+---@param bundleId number
+---@param index number
+---@return boolean
+---@return any
+---@return number
+function _ItemdatabaseGetBundleItemInfo(bundleId, index) end
+
+-- _ITEMDATABASE_GET_CATALOG_ITEM_CATEGORY_PATHSET  (0xAA29A5F13B2C20B2)
+-- Returns the pathset hash for the selected catalog item category, such as CI_CATEGORY_AMMO or CI_CATEGORY_CAMP_TENT.
+-- p1 is observed as DEFAULT in Rockstar scripts.
+-- min build: 1232
+---@param catalogItemCategory number
+---@param p1 number
+---@return number
+function _ItemdatabaseGetCatalogItemCategoryPathset(catalogItemCategory, p1) end
+
+-- _ITEMDATABASE_GET_COLLECTION_SIZE  (0xD389A2549C4EFB30)
+-- Returns (collection?) size/index (?)
+-- _ITEMDATABASE_GET_(A)* - _ITEMDATABASE_GET_(B)*
+-- min build: 1207
+---@param collectionId number
+---@return number
+function _ItemdatabaseGetCollectionSize(collectionId) end
+
+-- _ITEMDATABASE_GET_COMPONENT_ITEM  (0x8750F69A720C2E41)
+-- Params: p2 can be a component item hash
+-- min build: 1207
+---@param collectionId number
+---@param index number
+---@return boolean
+---@return number
+function _ItemdatabaseGetComponentItem(collectionId, index) end
+
+-- _ITEMDATABASE_GET_FITS_SLOT_COUNT  (0x2970D1D6BFCF9B46)
+-- min build: 1207
+---@param category number
+---@return number
+function _ItemdatabaseGetFitsSlotCount(category) end
+
+-- _ITEMDATABASE_GET_FITS_SLOT_INFO  (0x77210C146CED5261)
+-- min build: 1207
+---@param category number
+---@param index number
+---@return boolean
+---@return number
+function _ItemdatabaseGetFitsSlotInfo(category, index) end
+
+-- _ITEMDATABASE_GET_HAS_SLOT_COUNT  (0x44915068579D7710)
+-- min build: 1207
+---@param category number
+---@return number
+function _ItemdatabaseGetHasSlotCount(category) end
+
+-- _ITEMDATABASE_GET_HAS_SLOT_INFO  (0x8A9BD0DB7E8376CF)
+-- min build: 1207
+---@param category number
+---@param index number
+---@return boolean
+---@return number
+function _ItemdatabaseGetHasSlotInfo(category, index) end
+
+-- _ITEMDATABASE_GET_ITEM_PATHSET  (0xF4452CE83118C738)
+-- min build: 1207
+---@param key number
+---@param defaultPathset number
+---@return number
+function _ItemdatabaseGetItemPathset(key, defaultPathset) end
+
+-- _ITEMDATABASE_GET_ITEM_PRICE_MODIFIERS  (0x4EB37AAB79AB0C48)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function _ItemdatabaseGetItemPriceModifiers(key) end
+
+-- _ITEMDATABASE_GET_ITEM_TAG_TYPE  (0x6111B8F9413F413A)
+-- min build: 1207
+---@param item number
+---@param tag number
+---@return number
+function _ItemdatabaseGetItemTagType(item, tag) end
+
+-- _ITEMDATABASE_GET_MODIFIED_PRICE  (0xCB92EC9C004732B4)
+-- Returns an alternative cost hash to COST_SHOP_DEFAULT
+-- min build: 1207
+---@param key number
+---@param index number
+---@return number
+function _ItemdatabaseGetModifiedPrice(key, index) end
+
+-- _ITEMDATABASE_GET_NUMBER_OF_MODIFIED_PRICES  (0x5AAAF40E9B224F5E)
+-- min build: 1207
+---@param key number
+---@return number
+function _ItemdatabaseGetNumberOfModifiedPrices(key) end
+
+-- _ITEMDATABASE_GET_NUMBER_OF_MODIFIERS  (0x1289D8315235856D)
+-- min build: 1207
+---@param key number
+---@return number
+function _ItemdatabaseGetNumberOfModifiers(key) end
+
+-- _ITEMDATABASE_GET_PRIORITY_ACCESS_AWARD  (0xEF254F1A4C08B7E6)
+-- _ITEMDATABASE_GET_* - _ITEMDATABASE_IS_*
+-- min build: 1207
+---@param award number
+---@return boolean
+function _ItemdatabaseGetPriorityAccessAward(award) end
+
+-- _ITEMDATABASE_GET_SHOP_INVENTORIES_ITEM_INFO  (0x4A79B41B4EB91F4E)
+-- min build: 1207
+---@param shopType number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopInventoriesItemInfo(shopType, index) end
+
+-- _ITEMDATABASE_GET_SHOP_INVENTORIES_ITEM_INFO_BY_KEY  (0xCFB06801F5099B25)
+-- Same Native Function as 0x17721003A66C72BF
+-- min build: 1207
+---@param shopType number
+---@param key number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopInventoriesItemInfoByKey(shopType, key) end
+
+-- _ITEMDATABASE_GET_SHOP_INVENTORIES_ITEMS_COUNT  (0xC568B1A0F17C7025)
+-- min build: 1207
+---@param shopType number
+---@return number
+function _ItemdatabaseGetShopInventoriesItemsCount(shopType) end
+
+-- _ITEMDATABASE_GET_SHOP_INVENTORIES_REQUIREMENT_GROUP_INFO  (0x76C752D788A76813)
+-- min build: 1207
+---@param shopType number
+---@param key number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopInventoriesRequirementGroupInfo(shopType, key, index) end
+
+-- _ITEMDATABASE_GET_SHOP_INVENTORIES_REQUIREMENT_INFO  (0xE0EA5C031AE5539F)
+-- min build: 1207
+---@param shopType number
+---@param key number
+---@param groupIndex number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopInventoriesRequirementInfo(shopType, key, groupIndex, index) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_INFO  (0x66A6D76B6BB999B4)
+-- min build: 1207
+---@param layout number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopLayoutInfo(layout) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_MENU_INFO_BY_ID  (0xD66114469978B55B)
+-- min build: 1207
+---@param layout number
+---@param menu number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopLayoutMenuInfoById(layout, menu) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_MENU_INFO_BY_INDEX  (0xF04247092F193B75)
+-- min build: 1207
+---@param layout number
+---@param menu number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopLayoutMenuInfoByIndex(layout, menu, index) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_MENU_PAGE_KEY  (0x9A60570657A7B635)
+-- min build: 1207
+---@param layout number
+---@param menu number
+---@param index number
+---@return boolean
+---@return number
+function _ItemdatabaseGetShopLayoutMenuPageKey(layout, menu, index) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_PAGE_INFO_BY_INDEX  (0xDBEADA0DF5F9AB9F)
+-- Outputs the layout page info at the selected index.
+-- struct LayoutPageInfo
+-- {
+-- 	alignas(8) Hash pageKey;
+-- 	alignas(8) Hash unk1;
+-- 	alignas(8) BOOL unk2;
+-- 	alignas(8) int  numItems;
+-- };
+-- min build: 1355
+---@param layout number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopLayoutPageInfoByIndex(layout, index) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_PAGE_INFO_BY_KEY  (0xB347C100DF0C9B7F)
+-- min build: 1207
+---@param layout number
+---@param pageKey number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopLayoutPageInfoByKey(layout, pageKey) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_PAGE_ITEM_KEY  (0xF32BEF578B3DBAE8)
+-- min build: 1207
+---@param layout number
+---@param pageKey number
+---@param index number
+---@return boolean
+---@return number
+---@return number
+---@return number
+function _ItemdatabaseGetShopLayoutPageItemKey(layout, pageKey, index) end
+
+-- _ITEMDATABASE_GET_SHOP_LAYOUT_ROOT_MENU_INFO  (0x86FCB565CCA0CFA7)
+-- min build: 1207
+---@param layout number
+---@param index number
+---@return boolean
+---@return any
+function _ItemdatabaseGetShopLayoutRootMenuInfo(layout, index) end
+
+-- _ITEMDATABASE_IS_BUNDLE_VALID  (0x4308812A6E9CA62E)
+-- Params: mode is 0
+-- min build: 1207
+---@param bundle number
+---@param mode number
+---@return boolean
+function _ItemdatabaseIsBundleValid(bundle, mode) end
+
+-- _ITEMDATABASE_IS_INTRINSIC_ITEM  (0x337F88E3A063995E)
+-- min build: 1207
+---@param key number
+---@return boolean
+function _ItemdatabaseIsIntrinsicItem(key) end
+
+-- _ITEMDATABASE_IS_KEY_VALID  (0x6D5D51B188333FD1)
+-- Params: mode is 0
+-- min build: 1207
+---@param key number
+---@param mode number
+---@return boolean
+function _ItemdatabaseIsKeyValid(key, mode) end
+
+-- _ITEMDATABASE_IS_OVERPOWERED_ITEM  (0x337F88E3A063995F)
+-- min build: 1207
+---@param key number
+---@return boolean
+function _ItemdatabaseIsOverpoweredItem(key) end
+
+-- _ITEMDATABASE_IS_SHOP_KEY_VALID  (0x00B9507D8E1D8716)
+-- min build: 1207
+---@param shopType number
+---@return boolean
+function _ItemdatabaseIsShopKeyValid(shopType) end
+
+-- _ITEMDATABASE_IS_SHOP_LAYOUT_KEY_VALID  (0x3AFE5182C45A84F6)
+-- min build: 1207
+---@param layout number
+---@return boolean
+function _ItemdatabaseIsShopLayoutKeyValid(layout) end
+
+-- _ITEMDATABASE_LOCALIZATION_GET_NUM_LABEL_TYPES  (0xCEC6A41E8910486A)
+-- Returns docData.iNumTotalLabelTypes
+-- min build: 1207
+---@param p0 any
+---@return number
+function _ItemdatabaseLocalizationGetNumLabelTypes(p0) end
+
+-- _ITEMDATABASE_LOCALIZATION_GET_NUM_VALUES  (0x49885D82A13EEAEA)
+-- Returns iNumValuesForType
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return number
+function _ItemdatabaseLocalizationGetNumValues(p0, p1) end
+
+-- _ITEMDATABASE_LOCALIZATION_GET_TYPE  (0xCABF5D41D0073D4A)
+-- Returns LabelType
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _ItemdatabaseLocalizationGetType(p0, p1) end
+
+-- _ITEMDATABASE_LOCALIZATION_GET_VALUE  (0x9AE5610FDCED6EA7)
+-- min build: 1207
+---@param p0 any
+---@param label number
+---@param p2 any
+---@return number
+function _ItemdatabaseLocalizationGetValue(p0, label, p2) end
+
+-- _ITEMDATABASE_RELEASE_ITEM_COLLECTION  (0xCBB7B6EDFA933ADE)
+-- min build: 1207
+---@param collectionId number
+---@return boolean
+function _ItemdatabaseReleaseItemCollection(collectionId) end
+
+-- ITEMDATABASE_FILLOUT_ITEM_BY_NAME  (0x2A610BEE7D341CC4)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function ItemdatabaseFilloutItemByName(key) end
+
+-- ITEMDATABASE_FILLOUT_ITEM_EFFECT_ID_INFO  (0xCF2D360D27FD1ABF)
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function ItemdatabaseFilloutItemEffectIdInfo(key) end
+
+-- ITEMDATABASE_FILLOUT_ITEM_INFO  (0xFE90ABBCBFDC13B2)
+-- Outputs item infos.
+-- struct ItemInfo
+-- {
+-- 	alignas(8) Hash category;
+-- 	alignas(8) Hash itemType;
+-- 	alignas(8) Hash unk2;
+-- 	alignas(8) Hash model;
+-- 	alignas(8) Hash award;
+-- };
+-- min build: 1207
+---@param key number
+---@return boolean
+---@return any
+function ItemdatabaseFilloutItemInfo(key) end
+
+-- ITEMDATABASE_IS_BUYABLE_AWARD_VALID  (0x4CE753203FA42214)
+-- min build: 1207
+---@param award number
+---@return boolean
+function ItemdatabaseIsBuyableAwardValid(award) end

--- a/.luals/redm-natives/ITEMSETS.lua
+++ b/.luals/redm-natives/ITEMSETS.lua
@@ -1,0 +1,71 @@
+---@meta
+
+-- RDR3 namespace: ITEMSETS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _CLEAR_ITEMSET  (0x20A4BF0E09BEE146)
+-- min build: 1207
+---@param itemset number
+function _ClearItemset(itemset) end
+
+-- ADD_TO_ITEMSET  (0xABE74510883C7950)
+-- min build: 1207
+---@param entity number
+---@param itemset number
+---@return boolean
+function AddToItemset(entity, itemset) end
+
+-- CLEAN_ITEMSET  (0x85F3A86CA9021FB0)
+-- min build: 1207
+---@param itemset number
+function CleanItemset(itemset) end
+
+-- CREATE_ITEMSET  (0xA1AF16083320065A)
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function CreateItemset(p0) end
+
+-- DESTROY_ITEMSET  (0x712BC69F10549B92)
+-- min build: 1207
+---@param itemset number
+function DestroyItemset(itemset) end
+
+-- GET_INDEXED_ITEM_IN_ITEMSET  (0x275A2E2C0FAB7612)
+-- min build: 1207
+---@param index number
+---@param itemset number
+---@return number
+function GetIndexedItemInItemset(index, itemset) end
+
+-- GET_INDEXED_SCENARIO_POINT_INDEX_IN_ITEMSET  (0x9FC3CDB5CE815901)
+-- min build: 1207
+---@param index number
+---@param itemset number
+---@return any
+function GetIndexedScenarioPointIndexInItemset(index, itemset) end
+
+-- GET_ITEMSET_SIZE  (0x55F2E375AC6018A9)
+-- min build: 1207
+---@param itemset number
+---@return number
+function GetItemsetSize(itemset) end
+
+-- IS_IN_ITEMSET  (0xD1503C2EE2FE688C)
+-- min build: 1207
+---@param entity number
+---@param itemset number
+---@return boolean
+function IsInItemset(entity, itemset) end
+
+-- IS_ITEMSET_VALID  (0xD30765D153EF5C76)
+-- min build: 1207
+---@param itemset number
+---@return boolean
+function IsItemsetValid(itemset) end
+
+-- REMOVE_FROM_ITEMSET  (0xC5BAA432B429DC24)
+-- min build: 1207
+---@param entity number
+---@param itemset number
+function RemoveFromItemset(entity, itemset) end

--- a/.luals/redm-natives/LAW.lua
+++ b/.luals/redm-natives/LAW.lua
@@ -1,0 +1,960 @@
+---@meta
+
+-- RDR3 namespace: LAW -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x00DB0BC05E3FAA4E  (0x00DB0BC05E3FAA4E)
+-- min build: 1207
+---@param ped number
+---@param bitset number
+function N_0x00DB0BC05E3FAA4E(ped, bitset) end
+
+-- _0x018F30D762E62DF8  (0x018F30D762E62DF8)
+-- min build: 1207
+---@param ped number
+---@return any
+---@return any
+function N_0x018F30D762E62DF8(ped) end
+
+-- _0x07E8B8B20570271C  (0x07E8B8B20570271C)
+-- Used in SP only, called together with 0x55F37F5F3F2475E1 & CLEAR_WANTED_SCORE
+-- _REPORT_*
+-- min build: 1207
+---@param player number
+function N_0x07E8B8B20570271C(player) end
+
+-- _0x0BDFEBCF40A5F7E3  (0x0BDFEBCF40A5F7E3)
+-- Only used in net_fetch R* Script
+-- min build: 1207
+---@param crimeType number
+---@return number
+function N_0x0BDFEBCF40A5F7E3(crimeType) end
+
+-- _0x0C392DB374655176  (0x0C392DB374655176)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param itemSet number
+function N_0x0C392DB374655176(x, y, z, p3, itemSet) end
+
+-- _0x0DBACA9C38C9A686  (0x0DBACA9C38C9A686)
+-- Only used in sisikapenitentiary R* Script: name = SISIKA
+-- _IS_G* or _IS_H*
+-- min build: 1207
+---@param name string
+---@return boolean
+function N_0x0DBACA9C38C9A686(name) end
+
+-- _0x0EAF918F751F27BA  (0x0EAF918F751F27BA)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x0EAF918F751F27BA(ped) end
+
+-- _0x0F230DE0DDBE3649  (0x0F230DE0DDBE3649)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x0F230DE0DDBE3649(player) end
+
+-- _0x15ABD5004CAD2D99  (0x15ABD5004CAD2D99)
+-- Params: p0 either 0, 1 or -1 in R* Scripts
+-- Set to 0 called together with _SUPPRESS_CRIME
+-- min build: 1207
+---@param p0 number
+function N_0x15ABD5004CAD2D99(p0) end
+
+-- _0x2001687F9562FD9D  (0x2001687F9562FD9D)
+-- Only used in resapwn_dump_body R* Script
+-- min build: 1207
+---@param p0 any
+function N_0x2001687F9562FD9D(p0) end
+
+-- _0x21213B833EF4DAE7  (0x21213B833EF4DAE7)
+-- min build: 1207
+---@param player number
+---@param ped number
+---@return vector3
+function N_0x21213B833EF4DAE7(player, ped) end
+
+-- _0x22741652985C84D0  (0x22741652985C84D0)
+-- Used in SP only
+-- _REPORT_*
+-- min build: 1207
+---@param player number
+---@param lawRegionHash number
+function N_0x22741652985C84D0(player, lawRegionHash) end
+
+-- _0x26934083D3F2579C  (0x26934083D3F2579C)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x26934083D3F2579C(player) end
+
+-- _0x292AD61A33A7A485  (0x292AD61A33A7A485)
+-- Only used in R* Script fm_mission_controller
+-- _CLEAR_WANTED_*
+-- min build: 1207
+function N_0x292AD61A33A7A485() end
+
+-- _0x318F0F9A4426CFA2  (0x318F0F9A4426CFA2)
+-- Only used in R* SP Script av_amb_camp_robbery
+-- min build: 1207
+---@param ped number
+---@return any
+---@return any
+function N_0x318F0F9A4426CFA2(ped) end
+
+-- _0x331D349E0380B097  (0x331D349E0380B097)
+-- min build: 1207
+---@param p0 any
+function N_0x331D349E0380B097(p0) end
+
+-- _0x3738B784DDD35CC6  (0x3738B784DDD35CC6)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param p2 number
+---@return boolean
+function N_0x3738B784DDD35CC6(player, p1, p2) end
+
+-- _0x3852237A3D9DF145  (0x3852237A3D9DF145)
+-- min build: 1207
+---@param p0 number
+function N_0x3852237A3D9DF145(p0) end
+
+-- _0x390710D2DAFA6BFF  (0x390710D2DAFA6BFF)
+-- _CLEAR*
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function N_0x390710D2DAFA6BFF(player, p1) end
+
+-- _0x3D2674828A4E6B3C  (0x3D2674828A4E6B3C)
+-- min build: 1207
+---@return boolean
+function N_0x3D2674828A4E6B3C() end
+
+-- _0x40851BCC33ACD9AB  (0x40851BCC33ACD9AB)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x40851BCC33ACD9AB(ped) end
+
+-- _0x522F74636DF10201  (0x522F74636DF10201)
+-- min build: 1207
+---@param player number
+---@param itemSet number
+function N_0x522F74636DF10201(player, itemSet) end
+
+-- _0x5E6F375CA101C108  (0x5E6F375CA101C108)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function N_0x5E6F375CA101C108(player, p1) end
+
+-- _0x61B98367D93F012F  (0x61B98367D93F012F)
+-- min build: 1207
+---@param player number
+function N_0x61B98367D93F012F(player) end
+
+-- _0x6ABC50979655BEE7  (0x6ABC50979655BEE7)
+-- min build: 1207
+---@param player number
+---@param p2 any
+---@return number
+function N_0x6ABC50979655BEE7(player, p2) end
+
+-- _0x7351DA734F989F4E  (0x7351DA734F989F4E)
+-- Only used in shoprobberies
+-- min build: 1207
+---@param entity number
+---@return boolean
+function N_0x7351DA734F989F4E(entity) end
+
+-- _0x7EF2A2FE38D74456  (0x7EF2A2FE38D74456)
+-- _SET_DISPATCH_*
+-- min build: 1207
+---@param flag number
+---@param p1 boolean
+function N_0x7EF2A2FE38D74456(flag, p1) end
+
+-- _0x7FC667F6DDFBCDCC  (0x7FC667F6DDFBCDCC)
+-- Only used in R* Script long_update
+-- Returns a value thats being subtracted from GET_GAME_TIMER
+-- min build: 1207
+---@param player number
+---@return number
+function N_0x7FC667F6DDFBCDCC(player) end
+
+-- _0x82F11E1296996574  (0x82F11E1296996574)
+-- Only used in rcm_gunslinger1_1 R* Script: p0 = 0
+-- min build: 1207
+---@param p0 number
+function N_0x82F11E1296996574(p0) end
+
+-- _0x856CE8FDE2416602  (0x856CE8FDE2416602)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x856CE8FDE2416602(ped) end
+
+-- _0x89E005B1662F6E48  (0x89E005B1662F6E48)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param p2 number
+---@return boolean
+function N_0x89E005B1662F6E48(player, p1, p2) end
+
+-- _0x95878B13E272EF1F  (0x95878B13E272EF1F)
+-- min build: 1207
+---@param entity number
+---@param ped number
+---@param p2 boolean
+---@param x number
+---@param y number
+---@param z number
+---@param crimeType number
+---@return any
+function N_0x95878B13E272EF1F(entity, ped, p2, x, y, z, crimeType) end
+
+-- _0x9772395CC73E8D1F  (0x9772395CC73E8D1F)
+-- Only used in loanshark_miner1 R* Script: name = ANNESBURG_MINES
+-- min build: 1207
+---@param ped number
+---@param name string
+function N_0x9772395CC73E8D1F(ped, name) end
+
+-- _0x987BE590FB9D41E5  (0x987BE590FB9D41E5)
+-- min build: 1207
+---@param p0 boolean
+function N_0x987BE590FB9D41E5(p0) end
+
+-- _0x9B4C564BFA7CFF37  (0x9B4C564BFA7CFF37)
+-- min build: 1207
+---@param p0 number
+function N_0x9B4C564BFA7CFF37(p0) end
+
+-- _0x9C5BD8C562565CE6  (0x9C5BD8C562565CE6)
+-- min build: 1207
+---@return number
+function N_0x9C5BD8C562565CE6() end
+
+-- _0x9C8A2BF37E966464  (0x9C8A2BF37E966464)
+-- Only used in act_bankrobbery01 R* Script
+-- min build: 1207
+---@param player number
+---@param itemSet number
+function N_0x9C8A2BF37E966464(player, itemSet) end
+
+-- _0x9D5C9A5A3321B128  (0x9D5C9A5A3321B128)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x9D5C9A5A3321B128(player) end
+
+-- _0x9EF07CFBB19A9733  (0x9EF07CFBB19A9733)
+-- Only used in shoprobberies R* Scripts
+-- min build: 1207
+---@return boolean
+function N_0x9EF07CFBB19A9733() end
+
+-- _0xB527099D1E1EED49  (0xB527099D1E1EED49)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@return boolean
+---@return number
+function N_0xB527099D1E1EED49(player, p1) end
+
+-- _0xBD944A3D36E992DE  (0xBD944A3D36E992DE)
+-- Called together with REPORT_POLICE_SPOTTED_PLAYER
+-- min build: 1207
+function N_0xBD944A3D36E992DE() end
+
+-- _0xC0DF161950FB101E  (0xC0DF161950FB101E)
+-- Only used in rcm_serial_killer1 R* Script
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xC0DF161950FB101E(ped) end
+
+-- _0xC5EB2755FA25F1E9  (0xC5EB2755FA25F1E9)
+-- min build: 1207
+---@param p0 boolean
+function N_0xC5EB2755FA25F1E9(p0) end
+
+-- _0xC687A23E166DCF68  (0xC687A23E166DCF68)
+-- min build: 1207
+---@return any
+---@return any
+function N_0xC687A23E166DCF68() end
+
+-- _0xC7DC5A0A7DF608CB  (0xC7DC5A0A7DF608CB)
+-- _GET_DISPATCH_*
+-- min build: 1207
+---@param flag number
+---@return boolean
+function N_0xC7DC5A0A7DF608CB(flag) end
+
+-- _0xCBFB4951F2E3934C  (0xCBFB4951F2E3934C)
+-- min build: 1207
+---@param player number
+---@return any
+function N_0xCBFB4951F2E3934C(player) end
+
+-- _0xD6C0A8C7C0B2F82C  (0xD6C0A8C7C0B2F82C)
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function N_0xD6C0A8C7C0B2F82C(player, p1) end
+
+-- _0xD7494DED50C6EF52  (0xD7494DED50C6EF52)
+-- Only used in R* SP Scripts
+-- Params: p2 either 1 or 2
+-- min build: 1207
+---@param player number
+---@param crimeType number
+---@param p2 number
+function N_0xD7494DED50C6EF52(player, crimeType, p2) end
+
+-- _0xDA1A9ADC4E3D4B16  (0xDA1A9ADC4E3D4B16)
+-- Only used in R* SP Scripts
+-- Params: p1 = true, p2 = false
+-- min build: 1207
+---@param itemSet number
+---@param p1 boolean
+---@param p2 boolean
+function N_0xDA1A9ADC4E3D4B16(itemSet, p1, p2) end
+
+-- _0xDAEFDFDB2AEECE37  (0xDAEFDFDB2AEECE37)
+-- crimeType: see _REPORT_CRIME
+-- min build: 1207
+---@param crimeType number
+---@param p1 any
+---@return number
+function N_0xDAEFDFDB2AEECE37(crimeType, p1) end
+
+-- _0xDCF12B89624AAC96  (0xDCF12B89624AAC96)
+-- min build: 1207
+---@param p0 boolean
+function N_0xDCF12B89624AAC96(p0) end
+
+-- _0xDEA083C16BB91345  (0xDEA083C16BB91345)
+-- min build: 1207
+function N_0xDEA083C16BB91345() end
+
+-- _0xE083BEDA81709891  (0xE083BEDA81709891)
+-- min build: 1207
+---@param player number
+---@return number
+function N_0xE083BEDA81709891(player) end
+
+-- _0xE4D6E45F491A66CB  (0xE4D6E45F491A66CB)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@return any
+function N_0xE4D6E45F491A66CB(player, p1) end
+
+-- _0xE94B5E938619712E  (0xE94B5E938619712E)
+-- Seems to disable lawmen guarding behaviors (like during a region lockdown). Must be called every frame.
+-- Only used in R* SP Scripts, mostly used in train_fast_travel_core
+-- min build: 1207
+function N_0xE94B5E938619712E() end
+
+-- _0xE9AC8466ABE484BB  (0xE9AC8466ABE484BB)
+-- Only used in R* SP Scripts
+-- Params: p1 = 0
+-- min build: 1207
+---@param p0 boolean
+---@param p1 any
+function N_0xE9AC8466ABE484BB(p0, p1) end
+
+-- _0xE9EB79CBF9C0F58A  (0xE9EB79CBF9C0F58A)
+-- Returns p1 value for 0xE4D6E45F491A66CB
+-- min build: 1207
+---@param player number
+---@return number
+function N_0xE9EB79CBF9C0F58A(player) end
+
+-- _0xEDFC6C1FD1C964F5  (0xEDFC6C1FD1C964F5)
+-- _SET_C* - _SET_D*
+-- min build: 1207
+---@param player number
+---@param crimeType number
+---@param bounty number
+---@param p3 number
+---@param p4 number
+---@param p5 boolean
+---@param p6 number
+---@param p7 number
+---@param p8 any
+function N_0xEDFC6C1FD1C964F5(player, crimeType, bounty, p3, p4, p5, p6, p7, p8) end
+
+-- _0xF611DE44AEB36A1D  (0xF611DE44AEB36A1D)
+-- min build: 1207
+---@param crimeType number
+---@param p1 boolean
+function N_0xF611DE44AEB36A1D(crimeType, p1) end
+
+-- _0xFFEBE5AA96BC2E4E  (0xFFEBE5AA96BC2E4E)
+-- min build: 1207
+---@param ped number
+---@param crimeType number
+---@param p2 boolean
+---@return any
+function N_0xFFEBE5AA96BC2E4E(ped, crimeType, p2) end
+
+-- _ADD_WITNESS_RESPONSE  (0x10827B5A0AAC56A7)
+-- min build: 1207
+---@param player number
+---@param crimeType number
+---@param pedGroup number
+function _AddWitnessResponse(player, crimeType, pedGroup) end
+
+-- _ARE_ANY_LAW_PEDS_INVESTIGATING  (0xECE3C34B270428D5)
+-- Only used in rcm_homerob00 R* Script
+-- min build: 1207
+---@return boolean
+function _AreAnyLawPedsInvestigating() end
+
+-- _ARE_INVESTIGATORS_ACTIVE  (0xF0FBFB9AB15F7734)
+-- min build: 1207
+---@param player number
+---@param areInvestigatorsActive boolean
+---@param p2 any
+---@return boolean
+function _AreInvestigatorsActive(player, areInvestigatorsActive, p2) end
+
+-- _ARE_LAW_PEDS_ENABLED_FOR_TRAIN  (0xA22C46F16359471C)
+-- Only used in trainrobbery_ambient R* Script
+-- min build: 1207
+---@return boolean
+function _AreLawPedsEnabledForTrain() end
+
+-- _ARE_WITNESSES_PENDING  (0x0BB6DE7D23C60626)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _AreWitnessesPending(player) end
+
+-- _CREATE_GUARD_ZONE  (0x8F9DE75680275C9F)
+-- min build: 1207
+---@param name string
+function _CreateGuardZone(name) end
+
+-- _CREATE_GUARD_ZONE_FOR_ENTITY  (0x0D4B77E862475ED3)
+-- Returns true when investigation creation was successful
+-- min build: 1311
+---@param guardZoneName string
+---@param entity number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function _CreateGuardZoneForEntity(guardZoneName, entity, x, y, z) end
+
+-- _CREATE_LAW_DISPATCH_RESPONSE_FOR_COORDS  (0x75CBF20BA47E4F89)
+-- dispatchResponseHash: see common/data/dispatchresponses/..
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param dispatchResponseHash number
+---@return any
+function _CreateLawDispatchResponseForCoords(x, y, z, dispatchResponseHash) end
+
+-- _DISABLE_GUARD_ZONE  (0x26D558692B25DD95)
+-- min build: 1207
+---@param name string
+function _DisableGuardZone(name) end
+
+-- _ENABLE_DISPATCH_LAW  (0xC805EB785824F712)
+-- Reported to affect law witness creation/reporting rather than dispatch itself. When disabled, NPCs may not witness or report crimes.
+-- min build: 1207
+---@param toggle boolean
+function _EnableDispatchLaw(toggle) end
+
+-- _ENABLE_DISPATCH_LAW_2  (0x710448D44A64C213)
+-- Reported to affect law witness creation/reporting rather than dispatch itself. When disabled, NPCs may not witness or report crimes.
+-- min build: 1207
+---@param toggle boolean
+function _EnableDispatchLaw2(toggle) end
+
+-- _FORCE_LAW_ON_LOCAL_PLAYER_IMMEDIATELY  (0x956510F8C36B5C64)
+-- min build: 1207
+function _ForceLawOnLocalPlayerImmediately() end
+
+-- _FORCE_PLAYER_SEARCH  (0x7803436E68C32B26)
+-- Forces law to search for the player until stopped with _STOP_PLAYER_SEARCH.
+-- min build: 1207
+function _ForcePlayerSearch() end
+
+-- _FORCE_PLAYER_SEARCH_THIS_FRAME  (0xC310239ACCCF5579)
+-- Forces law to search for the player this frame.
+-- min build: 1207
+function _ForcePlayerSearchThisFrame() end
+
+-- _GET_BOUNTY_HUNTER_GLOBAL_COOLDOWN  (0x76CF93D4B416B288)
+-- p0 is always BOUNTYHUNTERSGLOBALCOOLDOWN in R* scripts
+-- min build: 1207
+---@param p0 number
+---@return number
+function _GetBountyHunterGlobalCooldown(p0) end
+
+-- _GET_CRIME_BOUNTY_AMOUNT_BY_TYPE  (0x35E5E21F9159849C)
+-- Returns bounty (increment) value
+-- min build: 1207
+---@param crimeType number
+---@return number
+function _GetCrimeBountyAmountByType(crimeType) end
+
+-- _GET_CRIME_DISPATCH_TYPE_FOR_PLAYER  (0x148E7AC8141C9E64)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetCrimeDispatchTypeForPlayer(player) end
+
+-- _GET_HUD_PLAYER_CRIME_TYPE  (0x259CE340A8738814)
+-- See _REPORT_CRIME
+-- min build: 1207
+---@param player number
+---@return number
+function _GetHudPlayerCrimeType(player) end
+
+-- _GET_TIME_SINCE_LAST_SEEN_BY_LAW  (0x717DA2281DF90855)
+-- Returns the amount of time (probably in game minutes) since last seen by the law / left the wanted radius
+-- min build: 1207
+---@param player number
+---@return number
+function _GetTimeSinceLastSeenByLaw(player) end
+
+-- _HAS_PLAYER_BEEN_FOUND_BY_LAW_ACTIVE_SEARCH  (0x9945A3E2528A02E8)
+-- Reported to return true when law active search finds the player for the first time. Returns false when the player evades or dies.
+-- Requires _SET_LAW_REGION for law to become aware of crimes.
+-- min build: 1207
+---@param player number
+---@return boolean
+function _HasPlayerBeenFoundByLawActiveSearch(player) end
+
+-- _IS_GUARD_PED_INVESTIGATING  (0xD743C4293F47AFAD)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsGuardPedInvestigating(ped) end
+
+-- _IS_PLAYER_SEARCHED  (0xF46108C50A22B029)
+-- Returns whether the player is in the law search state.
+-- min build: 1207
+---@return boolean
+function _IsPlayerSearched() end
+
+-- _LAW_WITNESS_RESPONSE_TASK  (0xF0B67BAD53C35BD9)
+-- min build: 1207
+---@param pedGroup1 number
+---@param ped number
+---@param pedGroup2 number
+---@param x number
+---@param y number
+---@param z number
+---@param crimeType number
+---@return boolean
+function _LawWitnessResponseTask(pedGroup1, ped, pedGroup2, x, y, z, crimeType) end
+
+-- _PAUSE_BOUNTY_HUNTER_COOLDOWN  (0xC61EDEBF16CD9668)
+-- p0 is always BOUNTYHUNTERSGLOBALCOOLDOWN in R* scripts
+-- min build: 1207
+---@param p0 number
+---@param p1 boolean
+---@param p2 any
+function _PauseBountyHunterCooldown(p0, p1, p2) end
+
+-- _REMOVE_GUARD_ZONE  (0x67EBDD958835956C)
+-- min build: 1207
+---@param name string
+function _RemoveGuardZone(name) end
+
+-- _REPORT_CRIME  (0xF60386770878A98F)
+-- crimeType:
+-- enum eCrimeType : Hash
+-- {
+-- 	CRIME_ACCOMPLICE = 0xAF074F6D,
+-- 	CRIME_ARSON = 0x68134DC7,
+-- 	CRIME_ASSAULT = 0x0BADC882,
+-- 	CRIME_ASSAULT_ANIMAL = 0x18DA55EE,
+-- 	CRIME_ASSAULT_CORPSE = 0x4E5F23F2,
+-- 	CRIME_ASSAULT_HORSE = 0xC4736181,
+-- 	CRIME_ASSAULT_LAW = 0xD7466D7C,
+-- 	CRIME_ASSAULT_LIVESTOCK = 0xCCE1CCBD,
+-- 	CRIME_BANK_ROBBERY = 0x6A1ADE3D,
+-- 	CRIME_BURGLARY = 0xA54C77E0,
+-- 	CRIME_CHEATING = 0xA2FF1145,
+-- 	CRIME_DISTURBANCE = 0x5011F613,
+-- 	CRIME_EXPLOSION = 0x3EBA7A37,
+-- 	CRIME_EXPLOSION_POISON = 0x91D0A0E1,
+-- 	CRIME_GRAVE_ROBBERY = 0x971EA5AF,
+-- 	CRIME_HASSLE = 0x58488776,
+-- 	CRIME_HIT_AND_RUN = 0xFF0A3CC4,
+-- 	CRIME_HIT_AND_RUN_LAW = 0x064814AF,
+-- 	CRIME_INTIMIDATION = 0x8319FBAB,
+-- 	CRIME_JACK_HORSE = 0x82F7E4A2,
+-- 	CRIME_JACK_VEHICLE = 0x6B981F4C,
+-- 	CRIME_JAIL_BREAK = 0x12C1D589,
+-- 	CRIME_KIDNAPPING = 0x98F908DB,
+-- 	CRIME_KIDNAPPING_LAW = 0xFD72A7EA,
+-- 	CRIME_LASSO_ASSAULT = 0x56EE5D5A,
+-- 	CRIME_LAW_IS_THREATENED = 0x1CB91DF0,
+-- 	CRIME_LOITERING = 0x6629D2F4,
+-- 	CRIME_LOOTING = 0x55AD2BEB,
+-- 	CRIME_MURDER = 0xE28ECE7E,
+-- 	CRIME_MURDER_ANIMAL = 0x48F59A66,
+-- 	CRIME_MURDER_HORSE = 0xC7261D79,
+-- 	CRIME_MURDER_LAW = 0x7797FCE7,
+-- 	CRIME_MURDER_LIVESTOCK = 0x9569C546,
+-- 	CRIME_MURDER_PLAYER = 0xF5ABD6C9,
+-- 	CRIME_MURDER_PLAYER_HORSE = 0xD55C6A79,
+-- 	CRIME_PROPERTY_DESTRUCTION = 0x533B003D,
+-- 	CRIME_RESIST_ARREST = 0xDF577BA5,
+-- 	CRIME_ROBBERY = 0xA3BEDE4C,
+-- 	CRIME_SELF_DEFENCE = 0xBD6A0AA3,
+-- 	CRIME_STAGECOACH_ROBBERY = 0xFC738E61,
+-- 	CRIME_STOLEN_GOODS = 0x9A949C79,
+-- 	CRIME_THEFT = 0x72ADE410,
+-- 	CRIME_THEFT_HORSE = 0xBE3A5838,
+-- 	CRIME_THEFT_LIVESTOCK = 0x85BA08FD,
+-- 	CRIME_THEFT_VEHICLE = 0x43A9ECA1,
+-- 	CRIME_THREATEN = 0x941C985A,
+-- 	CRIME_THREATEN_LAW = 0x7F908566,
+-- 	CRIME_TRAIN_ROBBERY = 0x647D2A5A,
+-- 	CRIME_TRAMPLE = 0x45DB39D8,
+-- 	CRIME_TRAMPLE_LAW = 0xF00F266B,
+-- 	CRIME_TRAMPLE_PLAYER = 0x75970C15,
+-- 	CRIME_TRESPASSING = 0xAEDE8E35,
+-- 	CRIME_UNARMED_ASSAULT = 0x5098CC5A,
+-- 	CRIME_VANDALISM = 0x80FDC759,
+-- 	CRIME_VANDALISM_VEHICLE = 0xF9E7ECE4,
+-- 	CRIME_VEHICLE_DESTRUCTION = 0x54A85DDC,
+-- 	CRIME_WANTED_LEVEL_UP_DEBUG_HIGH = 0x99C52FF5,
+-- 	CRIME_WANTED_LEVEL_UP_DEBUG_LOW = 0xD891890F
+-- };
+-- min build: 1207
+---@param player number
+---@param crimeType number
+---@param bounty number
+---@param entity number
+---@param isKnownSuspect boolean
+function _ReportCrime(player, crimeType, bounty, entity, isKnownSuspect) end
+
+-- _REPORT_PLAYER_LAW_DISPATCH_RESPONSE_OVERRIDE  (0x9C4352134B2835FB)
+-- min build: 1207
+---@param player number
+---@param dispatchResponseHash number
+function _ReportPlayerLawDispatchResponseOverride(player, dispatchResponseHash) end
+
+-- _SET_ALLOW_DISABLED_LAW_RESPONSES  (0x4B52BF96E225D230)
+-- min build: 1207
+---@param toggle boolean
+function _SetAllowDisabledLawResponses(toggle) end
+
+-- _SET_BOUNTY_HUNTER_GLOBAL_COOLDOWN  (0xF19706B1F8FFA88F)
+-- p0 is always BOUNTYHUNTERSGLOBALCOOLDOWN in R* scripts
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function _SetBountyHunterGlobalCooldown(p0, p1) end
+
+-- _SET_BOUNTY_HUNTER_PURSUIT_CLEARED  (0x55F37F5F3F2475E1)
+-- Force clears local player's wanted level
+-- min build: 1207
+function _SetBountyHunterPursuitCleared() end
+
+-- _SET_CANT_LOSE_LAW_THIS_RESPONSE  (0xDDCE8E960D1DE240)
+-- min build: 1207
+---@param enabled boolean
+function _SetCantLoseLawThisResponse(enabled) end
+
+-- _SET_CUSTOM_LAW_DISPATCH_RESPONSE  (0x009CF9A29972C298)
+-- Note: This native is only used in multiplayer scripts
+-- dispatchResponseHash: see update1/common/data/dispatchresponses/..
+-- min build: 1207
+---@param dispatchResponseHash number
+function _SetCustomLawDispatchResponse(dispatchResponseHash) end
+
+-- _SET_DISPATCH_MULTIPLIER_OVERRIDE  (0x002BABE0B7D53136)
+-- min build: 1207
+---@param multiplier number
+function _SetDispatchMultiplierOverride(multiplier) end
+
+-- _SET_GUARD_ZONE_POSITION  (0x7E7BF59F89FC6C6D)
+-- min build: 1207
+---@param name string
+---@param x number
+---@param y number
+---@param z number
+function _SetGuardZonePosition(name, x, y, z) end
+
+-- _SET_GUARD_ZONE_POSITION_2  (0x2F9005E2EA4E5EE4)
+-- min build: 1207
+---@param name string
+---@param x number
+---@param y number
+---@param z number
+function _SetGuardZonePosition2(name, x, y, z) end
+
+-- _SET_GUARD_ZONE_VOLUME_REGISTRATION_END  (0xA8A74AA79FB67159)
+-- min build: 1207
+---@param name string
+---@param volume number
+function _SetGuardZoneVolumeRegistrationEnd(name, volume) end
+
+-- _SET_GUARD_ZONE_VOLUME_REGISTRATION_START  (0x8C598A930F471938)
+-- min build: 1207
+---@param name string
+---@param volume number
+function _SetGuardZoneVolumeRegistrationStart(name, volume) end
+
+-- _SET_GUARD_ZONE_VOLUME_RESTRICTED  (0x35815F372D43E1E5)
+-- min build: 1207
+---@param name string
+---@param volume number
+function _SetGuardZoneVolumeRestricted(name, volume) end
+
+-- _SET_GUARD_ZONE_VOLUME_THREAT  (0xA1B0E6301E2E02A6)
+-- min build: 1207
+---@param name string
+---@param volume number
+function _SetGuardZoneVolumeThreat(name, volume) end
+
+-- _SET_GUARD_ZONE_VOLUME_WARNING  (0xAD3E07C37A7C1ADC)
+-- min build: 1207
+---@param name string
+---@param volume number
+function _SetGuardZoneVolumeWarning(name, volume) end
+
+-- _SET_LAW_DISABLED  (0x8DE82BC774F3B862)
+-- Temporarily disables law dispatch response even if crimes are witnessed or reported. Re-enabling after a report can resume dispatch and law search.
+-- min build: 1207
+---@param toggle boolean
+function _SetLawDisabled(toggle) end
+
+-- _SET_LAW_RBS_VOLUME  (0x9BBDCB8DF789EBC1)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function _SetLawRbsVolume(player, p1) end
+
+-- _SET_LAW_REGION  (0x4752F68EB7F2D280)
+-- enum eLawRegion : Hash
+-- {
+-- 	LAW_DISPATCH_REGION_NONE = 0,
+-- 	LAW_REGION_AGUASDULCES = 0x2F573EBE,
+-- 	LAW_REGION_ANNESBURG = 0x68CAFD50,
+-- 	LAW_REGION_ARMADILLO = 0xF0B90756,
+-- 	LAW_REGION_BAYOU_NWA = 0x80966B1C,
+-- 	LAW_REGION_BEECHERS_HOPE = 0xE2544977,
+-- 	LAW_REGION_BIG_VALLEY = 0x3DF1559A,
+-- 	LAW_REGION_BLACKWATER = 0x60D4886D,
+-- 	LAW_REGION_BLACKWATER_MAINGAME = 0x66553576,
+-- 	LAW_REGION_BLUEGILL_MARSH = 0x1D6AED8E,
+-- 	LAW_REGION_BRAITHWAITE_MANOR = 0x3D71E7FF,
+-- 	LAW_REGION_BUTCHER_CREEK = 0x2B3E1822,
+-- 	LAW_REGION_CALIGA_HALL = 0xF3FE5080,
+-- 	LAW_REGION_CORNWALL = 0xCC4672FA,
+-- 	LAW_REGION_CUMBERLAND_FOREST = 0x81A78306,
+-- 	LAW_REGION_EMERALD_RANCH = 0x5C069DF3,
+-- 	LAW_REGION_FORT_WALLACE = 0x0AF25192,
+-- 	LAW_REGION_GREAT_PLAINS = 0xB20573FA,
+-- 	LAW_REGION_GREAT_PLAINS_MAINGAME = 0x9862FF7C,
+-- 	LAW_REGION_GRIZZLIES = 0xBB936031,
+-- 	LAW_REGION_GUAMA = 0x200DFF42,
+-- 	LAW_REGION_HEARTLANDS = 0xAD14DA65,
+-- 	LAW_REGION_LAGRAS = 0xC64808D3,
+-- 	LAW_REGION_MACFARLANES_RANCH = 0x396A7D5F,
+-- 	LAW_REGION_MANICATO = 0x039DB6BF,
+-- 	LAW_REGION_MANZANITA_POST = 0x895E580E,
+-- 	LAW_REGION_MANZANITA_POST_MAINGAME = 0x9BDD6A38,
+-- 	LAW_REGION_OCCUPIED_CARAVAN_CAMP = 0x7EBABB01,
+-- 	LAW_REGION_OLD_MAP_WILDERNESS = 0xCBB45950,
+-- 	LAW_REGION_OLD_MAP_WILDERNESS_MAINGAME = 0x9F839BE7,
+-- 	LAW_REGION_OUTLAW3 = 0x97A02FC1,
+-- 	LAW_REGION_PRONGHORN_RANCH = 0x398E4BFC,
+-- 	LAW_REGION_RHODES = 0x89222928,
+-- 	LAW_REGION_RHODES_LOCKDOWN = 0xB1181671,
+-- 	LAW_REGION_RIDGEWOOD_FARM = 0x635C3028,
+-- 	LAW_REGION_ROANOKE_RIDGE = 0x46386A9A,
+-- 	LAW_REGION_SAINT_DENIS = 0x5CF7C268,
+-- 	LAW_REGION_SAINT_DENIS_RURAL = 0x4FD5331A,
+-- 	LAW_REGION_SCARLETT_MEADOWS = 0x5FDD9717,
+-- 	LAW_REGION_SISIKA = 0x2B6BBA52,
+-- 	LAW_REGION_STRAWBERRY = 0xDD932620,
+-- 	LAW_REGION_TALL_TREES = 0xD939B758,
+-- 	LAW_REGION_TALL_TREES_MAINGAME = 0x084B17DF,
+-- 	LAW_REGION_THIEVES_LANDING = 0x3D0C2EB6,
+-- 	LAW_REGION_THIEVES_LANDING_MAINGAME = 0x61C450F3,
+-- 	LAW_REGION_TUMBLEWEED = 0x0EFAF8DC,
+-- 	LAW_REGION_VALENTINE = 0xA7A3F0C3,
+-- 	LAW_REGION_VALENTINE_LOCKDOWN = 0x123582FE,
+-- 	LAW_REGION_VAN_HORN = 0x619B528E,
+-- 	LAW_REGION_WAPITI = 0x7A976E02
+-- };
+-- min build: 1207
+---@param player number
+---@param lawRegionHash number
+---@param stateHash number
+function _SetLawRegion(player, lawRegionHash, stateHash) end
+
+-- _SET_PED_LAW_BEHAVIOUR  (0x819ADD5EF1742F47)
+-- behaviour: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CLawBehavior__Flags
+-- min build: 1207
+---@param ped number
+---@param behaviour number
+function _SetPedLawBehaviour(ped, behaviour) end
+
+-- _STOP_PLAYER_SEARCH  (0x29CD4896ECB66C12)
+-- Stops the forced player search state.
+-- min build: 1207
+function _StopPlayerSearch() end
+
+-- ADD_BOUNTY  (0x0E3BDEED21BEB945)
+-- min build: 1207
+---@param player number
+---@param itemValueAmount number
+function AddBounty(player, itemValueAmount) end
+
+-- ARE_WITNESSES_ACTIVE  (0x69E181772886F48B)
+-- min build: 1207
+---@param player number
+---@return boolean
+function AreWitnessesActive(player) end
+
+-- CLEAR_BOUNTY  (0xC76F252371150D9A)
+-- min build: 1207
+---@param player number
+function ClearBounty(player) end
+
+-- CLEAR_PLAYER_PAST_CRIMES  (0xBCC6DC59E32A2BDC)
+-- min build: 1207
+---@param player number
+function ClearPlayerPastCrimes(player) end
+
+-- CLEAR_WANTED_SCORE  (0x062B4A4A3396351D)
+-- min build: 1207
+---@param player number
+function ClearWantedScore(player) end
+
+-- GET_BOUNTY  (0x54310AAB97B92816)
+-- min build: 1207
+---@param player number
+---@return number
+function GetBounty(player) end
+
+-- GET_PLAYER_REGISTERED_CRIME  (0x532C5FDDB986EE5C)
+-- Reads one entry from the player's registered-crimes list (oldest -> newest) at the given index.
+-- 	- Commonly iterated with index 0..23.
+-- 	- Returns true if the entry exists/was copied into outData.
+-- 	- Scripts typically check outData.f_10 (reported flag) and use (crimeType, unk7) as inputs to other LAW queries.
+-- 
+-- outData (script struct<11>):
+-- 	struct RegisteredCrime
+-- 	{
+-- 		alignas(8) Hash crimeType;   // outData.f_0
+-- 		alignas(8) int  bounty;      // outData.f_1
+-- 		alignas(8) Hash unk2;        // outData.f_2
+-- 		alignas(8) Any  unk3;        // outData.f_3
+-- 		alignas(8) Any  unk4;        // outData.f_4
+-- 		alignas(8) Any  unk5;        // outData.f_5
+-- 		alignas(8) Any  unk6;        // outData.f_6
+-- 		alignas(8) int  unk7;        // outData.f_7 (paired with crimeType in scripts)
+-- 		alignas(8) Any  unk8;        // outData.f_8
+-- 		alignas(8) Any  unk9;        // outData.f_9
+-- 		alignas(8) bool wasReported; // outData.f_10
+-- 	};
+-- min build: 1207
+---@param player number
+---@param index number
+---@return boolean
+---@return any
+function GetPlayerRegisteredCrime(player, index) end
+
+-- GET_WANTED_SCORE  (0xDD5FD601481F648B)
+-- min build: 1207
+---@param player number
+---@return number
+function GetWantedScore(player) end
+
+-- IS_LAW_INCIDENT_ACTIVE  (0xAD401C63158ACBAA)
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsLawIncidentActive(player) end
+
+-- NUM_CRIMES_SUPPRESSED  (0xC08E804C91F47C80)
+-- Returns amount of suppressed crimes to be used later in the function MPINTRO_CRIME_MONITOR_MAINTAIN
+-- min build: 1207
+---@param player number
+---@param crimeType number
+---@return number
+function NumCrimesSuppressed(player, crimeType) end
+
+-- RESET_WANTED_FOR_NEW_INCIDENT  (0x2728C77FBC4B9796)
+-- min build: 1207
+---@param player number
+function ResetWantedForNewIncident(player) end
+
+-- SET_BOUNTY  (0x093A9D1F72DF0D19)
+-- min build: 1207
+---@param player number
+---@param amount number
+function SetBounty(player, amount) end
+
+-- SET_DISABLE_DISTURBANCE_CRIMES  (0xDE5FAA741A781F73)
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function SetDisableDisturbanceCrimes(player, p1) end
+
+-- SET_LAW_SENSE_RANGE_MODIFIER  (0xFEC85339AACA2A35)
+-- Default range is 1.0f
+-- min build: 1207
+---@param player number
+---@param range number
+function SetLawSenseRangeModifier(player, range) end
+
+-- SET_PLAYER_ARRESTED_IN_REGION  (0xE0FA74AA3CCE650B)
+-- min build: 1207
+---@param player number
+---@param lawRegionHash number
+function SetPlayerArrestedInRegion(player, lawRegionHash) end
+
+-- SET_PLAYER_TURNED_IN_BOUNTY_IN_REGION  (0x73BAD7B2F2DB50DE)
+-- min build: 1207
+---@param player number
+---@param lawRegionHash number
+function SetPlayerTurnedInBountyInRegion(player, lawRegionHash) end
+
+-- SET_POSTPONE_DISTURBANCE_CRIMES_DURING_COMBAT  (0x362086B911657B1A)
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function SetPostponeDisturbanceCrimesDuringCombat(player, p1) end
+
+-- SET_WANTED_SCORE  (0xA80FF73F772ACF6A)
+-- min build: 1207
+---@param player number
+---@param intensity number
+function SetWantedScore(player, intensity) end
+
+-- SUPPRESS_CRIME_THIS_FRAME  (0x785177E4D57D7389)
+-- crimeType: see _REPORT_CRIME
+-- min build: 1207
+---@param player number
+---@param crimeType number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function SuppressCrimeThisFrame(player, crimeType, p2, p3, p4) end

--- a/.luals/redm-natives/LOCALIZATION.lua
+++ b/.luals/redm-natives/LOCALIZATION.lua
@@ -1,0 +1,45 @@
+---@meta
+
+-- RDR3 namespace: LOCALIZATION -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _DOES_CURRENT_LANGUAGE_SUPPORT_CONDENSED_STYLE  (0x45D50415E4D885FF)
+-- Returns true if the current language is american, french, german, italian, spanish, brazilian or mexican.
+-- _DOES_*
+-- min build: 1207
+---@return boolean
+function _DoesCurrentLanguageSupportCondensedStyle() end
+
+-- GET_CURRENT_LANGUAGE  (0xDB917DA5C6835FCC)
+-- 0 = american (en-US)
+-- 1 = french (fr-FR)
+-- 2 = german (de-DE)
+-- 3 = italian (it-IT)
+-- 4 = spanish (es-ES)
+-- 5 = brazilian (pt-BR)
+-- 6 = polish (pl-PL)
+-- 7 = russian (ru-RU)
+-- 8 = korean (ko-KR)
+-- 9 = chinesetrad (zh-TW)
+-- 10 = japanese (ja-JP)
+-- 11 = mexican (es-MX)
+-- 12 = chinesesimp (zh-CN)
+-- min build: 1207
+---@return number
+function GetCurrentLanguage() end
+
+-- LOCALIZATION_GET_SYSTEM_DATE_TYPE  (0x76E30B799EBEEA0F)
+-- 0 = DATE_FORMAT_DMY
+-- 1 = DATE_FORMAT_MDY
+-- 2 = DATE_FORMAT_YMD
+-- 
+-- Old name: _LOCALIZATION_GET_SYSTEM_DATE_FORMAT
+-- min build: 1207
+---@return number
+function LocalizationGetSystemDateType() end
+
+-- LOCALIZATION_GET_SYSTEM_LANGUAGE  (0x3C1A05F86AE6ACB5)
+-- Same return values as GET_CURRENT_LANGUAGE
+-- min build: 1207
+---@return number
+function LocalizationGetSystemLanguage() end

--- a/.luals/redm-natives/MAP.lua
+++ b/.luals/redm-natives/MAP.lua
@@ -1,0 +1,569 @@
+---@meta
+
+-- RDR3 namespace: MAP -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0xD3F58E9316B7FC2A  (0xD3F58E9316B7FC2A)
+-- min build: 1207
+---@param p0 any
+function N_0xD3F58E9316B7FC2A(p0) end
+
+-- _ABANDON_BLIP  (0xDEEDE7C41742E011)
+-- Not sure what exactly this does, but it calls rage::fwuiBlip::ClearScriptIdentity() internally
+-- min build: 1207
+---@param blip number
+function _AbandonBlip(blip) end
+
+-- _ADD_PROP_TO_MINIMAP  (0x1392105DA88BBFFB)
+-- list of minimap props: https://github.com/femga/rdr3_discoveries/tree/master/graphics/minimap/minimapObjects
+-- min build: 1207
+---@param minimapProp number
+---@param x number
+---@param y number
+---@param rotation number
+---@param p4 number
+function _AddPropToMinimap(minimapProp, x, y, rotation, p4) end
+
+-- _BLIP_ADD_FOR_AREA  (0xEC174ADBCB611ECC)
+-- min build: 1207
+---@param blipHash number
+---@param x number
+---@param y number
+---@param z number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@param p7 number
+---@return number
+function _BlipAddForArea(blipHash, x, y, z, scaleX, scaleY, scaleZ, p7) end
+
+-- _BLIP_ADD_FOR_STYLE  (0x3E593DF9C2962EC6)
+-- min build: 1207
+---@param styleHash number
+---@return number
+function _BlipAddForStyle(styleHash) end
+
+-- _BLIP_ADD_FOR_VOLUME  (0xA6EF0C54A3443E70)
+-- min build: 1207
+---@param blipHash number
+---@param volume number
+---@return number
+function _BlipAddForVolume(blipHash, volume) end
+
+-- _BLIP_ADD_STYLE  (0xBD62D98799A3DAF0)
+-- min build: 1207
+---@param blip number
+---@param styleHash number
+---@return boolean
+function _BlipAddStyle(blip, styleHash) end
+
+-- _BLIP_SET_STYLE  (0xEDD964B7984AC291)
+-- https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/blip_styles
+-- Removes any existing modifiers and sets the style.
+-- min build: 1207
+---@param blip number
+---@param styleHash number
+---@return boolean
+function _BlipSetStyle(blip, styleHash) end
+
+-- _CLEAR_BLIP  (0x01B928CA2E198B01)
+-- Clears blip data, must be called before REMOVE_BLIP.
+-- Blips seem to be handled via databinding internally, this function should then allow you to clear blip container and therefore free up memory.
+-- min build: 1207
+---@param blip number
+---@return boolean
+function _ClearBlip(blip) end
+
+-- _CLEAR_BLIP_ICON_FROM_LOCKON_ENTITY_PROMPT  (0x44813684F72B563C)
+-- Removes the blip icon from the entity lockon prompt
+-- min build: 1207
+---@param entity number
+---@param blip number
+function _ClearBlipIconFromLockonEntityPrompt(entity, blip) end
+
+-- _CLEAR_PAUSEMAP_COORDS  (0x7C9F4CDF402CA82A)
+-- Clears the previously set coordinates for the pause map view, removing any specified focal point and radius that were set using `_SET_PAUSEMAP_COORDS_WITH_RADIUS` (0xE0884C184728C75B). This function resets the map view, allowing it to open with the default coordinates and view instead of a specific target area.
+-- Clears any previously set coordinates for the pause map view, restoring the default view when the map is opened.
+-- 
+-- Video: https://imgur.com/gallery/0x7c9f4cdf402ca82a-mZE3Nwj
+-- min build: 1311
+function _ClearPausemapCoords() end
+
+-- _DOES_ENTITY_HAVE_BLIP  (0x9FA00E2FC134A9D0)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _DoesEntityHaveBlip(entity) end
+
+-- _FIND_CLOSEST_GPS_POSITION  (0x3FDA2B79AEEE351C)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return vector3
+function _FindClosestGpsPosition(x, y, z) end
+
+-- _GET_WAYPOINT_COORDS  (0x29B30D07C3F7873B)
+-- Note: Z coordinate will always be zero
+-- min build: 1207
+---@return vector3
+function _GetWaypointCoords() end
+
+-- _GET_WAYPOINT_POSITION  (0xF08E42BFA46BDFF8)
+-- Unlike `GET_WAYPOINT_COORDS` (0x29B30D07C3F7873B), which returns a single value, this native returns the x and y coordinates of the waypoint separately as float pointers.
+-- Image: https://i.imgur.com/tu1jnY7.png
+-- min build: 1207
+---@return boolean
+---@return number
+---@return number
+function _GetWaypointPosition() end
+
+-- _HIDE_ACTIVE_POINTS_OF_INTEREST  (0xA1B4052C2A3DCC1E)
+-- min build: 1207
+function _HideActivePointsOfInterest() end
+
+-- _IS_BLIP_ATTACHED_TO_ANY_ENTITY  (0xE9F676788F8D5E1E)
+-- min build: 1207
+---@param blip number
+---@return boolean
+function _IsBlipAttachedToAnyEntity(blip) end
+
+-- _IS_DISPLAY_BLIP_ICON_ON_LOCKON_ENTITY_PROMPT  (0x3CB8859F04763C78)
+-- Returns true if the entity lockon prompt contains an blip icon.
+-- min build: 1207
+---@param entity number
+---@param blip number
+---@return boolean
+function _IsDisplayBlipIconOnLockonEntityPrompt(entity, blip) end
+
+-- _IS_PATH_FOR_GPS_ON_ROAD  (0xF47A1EB2A538A3A3)
+-- Checks if the GPS route to the waypoint is navigable along a road.
+-- If a route exists but there is no valid road path, this function returns false.
+-- min build: 1207
+---@return boolean
+function _IsPathForGpsOnRoad() end
+
+-- _MAP_DISABLE_REGION_BLIP  (0x6786D7AFAC3162B3)
+-- min build: 1207
+---@param regionHash number
+function _MapDisableRegionBlip(regionHash) end
+
+-- _MAP_DISCOVER_REGION  (0xD8C7162AB2E2AF45)
+-- min build: 1207
+---@param discoveryHash number
+function _MapDiscoverRegion(discoveryHash) end
+
+-- _MAP_DISCOVERY_SET_ENABLED  (0xDA98246C7A3C2189)
+-- min build: 1207
+---@param discoveryHash number
+function _MapDiscoverySetEnabled(discoveryHash) end
+
+-- _MAP_ENABLE_REGION_BLIP  (0x563FCB6620523917)
+-- regionHash: https://github.com/femga/rdr3_discoveries/tree/master/graphics/minimap/wanted_regions
+-- min build: 1207
+---@param regionHash number
+---@param styleHash number
+function _MapEnableRegionBlip(regionHash, styleHash) end
+
+-- _MAP_IS_DISCOVERY_ACTIVE  (0x3F81EA4275D39D6F)
+-- min build: 1207
+---@param discoveryHash number
+---@return boolean
+function _MapIsDiscoveryActive(discoveryHash) end
+
+-- _MAP_IS_REGION_HIGHLIGHTED_WITH_STYLE  (0xE38450DBCBC70E3D)
+-- min build: 1207
+---@param regionHash number
+---@param styleHash number
+---@return boolean
+function _MapIsRegionHighlightedWithStyle(regionHash, styleHash) end
+
+-- _REMOVE_PROP_FROM_MINIMAP  (0xE057FEA9A22EB3EE)
+-- min build: 1207
+---@param minimapProp number
+function _RemovePropFromMinimap(minimapProp) end
+
+-- _REVEAL_MINIMAP_FOW  (0xF8096DF9B87246E3)
+-- min build: 1207
+---@param hash number
+function _RevealMinimapFow(hash) end
+
+-- _SET_BLIP_FROZEN  (0x250C75EB1728CC0D)
+-- Removes blip from any entity and makes it static on the map, try it on GET_MAIN_PLAYER_BLIP_ID for a demonstration.
+-- min build: 1207
+---@param blip number
+function _SetBlipFrozen(blip) end
+
+-- _SET_BLIP_NAME  (0x9CB1A1623062F402)
+-- min build: 1207
+---@param blip number
+---@param name string
+function _SetBlipName(blip, name) end
+
+-- _SET_DISPLAY_BLIP_ICON_FOR_ENTITY_PROMPT_REMOVED  (0xBB68D4D3CA3DE402)
+-- Removes the icon from the lockon prompt. Never executed in R* Scripts due to hardcoded 0.
+-- min build: 1207
+---@param entity number
+---@param p1 number
+function _SetDisplayBlipIconForEntityPromptRemoved(entity, p1) end
+
+-- _SET_DISPLAY_BLIP_ICON_FOR_ENTITY_PROMPT_WITH_LOCKON  (0x7563CBCA99253D1A)
+-- Sets the blip icon to lockon entity prompt.
+-- min build: 1207
+---@param entity number
+---@param blipIcon number
+function _SetDisplayBlipIconForEntityPromptWithLockon(entity, blipIcon) end
+
+-- _SET_DISPLAY_BLIP_ICON_FOR_ENTITY_PROMPT_WITHOUT_LOCKON  (0x1726963E6049DB53)
+-- Activates a blip icon prompt for a specific entity, allowing it to be displayed without requiring a lock-on. This function enables the blip to appear associated with the given entity, making it visible without the need to focus or target the entity directly.
+-- Video: https://imgur.com/gallery/0x1726963e6049db53-vuuCwqe
+-- min build: 1207
+---@param entity number
+function _SetDisplayBlipIconForEntityPromptWithoutLockon(entity) end
+
+-- _SET_DISPLAY_BLIP_ICON_TO_LOCKON_ENTITY_PROMPT  (0x97F6F158CC5B5CA2)
+-- Adds entity blip icon to the entity lockon prompt, if invalid param it will remove the icon if it had any.
+-- min build: 1207
+---@param entity number
+---@param blip number
+function _SetDisplayBlipIconToLockonEntityPrompt(entity, blip) end
+
+-- _SET_FOW_UPDATE_PLAYER_OVERRIDE  (0x63E7279D04160477)
+-- Used for GUARMA MODE; Enabled: toggle = false, 0; Disabled: toggle = true, 0
+-- Hash p1 seems to be unused, always 0
+-- min build: 1207
+---@param toggle boolean
+---@param p1 number
+function _SetFowUpdatePlayerOverride(toggle, p1) end
+
+-- _SET_MINIMAP_FOW_OVERRIDE_REVEAL_SCALE  (0xE5A7F70B7C0F3271)
+-- min build: 1207
+---@param scale number
+---@param p1 number
+function _SetMinimapFowOverrideRevealScale(scale, p1) end
+
+-- _SET_MINIMAP_FOW_SHOULD_UPDATE  (0x632AA10BF7EA53D3)
+-- min build: 1207
+---@param toggle boolean
+---@param p1 number
+function _SetMinimapFowShouldUpdate(toggle, p1) end
+
+-- _SET_MINIMAP_ZONE  (0xA657EC9DBC6CC900)
+-- hash can be the hash of "guarma" or "world".
+-- min build: 1207
+---@param zone number
+function _SetMinimapZone(zone) end
+
+-- _SET_PAUSEMAP_COORDS_WITH_RADIUS  (0xE0884C184728C75B)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+function _SetPausemapCoordsWithRadius(x, y, z, radius) end
+
+-- _SET_RADAR_CONFIG_TYPE  (0x9C113883487FD53C)
+-- https://github.com/femga/rdr3_discoveries/blob/master/graphics/minimap/radar/radar_configs.lua
+-- configHash: -1943724816, 347777538, -117986897, -789269373, -547506804, -1986542417, 2080113112
+-- p1: usually 898171178 or 0 in R* scripts (doesn't seems to have any effect)
+-- min build: 1207
+---@param configHash number
+---@param p1 number
+function _SetRadarConfigType(configHash, p1) end
+
+-- _SHOW_ACTIVE_POINTS_OF_INTEREST  (0x3FBB838AEA30C1D8)
+-- min build: 1207
+function _ShowActivePointsOfInterest() end
+
+-- _START_GPS_CUSTOM_ROUTE_FROM_WAYPOINT_RECORDING_ROUTE  (0x6B44F13D888F770D)
+-- min build: 1207
+---@param waypointRecording string
+---@param point number
+---@param numPoints number
+---@param colorNameHash number
+---@param p4 boolean
+---@param p5 boolean
+function _StartGpsCustomRouteFromWaypointRecordingRoute(waypointRecording, point, numPoints, colorNameHash, p4, p5) end
+
+-- _TRIGGER_SONAR_BLIP_ON_ENTITY  (0x0C7A2289A5C4D7C9)
+-- min build: 1207
+---@param typeHash number
+---@param entity number
+function _TriggerSonarBlipOnEntity(typeHash, entity) end
+
+-- ADD_POINT_TO_GPS_MULTI_ROUTE  (0x64C59DD6834FA942)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 boolean
+function AddPointToGpsMultiRoute(x, y, z, p3) end
+
+-- ALLOW_SONAR_BLIPS  (0x6E6E64788C07D2E0)
+-- min build: 1207
+---@param toggle boolean
+function AllowSonarBlips(toggle) end
+
+-- BLIP_ADD_FOR_COORDS  (0x554D9D53F696D002)
+-- https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/textures/blips
+-- https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/textures/blips_mp
+-- min build: 1207
+---@param blipHash number
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function BlipAddForCoords(blipHash, x, y, z) end
+
+-- BLIP_ADD_FOR_ENTITY  (0x23F74C2FDA6E7C61)
+-- min build: 1207
+---@param blipHash number
+---@param entity number
+---@return number
+function BlipAddForEntity(blipHash, entity) end
+
+-- BLIP_ADD_FOR_PICKUP_PLACEMENT  (0xA486008892065FB9)
+-- min build: 1207
+---@param blipHash number
+---@param pickup number
+---@return number
+function BlipAddForPickupPlacement(blipHash, pickup) end
+
+-- BLIP_ADD_FOR_RADIUS  (0x45F13B7E0A15C880)
+-- min build: 1207
+---@param blipHash number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return number
+function BlipAddForRadius(blipHash, x, y, z, radius) end
+
+-- BLIP_ADD_MODIFIER  (0x662D364ABF16DE2F)
+-- https://alloc8or.re/rdr3/doc/enums/eBlipModifier.txt
+-- https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/blip_modifiers
+-- 
+-- Old name: _BLIP_SET_MODIFIER
+-- min build: 1207
+---@param blip number
+---@param modifierHash number
+---@return boolean
+function BlipAddModifier(blip, modifierHash) end
+
+-- BLIP_REMOVE_MODIFIER  (0xB059D7BD3D78C16F)
+-- If modifierHash is 0, ALL modifiers will be removed.
+-- min build: 1207
+---@param blip number
+---@param modifierHash number
+---@return boolean
+function BlipRemoveModifier(blip, modifierHash) end
+
+-- CLEAR_GPS_CUSTOM_ROUTE  (0x1EAA5674B4D181C5)
+-- min build: 1207
+function ClearGpsCustomRoute() end
+
+-- CLEAR_GPS_FLAGS  (0x4D3771237C79FF41)
+-- Clears the GPS flags.
+-- min build: 1207
+function ClearGpsFlags() end
+
+-- CLEAR_GPS_MULTI_ROUTE  (0x9E0AB9AAEE87CE28)
+-- Does the same as SET_GPS_MULTI_ROUTE_RENDER(false);
+-- min build: 1207
+function ClearGpsMultiRoute() end
+
+-- CLEAR_GPS_PLAYER_WAYPOINT  (0x08FDC6F796E350D1)
+-- min build: 1207
+function ClearGpsPlayerWaypoint() end
+
+-- DISPLAY_RADAR  (0x1B3DA717B9AFF828)
+-- If Minimap / Radar should be displayed.
+-- min build: 1207
+---@param toggle boolean
+function DisplayRadar(toggle) end
+
+-- DOES_BLIP_EXIST  (0xCD82FA174080B3B1)
+-- min build: 1207
+---@param blip number
+---@return boolean
+function DoesBlipExist(blip) end
+
+-- FORCE_SONAR_BLIPS_THIS_FRAME  (0xEE1C7BA69BB74B08)
+-- Doesn't actually return anything.
+-- min build: 1207
+---@return any
+function ForceSonarBlipsThisFrame() end
+
+-- GET_BLIP_COORDS  (0x201C319797BDA603)
+-- min build: 1207
+---@param blip number
+---@return vector3
+function GetBlipCoords(blip) end
+
+-- GET_BLIP_FROM_ENTITY  (0x6D2C41A8BD6D6FD0)
+-- Returns the Blip handle of given Entity.
+-- min build: 1207
+---@param entity number
+---@return number
+function GetBlipFromEntity(entity) end
+
+-- GET_MAIN_PLAYER_BLIP_ID  (0x5CD2889B2B381D45)
+-- min build: 1207
+---@return number
+function GetMainPlayerBlipId() end
+
+-- IS_BLIP_ON_MINIMAP  (0x46534526B9CD2D17)
+-- min build: 1207
+---@param blip number
+---@return boolean
+function IsBlipOnMinimap(blip) end
+
+-- IS_WAYPOINT_ACTIVE  (0x202B1BBFC6AB5EE4)
+-- min build: 1207
+---@return boolean
+function IsWaypointActive() end
+
+-- LOCK_MINIMAP_ANGLE  (0x0BFD145EF819FB3A)
+-- Locks the minimap to the specified angle in integer degrees.
+-- 
+-- angle: The angle in whole degrees. If less than 0 or greater than 360, unlocks the angle.
+-- min build: 1207
+---@param angle number
+function LockMinimapAngle(angle) end
+
+-- REMOVE_BLIP  (0xF2C3C9DA47AAA54A)
+-- min build: 1207
+---@return number
+function RemoveBlip() end
+
+-- RESET_MINIMAP_FOW  (0xEB3CB3386C775D72)
+-- min build: 1207
+---@param hash number
+function ResetMinimapFow(hash) end
+
+-- SET_BLIP_COORDS  (0x4FF674F5E23D49CE)
+-- min build: 1207
+---@param blip number
+---@param posX number
+---@param posY number
+---@param posZ number
+function SetBlipCoords(blip, posX, posY, posZ) end
+
+-- SET_BLIP_FLASH_TIMER  (0x02FF4CF43B7209D1)
+-- min build: 1207
+---@param blip number
+---@param blipType number
+---@param blipHash number
+function SetBlipFlashTimer(blip, blipType, blipHash) end
+
+-- SET_BLIP_FLASHES  (0x0DF2B55F717DDB10)
+-- min build: 1207
+---@param blip number
+---@return boolean
+---@return number
+---@return number
+function SetBlipFlashes(blip) end
+
+-- SET_BLIP_NAME_FROM_TEXT_FILE  (0x0A062D6D7C0B2C2C)
+-- min build: 1207
+---@param blip number
+---@param textLabel string
+function SetBlipNameFromTextFile(blip, textLabel) end
+
+-- SET_BLIP_NAME_TO_PLAYER_NAME  (0x093DD5A31BC2B459)
+-- min build: 1207
+---@param blip number
+---@param player number
+function SetBlipNameToPlayerName(blip, player) end
+
+-- SET_BLIP_ROTATION  (0x6049966A94FBE706)
+-- min build: 1207
+---@param blip number
+---@param rotation number
+function SetBlipRotation(blip, rotation) end
+
+-- SET_BLIP_SCALE  (0xD38744167B2FA257)
+-- min build: 1207
+---@param blip number
+---@param scale number
+function SetBlipScale(blip, scale) end
+
+-- SET_BLIP_SPRITE  (0x74F74D3207ED525C)
+-- min build: 1207
+---@param blip number
+---@param hash number
+---@param p2 boolean
+function SetBlipSprite(blip, hash, p2) end
+
+-- SET_GPS_CUSTOM_ROUTE_RENDER  (0xF6CEF599FC470B33)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 number
+---@param p2 number
+function SetGpsCustomRouteRender(p0, p1, p2) end
+
+-- SET_GPS_FLAGS  (0x5DE61C90DDECFA2D)
+-- https://alloc8or.re/rdr3/doc/enums/rage__eGpsFlags.txt
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function SetGpsFlags(p0, p1) end
+
+-- SET_GPS_MULTI_ROUTE_RENDER  (0x4426D65E029A4DC0)
+-- min build: 1207
+---@param toggle boolean
+function SetGpsMultiRouteRender(toggle) end
+
+-- SET_MINIMAP_FOW_REVEAL_COORDINATE  (0x73348402566ECB6E)
+-- Up to eight coordinates may be revealed per frame
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+function SetMinimapFowRevealCoordinate(x, y, z, p3) end
+
+-- SET_MINIMAP_FOW_REVEAL_VOLUME  (0x63CBBD6CA6F321F9)
+-- min build: 1207
+---@param volume number
+---@param p1 number
+function SetMinimapFowRevealVolume(volume, p1) end
+
+-- SET_MINIMAP_HIDE_FOW  (0x4B8F743A4A6D2FF8)
+-- Reveals the entire minimap (FOW = Fog of War)
+-- min build: 1207
+---@param toggle boolean
+function SetMinimapHideFow(toggle) end
+
+-- SET_RADAR_AS_EXTERIOR_THIS_FRAME  (0xA8EBBAE986FB5457)
+-- min build: 1207
+function SetRadarAsExteriorThisFrame() end
+
+-- SET_RADAR_ZOOM  (0xCAF6489DA2C8DD9E)
+-- min build: 1207
+---@param zoomLevel number
+function SetRadarZoom(zoomLevel) end
+
+-- SET_WAYPOINT_OFF  (0xFA8C41E8020D3439)
+-- min build: 1207
+function SetWaypointOff() end
+
+-- START_GPS_MULTI_ROUTE  (0x3D3D15AF7BCAAF83)
+-- min build: 1207
+---@param colorNameHash number
+---@param onFoot boolean
+---@param inVehicle boolean
+function StartGpsMultiRoute(colorNameHash, onFoot, inVehicle) end
+
+-- TRIGGER_SONAR_BLIP  (0x72DD432F3CDFC0EE)
+-- min build: 1207
+---@param typeHash number
+---@param x number
+---@param y number
+---@param z number
+function TriggerSonarBlip(typeHash, x, y, z) end
+
+-- UNLOCK_MINIMAP_ANGLE  (0x5373DE8E179BC2A0)
+-- min build: 1207
+function UnlockMinimapAngle() end

--- a/.luals/redm-natives/MINIGAME.lua
+++ b/.luals/redm-natives/MINIGAME.lua
@@ -1,0 +1,304 @@
+---@meta
+
+-- RDR3 namespace: MINIGAME -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x012027C28F421F46  (0x012027C28F421F46)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x012027C28F421F46(p0, p1) end
+
+-- _0x0876326238914A3F  (0x0876326238914A3F)
+-- min build: 1207
+function N_0x0876326238914A3F() end
+
+-- _0x10342CC82E8356E9  (0x10342CC82E8356E9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x10342CC82E8356E9(p0, p1) end
+
+-- _0x15E90B6A993017AA  (0x15E90B6A993017AA)
+-- min build: 1207
+---@return any
+function N_0x15E90B6A993017AA() end
+
+-- _0x18A0D48DF9211C07  (0x18A0D48DF9211C07)
+-- min build: 1207
+function N_0x18A0D48DF9211C07() end
+
+-- _0x32A7C216344D623B  (0x32A7C216344D623B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x32A7C216344D623B(p0, p1, p2) end
+
+-- _0x39654E1F68B78287  (0x39654E1F68B78287)
+-- min build: 1207
+---@return any
+function N_0x39654E1F68B78287() end
+
+-- _0x398066F893149856  (0x398066F893149856)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x398066F893149856(p0, p1, p2) end
+
+-- _0x3AE451860F03CA8A  (0x3AE451860F03CA8A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x3AE451860F03CA8A(p0, p1) end
+
+-- _0x3B31732FADE5BAF3  (0x3B31732FADE5BAF3)
+-- min build: 1207
+---@return any
+function N_0x3B31732FADE5BAF3() end
+
+-- _0x3DF7EE3A76185108  (0x3DF7EE3A76185108)
+-- min build: 1207
+function N_0x3DF7EE3A76185108() end
+
+-- _0x3EECAADAB0D9FE29  (0x3EECAADAB0D9FE29)
+-- min build: 1207
+---@return any
+function N_0x3EECAADAB0D9FE29() end
+
+-- _0x3F4FD4BED07AB8C4  (0x3F4FD4BED07AB8C4)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x3F4FD4BED07AB8C4(p0) end
+
+-- _0x3FFE60DD8A936551  (0x3FFE60DD8A936551)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x3FFE60DD8A936551(p0, p1) end
+
+-- _0x455ECCA0715C507F  (0x455ECCA0715C507F)
+-- min build: 1207
+function N_0x455ECCA0715C507F() end
+
+-- _0x578907F59BA01B6D  (0x578907F59BA01B6D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x578907F59BA01B6D(p0) end
+
+-- _0x580F34C726387226  (0x580F34C726387226)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x580F34C726387226(p0, p1) end
+
+-- _0x58521E6DCDE97D74  (0x58521E6DCDE97D74)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x58521E6DCDE97D74(p0, p1, p2) end
+
+-- _0x644439B5387EE57E  (0x644439B5387EE57E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x644439B5387EE57E(p0, p1) end
+
+-- _0x6480723D3BE535B6  (0x6480723D3BE535B6)
+-- min build: 1207
+---@param p0 any
+function N_0x6480723D3BE535B6(p0) end
+
+-- _0x910B088E51A511AC  (0x910B088E51A511AC)
+-- min build: 1207
+---@return any
+function N_0x910B088E51A511AC() end
+
+-- _0x9DD95B405AB4983E  (0x9DD95B405AB4983E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x9DD95B405AB4983E(p0, p1) end
+
+-- _0xA2DB3C6270C122E3  (0xA2DB3C6270C122E3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xA2DB3C6270C122E3(p0, p1) end
+
+-- _0xBEA7D3CB47E1479C  (0xBEA7D3CB47E1479C)
+-- min build: 1207
+---@return any
+function N_0xBEA7D3CB47E1479C() end
+
+-- _0xD39D32EB3B52DD83  (0xD39D32EB3B52DD83)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xD39D32EB3B52DD83(p0) end
+
+-- _0xDF728C5AE137FC14  (0xDF728C5AE137FC14)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xDF728C5AE137FC14(p0, p1, p2) end
+
+-- _0xE1F365C4C8F259D8  (0xE1F365C4C8F259D8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xE1F365C4C8F259D8(p0, p1, p2) end
+
+-- _0xE53A308AC35877A8  (0xE53A308AC35877A8)
+-- min build: 1207
+---@return any
+function N_0xE53A308AC35877A8() end
+
+-- _0xEC819D612038EF4B  (0xEC819D612038EF4B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@return any
+function N_0xEC819D612038EF4B(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0xF6DE98516FD3AC9B  (0xF6DE98516FD3AC9B)
+-- min build: 1207
+function N_0xF6DE98516FD3AC9B() end
+
+-- _DOMINOES_BUY_IN  (0x399E6CD12FC8CA89)
+-- Hardcoded to return zero/false.
+-- min build: 1207
+---@param p0 any
+---@return any
+function _DominoesBuyIn(p0) end
+
+-- _DOMINOES_PLACE_DOMINO  (0xB79A29B33BF29BA5)
+-- Hardcoded to return zero/false.
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _DominoesPlaceDomino(p0, p1) end
+
+-- _DOMINOES_REQUEST_VALID_PLACEMENTS  (0xE26AEE7E67D9E21D)
+-- Hardcoded to return zero/false.
+-- min build: 1207
+---@param p0 any
+---@return any
+function _DominoesRequestValidPlacements(p0) end
+
+-- _MINIGAME_GET_NEXT_EVENT  (0xDF728C5AE137FC13)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _MinigameGetNextEvent(p0, p1) end
+
+-- _MINIGAME_GET_NEXT_EVENT_TYPE  (0x578907F59BA01B6C)
+-- min build: 1207
+---@return any
+function _MinigameGetNextEventType() end
+
+-- _MINIGAME_IS_CONNECTED_TO_SERVER  (0x2A0C4736AC5AF0CE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _MinigameIsConnectedToServer(p0) end
+
+-- _MINIGAME_IS_REQUEST_PENDING  (0x9105A4A2556FA937)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _MinigameIsRequestPending(p0) end
+
+-- _MINIGAME_IS_SEAT_OCCUPIED  (0x8593A8CB0ED2C3B4)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function _MinigameIsSeatOccupied(p0) end
+
+-- _MINIGAME_LEAVE_TABLE  (0xF5446E47941E654C)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _MinigameLeaveTable(p0) end
+
+-- _MINIGAME_POP_NEXT_EVENT  (0x833E03BAEBADC4B0)
+-- min build: 1207
+function _MinigamePopNextEvent() end
+
+-- _MINIGAME_REQUEST_SEAT_AT_TABLE  (0xF6AC6085D8D6C004)
+-- min build: 1207
+---@return boolean
+---@return any
+function _MinigameRequestSeatAtTable() end
+
+-- _POKER_BUY_IN  (0xB4D610EA5A1FDE74)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _PokerBuyIn(p0, p1) end
+
+-- _POKER_CALL  (0x8DED681B161EBD78)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _PokerCall(p0, p1) end
+
+-- _POKER_CHECK  (0x49A045628D9B1B86)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _PokerCheck(p0, p1) end
+
+-- _POKER_FOLD  (0x3DFAB7D9BB45B5BE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _PokerFold(p0) end
+
+-- _POKER_GET_GAME_SETTINGS_FOR_ID  (0x2D20E12E1990D584)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _PokerGetGameSettingsForId(p0) end
+
+-- _POKER_RAISE  (0xECCF45A79A17BB96)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _PokerRaise(p0, p1) end
+
+-- _POKER_REVEAL  (0x2F2131DB0A8B02DC)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _PokerReveal(p0) end

--- a/.luals/redm-natives/MISC.lua
+++ b/.luals/redm-natives/MISC.lua
@@ -1,0 +1,2115 @@
+---@meta
+
+-- RDR3 namespace: MISC -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0358B8A41916C613  (0x0358B8A41916C613)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0x0358B8A41916C613(p0, p1, p2, p3) end
+
+-- _0x0730E518486DEEC3  (0x0730E518486DEEC3)
+-- min build: 1207
+---@param p0 any
+function N_0x0730E518486DEEC3(p0) end
+
+-- _0x0A487CC74A517FB5  (0x0A487CC74A517FB5)
+-- min build: 1207
+---@param p0 any
+function N_0x0A487CC74A517FB5(p0) end
+
+-- _0x0D0AE5081F88CFE1  (0x0D0AE5081F88CFE1)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0x0D0AE5081F88CFE1(p0) end
+
+-- _0x1096603B519C905F  (0x1096603B519C905F)
+-- _SET_MISSION_NAME_*(FOR_ACTIVITY?/MINIGAME?)
+-- min build: 1207
+---@param name string
+function N_0x1096603B519C905F(name) end
+
+-- _0x154340E87D8CC178  (0x154340E87D8CC178)
+-- min build: 1207
+---@param p0 any
+function N_0x154340E87D8CC178(p0) end
+
+-- _0x183672FE838A661B  (0x183672FE838A661B)
+-- min build: 1207
+---@return any
+function N_0x183672FE838A661B() end
+
+-- _0x243CEDE8F916B994  (0x243CEDE8F916B994)
+-- min build: 1207
+function N_0x243CEDE8F916B994() end
+
+-- _0x2916B30DC6C41179  (0x2916B30DC6C41179)
+-- min build: 1207
+---@param weatherType number
+function N_0x2916B30DC6C41179(weatherType) end
+
+-- _0x33982467B1E349EF  (0x33982467B1E349EF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0x33982467B1E349EF(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x35165C658077CD0B  (0x35165C658077CD0B)
+-- min build: 1207
+---@return any
+function N_0x35165C658077CD0B() end
+
+-- _0x38C0C9CAE1544500  (0x38C0C9CAE1544500)
+-- min build: 1207
+---@param p0 number
+function N_0x38C0C9CAE1544500(p0) end
+
+-- _0x38C2BF94D15F464D  (0x38C2BF94D15F464D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x38C2BF94D15F464D(p0) end
+
+-- _0x3A87FDA8F1B6CDFB  (0x3A87FDA8F1B6CDFB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x3A87FDA8F1B6CDFB(p0, p1, p2) end
+
+-- _0x3C3C7B1B5EC08764  (0x3C3C7B1B5EC08764)
+-- min build: 1207
+function N_0x3C3C7B1B5EC08764() end
+
+-- _0x4647842FE8F31C1E  (0x4647842FE8F31C1E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x4647842FE8F31C1E(p0, p1) end
+
+-- _0x49C44FE78A135A1D  (0x49C44FE78A135A1D)
+-- min build: 1207
+---@param p0 any
+function N_0x49C44FE78A135A1D(p0) end
+
+-- _0x49F3241C28EBBFBC  (0x49F3241C28EBBFBC)
+-- min build: 1207
+---@param p0 number
+function N_0x49F3241C28EBBFBC(p0) end
+
+-- _0x4B0501A468B749F8  (0x4B0501A468B749F8)
+-- min build: 1207
+function N_0x4B0501A468B749F8() end
+
+-- _0x4B101DBCC9482F2D  (0x4B101DBCC9482F2D)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x4B101DBCC9482F2D(ped) end
+
+-- _0x4D5C9CC7E7E23E09  (0x4D5C9CC7E7E23E09)
+-- min build: 1207
+function N_0x4D5C9CC7E7E23E09() end
+
+-- _0x553D67295DDD2309  (0x553D67295DDD2309)
+-- UPDATE_PICKUP_COLLECTIBLE: set Eagle Eye fountain
+-- _J*, _K*, _L*
+-- min build: 1207
+---@param entity number
+function N_0x553D67295DDD2309(entity) end
+
+-- _0x5801BE2DF2AF07EC  (0x5801BE2DF2AF07EC)
+-- min build: 1207
+---@param p0 any
+function N_0x5801BE2DF2AF07EC(p0) end
+
+-- _0x5B4A8121A47D844D  (0x5B4A8121A47D844D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x5B4A8121A47D844D(p0) end
+
+-- _0x627B68D9CE6EE8DE  (0x627B68D9CE6EE8DE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x627B68D9CE6EE8DE(p0) end
+
+-- _0x68319452C5064ABA  (0x68319452C5064ABA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x68319452C5064ABA(p0, p1) end
+
+-- _0x6BCF7B5CD338281A  (0x6BCF7B5CD338281A)
+-- _SET_DISPATCH_*, unused
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x6BCF7B5CD338281A(p0, p1, p2) end
+
+-- _0x6BED40493A1AFDB8  (0x6BED40493A1AFDB8)
+-- min build: 1207
+---@param p1 number
+---@return any
+function N_0x6BED40493A1AFDB8(p1) end
+
+-- _0x6C7B68D3CE60E8DE  (0x6C7B68D3CE60E8DE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x6C7B68D3CE60E8DE(p0) end
+
+-- _0x6F02B5E50511721E  (0x6F02B5E50511721E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x6F02B5E50511721E(p0) end
+
+-- _0x745808BB01CEC6B9  (0x745808BB01CEC6B9)
+-- min build: 1207
+---@param p0 number
+function N_0x745808BB01CEC6B9(p0) end
+
+-- _0x74ACA66484CEBAF0  (0x74ACA66484CEBAF0)
+-- min build: 1207
+---@param p0 any
+function N_0x74ACA66484CEBAF0(p0) end
+
+-- _0x7CF96F1250EF3221  (0x7CF96F1250EF3221)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x7CF96F1250EF3221(p0) end
+
+-- _0x7FA58CED69405F9A  (0x7FA58CED69405F9A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x7FA58CED69405F9A(p0, p1) end
+
+-- _0x8314FC2013ECE2DA  (0x8314FC2013ECE2DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x8314FC2013ECE2DA(p0, p1, p2) end
+
+-- _0x8BB99B85444544D9  (0x8BB99B85444544D9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x8BB99B85444544D9(p0, p1) end
+
+-- _0x8C0F6A3D7236DEEB  (0x8C0F6A3D7236DEEB)
+-- min build: 1207
+---@param entity number
+---@param string string
+function N_0x8C0F6A3D7236DEEB(entity, string) end
+
+-- _0x8DB104CCEBCD58C5  (0x8DB104CCEBCD58C5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x8DB104CCEBCD58C5(p0, p1) end
+
+-- _0x94FCADCF9F0C368E  (0x94FCADCF9F0C368E)
+-- min build: 1207
+---@param p0 any
+function N_0x94FCADCF9F0C368E(p0) end
+
+-- _0x96282005C5C6801F  (0x96282005C5C6801F)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+function N_0x96282005C5C6801F(p0, p1) end
+
+-- _0x9A252AA23D7098F2  (0x9A252AA23D7098F2)
+-- min build: 1207
+function N_0x9A252AA23D7098F2() end
+
+-- _0x9BF2C0C568C61641  (0x9BF2C0C568C61641)
+-- min build: 1207
+---@param p0 any
+function N_0x9BF2C0C568C61641(p0) end
+
+-- _0xA08111B053D84B4D  (0xA08111B053D84B4D)
+-- _CLEAR*
+-- min build: 1207
+---@param p0 any
+function N_0xA08111B053D84B4D(p0) end
+
+-- _0xA3A8926951471C82  (0xA3A8926951471C82)
+-- min build: 1207
+function N_0xA3A8926951471C82() end
+
+-- _0xA9342743B634A462  (0xA9342743B634A462)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+function N_0xA9342743B634A462(p0) end
+
+-- _0xAB26DEEE120FD3FD  (0xAB26DEEE120FD3FD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xAB26DEEE120FD3FD(p0, p1) end
+
+-- _0xAD44856A1CD29635  (0xAD44856A1CD29635)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xAD44856A1CD29635(p0, p1, p2) end
+
+-- _0xAF3A84C7DE6A1DC5  (0xAF3A84C7DE6A1DC5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xAF3A84C7DE6A1DC5(p0, p1) end
+
+-- _0xAF530E56505D1BD6  (0xAF530E56505D1BD6)
+-- Hardcoded to return one/true.
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xAF530E56505D1BD6(p0) end
+
+-- _0xB08C4FA25BC29DB9  (0xB08C4FA25BC29DB9)
+-- min build: 1207
+---@param p0 any
+function N_0xB08C4FA25BC29DB9(p0) end
+
+-- _0xB1F6665AA54DCD5C  (0xB1F6665AA54DCD5C)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xB1F6665AA54DCD5C(p0) end
+
+-- _0xB711EB4BC8D06013  (0xB711EB4BC8D06013)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0xB711EB4BC8D06013() end
+
+-- _0xBB282CF5D2333FB8  (0xBB282CF5D2333FB8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBB282CF5D2333FB8(p0, p1) end
+
+-- _0xCC1BAF72D571DB8D  (0xCC1BAF72D571DB8D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xCC1BAF72D571DB8D(p0, p1, p2) end
+
+-- _0xCC3EDC5614B03F61  (0xCC3EDC5614B03F61)
+-- min build: 1207
+---@param p0 number
+function N_0xCC3EDC5614B03F61(p0) end
+
+-- _0xD3F943B88F55376A  (0xD3F943B88F55376A)
+-- min build: 1207
+---@param weatherType number
+function N_0xD3F943B88F55376A(weatherType) end
+
+-- _0xDA4D8EB04E8E2928  (0xDA4D8EB04E8E2928)
+-- min build: 1207
+---@param p0 any
+function N_0xDA4D8EB04E8E2928(p0) end
+
+-- _0xDBDA48EC456ED908  (0xDBDA48EC456ED908)
+-- min build: 1436
+function N_0xDBDA48EC456ED908() end
+
+-- _0xDC057B86FC157031  (0xDC057B86FC157031)
+-- Hardcoded to return one/true.
+-- min build: 1207
+---@return any
+function N_0xDC057B86FC157031() end
+
+-- _0xDE2C3B74D2B3705C  (0xDE2C3B74D2B3705C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDE2C3B74D2B3705C(p0, p1) end
+
+-- _0xEB946B9E579729AD  (0xEB946B9E579729AD)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function N_0xEB946B9E579729AD(ped, p1) end
+
+-- _0xF569E33FB72ED28E  (0xF569E33FB72ED28E)
+-- min build: 1207
+function N_0xF569E33FB72ED28E() end
+
+-- _0xF63FA29D4A9ACA86  (0xF63FA29D4A9ACA86)
+-- min build: 1207
+---@param entity number
+---@param string string
+function N_0xF63FA29D4A9ACA86(entity, string) end
+
+-- _0xF650DCF5D6F312C1  (0xF650DCF5D6F312C1)
+-- min build: 1232
+---@param p0 any
+function N_0xF650DCF5D6F312C1(p0) end
+
+-- _0xF81C53561D15F330  (0xF81C53561D15F330)
+-- min build: 1207
+---@return string
+function N_0xF81C53561D15F330() end
+
+-- _0xFC6ECB9170145ECE  (0xFC6ECB9170145ECE)
+-- min build: 1207
+function N_0xFC6ECB9170145ECE() end
+
+-- _0xFF252E2BAFB7330F  (0xFF252E2BAFB7330F)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+function N_0xFF252E2BAFB7330F(p0) end
+
+-- _ADD_DISPATCH_SPAWN_BLOCKING_AREA  (0xA2D5A26208421426)
+-- min build: 1207
+---@param volume number
+---@return any
+function _AddDispatchSpawnBlockingArea(volume) end
+
+-- _ADD_POP_MULTIPLIER_VOLUME  (0x3233C4EC0514C7EC)
+-- Only used in script function PROCESS_ZONE_CREATION
+-- Returns Pop multiplier volume ID
+-- min build: 1207
+---@param volume number
+---@param pedDensity number
+---@param vehicleDensity number
+---@param p3 boolean
+---@param p4 boolean
+---@return number
+function _AddPopMultiplierVolume(volume, pedDensity, vehicleDensity, p3, p4) end
+
+-- _CLEAR_ALL_BIT_FLAGS  (0xD2D74F89DF844A50)
+-- min build: 1207
+---@return any
+function _ClearAllBitFlags() end
+
+-- _CLEAR_BIT_FLAG  (0xB909149F2BB5F6DA)
+-- min build: 1207
+---@param flag number
+---@return any
+function _ClearBitFlag(flag) end
+
+-- _CLEAR_VOLUME_AREA  (0x2FCD528A397E5C88)
+-- min build: 1207
+---@param volume number
+---@param flag number
+function _ClearVolumeArea(volume, flag) end
+
+-- _CLEAR_WEATHER_TYPE_PERSIST_OVERTIME  (0xCE7690C0A0D1C36D)
+-- min build: 1207
+---@param milliseconds number
+function _ClearWeatherTypePersistOvertime(milliseconds) end
+
+-- _CLEAR_WEATHER_VARIATION  (0x0E71C80FA4EC8147)
+-- min build: 1207
+---@param weatherType string
+---@param p1 boolean
+function _ClearWeatherVariation(weatherType, p1) end
+
+-- _COUNT_BIT_FLAGS  (0xE704838F36F93B7B)
+-- min build: 1355
+---@return number
+---@return any
+function _CountBitFlags() end
+
+-- _CREATE_AI_MEMORY  (0x88BC5F4AEF77FC4E)
+-- aiMemoryType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/_CREATE_AI_MEMORY
+-- min build: 1207
+---@param aiMemoryType number
+---@return any
+function _CreateAiMemory(aiMemoryType) end
+
+-- _CREATE_COLOR_STRING  (0xBCC2CFADEA1AEA6C)
+-- Returns a formatted string (0x%x)
+-- min build: 1207
+---@param rgb number
+---@return string
+function _CreateColorString(rgb) end
+
+-- _CREATE_INCIDENT_WITH_ENTITIES  (0xAB3D3F45436DB1D8)
+-- dispatchService: see ENABLE_DISPATCH_SERVICE
+-- 
+-- The entities must be added to itemSet.
+-- min build: 1207
+---@param dispatchService number
+---@param x number
+---@param y number
+---@param z number
+---@param itemSet number
+---@param radius number
+---@return boolean
+---@return number
+function _CreateIncidentWithEntities(dispatchService, x, y, z, itemSet, radius) end
+
+-- _DISABLE_LOOTING_COMPOSITE_PICKABLE_THIS_FRAME  (0x082C043C7AFC3747)
+-- Disables composite pick prompt.
+-- min build: 1207
+---@param compositeId number
+---@param p1 boolean
+function _DisableLootingCompositePickableThisFrame(compositeId, p1) end
+
+-- _DOES_ITEM_HAVE_VALID_BASE  (0xBDC6E364C9C78178)
+-- min build: 1207
+---@param item number
+---@return boolean
+function _DoesItemHaveValidBase(item) end
+
+-- _DOES_POP_MULTIPLIER_AREA_EXIST_FOR_VOLUME  (0x39D6DACE323A20B6)
+-- min build: 1207
+---@param volume number
+---@return boolean
+function _DoesPopMultiplierAreaExistForVolume(volume) end
+
+-- _DOES_STRING_EXIST_IN_STRING  (0x9382D5D43D2AA6FF)
+-- min build: 1207
+---@param string1 string
+---@param string2 string
+---@return boolean
+function _DoesStringExistInString(string1, string2) end
+
+-- _FORCE_LIGHTNING_FLASH_AT_COORDS  (0x67943537D179597C)
+-- p3 is always -1.0f in the scripts
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+function _ForceLightningFlashAtCoords(x, y, z, p3) end
+
+-- _GAME_FRAMEWORK_MANAGER_GET_MODE  (0xFAED234C7F53ABEB)
+-- min build: 1207
+---@return number
+function _GameFrameworkManagerGetMode() end
+
+-- _GAME_FRAMEWORK_MANAGER_SHUTDOWN  (0xAFF2FD8ADD927585)
+-- min build: 1207
+function _GameFrameworkManagerShutdown() end
+
+-- _GET_AI_PED_DOES_HAVE_EVENT_MEMORY  (0xFDF38E2B711BF78E)
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+function _GetAiPedDoesHaveEventMemory(p1) end
+
+-- _GET_EASING_CURVE_VALUE  (0xEF50E344A8F93784)
+-- https://easings.net/
+-- 
+-- enum class eEasingCurveType
+-- {
+-- 	TYPE_LINEAR,
+-- 	TYPE_QUADRATIC_IN,
+-- 	TYPE_QUADRATIC_OUT,
+-- 	TYPE_QUADRATIC_INOUT,
+-- 	TYPE_CUBIC_IN,
+-- 	TYPE_CUBIC_OUT,
+-- 	TYPE_CUBIC_INOUT,
+-- 	TYPE_QUARTIC_IN,
+-- 	TYPE_QUARTIC_OUT,
+-- 	TYPE_QUARTIC_INOUT,
+-- 	TYPE_QUINTIC_IN,
+-- 	TYPE_QUINTIC_OUT,
+-- 	TYPE_QUINTIC_INOUT,
+-- 	TYPE_EXPONENTIAL_IN,
+-- 	TYPE_EXPONENTIAL_OUT,
+-- 	TYPE_EXPONENTIAL_INOUT,
+-- 	TYPE_SINE_IN,
+-- 	TYPE_SINE_OUT,
+-- 	TYPE_SINE_INOUT,
+-- 	TYPE_CIRCULAR_IN,
+-- 	TYPE_CIRCULAR_OUT,
+-- 	TYPE_CIRCULAR_INOUT,
+-- 	TYPE_BOUNCE_IN,
+-- 	TYPE_BOUNCE_OUT,
+-- 	TYPE_BOUNCE_INOUT,
+-- 	TYPE_CUSTOM
+-- };
+-- min build: 1207
+---@param t number
+---@param b number
+---@param d number
+---@param easingCurveType number
+---@return number
+function _GetEasingCurveValue(t, b, d, easingCurveType) end
+
+-- _GET_ENTITY_FROM_ITEM  (0xEE04C0AFD4EFAF0E)
+-- min build: 1207
+---@param item number
+---@return number
+function _GetEntityFromItem(item) end
+
+-- _GET_FORCED_WEATHER  (0xDD560ABEF5D3784C)
+-- Returns the weather type that has been set by a script
+-- min build: 1207
+---@return number
+---@return number
+function _GetForcedWeather() end
+
+-- _GET_GAME_TIMER_NON_SCALED_CLIPPED  (0x483B8C542103AD72)
+-- Returns rage::fwTimer::sm_nonScaledClippedTime
+-- min build: 1207
+---@return number
+function _GetGameTimerNonScaledClipped() end
+
+-- _GET_GROUND_Z_AND_MATERIAL_FOR_3D_COORD  (0xBBE5B63EFFB08E68)
+-- Raycasts downward from coords to find terrain/water.
+-- 
+-- - flags: collision mask (R* scripts commonly use 17, 129, or 3423).
+-- - outGroundZ: receives the hit Z.
+-- - outMaterialHash: receives the surface/material hash.
+-- - outFlags: receives hit flags (bitfield; water/special cases may set bits).
+-- 
+-- Returns true on hit, false otherwise.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param flags number
+---@return boolean
+---@return number
+---@return number
+---@return number
+function _GetGroundZAndMaterialFor3dCoord(x, y, z, flags) end
+
+-- _GET_ITEM_TYPE  (0xDC8D2FF478DF9553)
+-- 0 = invalid
+-- 1 = CEntity
+-- 2 = rage::volBase
+-- 3 = rage::volSphere
+-- 4 = rage::volBox
+-- 5 = rage::volAggregate
+-- 6 = rage::volCylinder
+-- 7 = CScriptedCoverPoint
+-- 8 = rage::ptfxScriptInfo
+-- 9 = CPed
+-- 10 = CVehicle
+-- 11 = CObject
+-- 12 = CItemSet
+-- 13 = CPersistentCharacter
+-- min build: 1207
+---@param handle number
+---@return number
+function _GetItemType(handle) end
+
+-- _GET_LOOTING_EVENT_HAS_FIRED  (0xF9B91C5129EABC08)
+-- Event names in the scripts: MGBegin, MGEnd, ReadyForCut
+-- min build: 1207
+---@param ped number
+---@param eventName string
+---@return boolean
+function _GetLootingEventHasFired(ped, eventName) end
+
+-- _GET_MAX_NUM_INSTRUCTIONS  (0xC43CD2668B204419)
+-- min build: 1207
+---@return number
+function _GetMaxNumInstructions() end
+
+-- _GET_NEXT_WEATHER_TYPE_HASH_NAME  (0x51021D36F62AAA83)
+-- min build: 1207
+---@return number
+function _GetNextWeatherTypeHashName() end
+
+-- _GET_NUMBER_OF_BULLETS_IMPACTED_ENTITY  (0x970339EFA4FDE518)
+-- Returns the number of bullets that just impacted the entity.
+-- Research notes this does not appear to work for arrows or throwable projectiles.
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param p2 boolean
+---@return number
+function _GetNumberOfBulletsImpactedEntity(entity, p1, p2) end
+
+-- _GET_NUMBER_OF_BULLETS_IN_AREA  (0xDC416CA762BC4F43)
+-- Returns the number of bullets in an area.
+-- Research notes this does not appear to work for arrows or throwable projectiles.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 boolean
+---@param p5 boolean
+---@return number
+function _GetNumberOfBulletsInArea(x, y, z, radius, p4, p5) end
+
+-- _GET_NUMBER_OF_INSTRUCTIONS  (0x72904D3D62AF5839)
+-- min build: 1207
+---@return number
+function _GetNumberOfInstructions() end
+
+-- _GET_OBJECT_FROM_INDEXED_ITEM  (0x18013392501CE5DC)
+-- min build: 1207
+---@param item number
+---@return number
+function _GetObjectFromIndexedItem(item) end
+
+-- _GET_PED_FROM_INDEXED_ITEM  (0x3FFB15534067DCD4)
+-- min build: 1207
+---@param item number
+---@return number
+function _GetPedFromIndexedItem(item) end
+
+-- _GET_PREV_WEATHER_TYPE_HASH_NAME  (0x4BEB42AEBCA732E9)
+-- min build: 1207
+---@return number
+function _GetPrevWeatherTypeHashName() end
+
+-- _GET_RANDOM_WEATHER_TYPE  (0x1359C181BC625503)
+-- min build: 1207
+---@return number
+function _GetRandomWeatherType() end
+
+-- _GET_RANDOM_WEATHER_TYPE_INDEX  (0x7F4CE164D9A11DFE)
+-- min build: 1207
+---@return number
+function _GetRandomWeatherTypeIndex() end
+
+-- _GET_STATUS_OF_SAVEGAME_OPERATION  (0x1B065A2BF7953815)
+-- Only 0 and 1 are valid for p0, higher values causes the native to return 2.
+-- min build: 1207
+---@param p0 number
+---@return number
+function _GetStatusOfSavegameOperation(p0) end
+
+-- _GET_STRING_FROM_BOOL  (0xF216F74101968DB0)
+-- min build: 1207
+---@param value boolean
+---@return string
+function _GetStringFromBool(value) end
+
+-- _GET_STRING_FROM_FLOAT  (0x2B6846401D68E563)
+-- min build: 1207
+---@param value number
+---@param digits number
+---@return string
+function _GetStringFromFloat(value, digits) end
+
+-- _GET_STRING_FROM_VECTOR  (0x6C4DBF553885F9EB)
+-- Returns a string in the following format: <<%.4f,%.4f,%.4f>>
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return string
+function _GetStringFromVector(x, y, z) end
+
+-- _GET_TEMPERATURE_AT_COORDS  (0xB98B78C3768AF6E0)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function _GetTemperatureAtCoords(x, y, z) end
+
+-- _GET_VEHICLE_FROM_INDEXED_ITEM  (0xE578C8AE173719B3)
+-- min build: 1207
+---@param item number
+---@return number
+function _GetVehicleFromIndexedItem(item) end
+
+-- _GET_VOLUME_FROM_INDEXED_ITEM  (0xF18AF483DF70BBDE)
+-- min build: 1207
+---@param item number
+---@return number
+function _GetVolumeFromIndexedItem(item) end
+
+-- _HAS_BULLET_IMPACTED_ENTITY  (0x7A76104CC2CC69E8)
+-- Returns true if the entity has just been impacted by a bullet.
+-- Research notes this bullet-impact group does not appear to work with arrows or throwable projectiles.
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param p2 boolean
+---@return boolean
+function _HasBulletImpactedEntity(entity, p1, p2) end
+
+-- _INT_TO_STRING  (0xCF11C0CEB40C401B)
+-- Note: the buffer should be exactly 32 bytes long
+-- min build: 1207
+---@param value number
+---@param format string
+---@param buffer string
+function _IntToString(value, format, buffer) end
+
+-- _IS_ANY_BIT_FLAG_SET  (0x80E9C316EF84DD81)
+-- min build: 1207
+---@return boolean
+---@return any
+function _IsAnyBitFlagSet() end
+
+-- _IS_BASE_A_COVER_POINT  (0xFEC1D4B5C82C176F)
+-- min build: 1207
+---@param handle number
+---@return boolean
+function _IsBaseACoverPoint(handle) end
+
+-- _IS_BASE_A_PERSISTENT_CHARACTER  (0x716F17F8A0419F95)
+-- min build: 1207
+---@param handle number
+---@return boolean
+function _IsBaseAPersistentCharacter(handle) end
+
+-- _IS_BIT_FLAG_SET  (0x8F4F050054005C27)
+-- min build: 1207
+---@param flag number
+---@return boolean
+---@return any
+function _IsBitFlagSet(flag) end
+
+-- _IS_GLOBAL_BLOCK_VALID  (0xACB7E1418A8B6E32)
+-- min build: 1207
+---@param index number
+---@return boolean
+function _IsGlobalBlockValid(index) end
+
+-- _IS_MISSION_CREATOR_ACTIVE  (0xF236C84C6ADFCB2F)
+-- min build: 1207
+---@return boolean
+function _IsMissionCreatorActive() end
+
+-- _IS_PED_DECOMPOSED  (0x5170DDA6D63ACAAA)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedDecomposed(ped) end
+
+-- _IS_PLAYER_OWNING_STANDALONE_SP  (0x36040772DF5E59A0)
+-- min build: 1355
+---@return boolean
+function _IsPlayerOwningStandaloneSp() end
+
+-- _LOOT_TABLES_GET_INFO  (0x48E4D50F87A96AA5)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@param lootTableKey number
+---@param p5 any
+---@return any
+function _LootTablesGetInfo(ped, p1, p2, lootTableKey, p5) end
+
+-- _QUEUE_SAVEGAME_OPERATION  (0x279B0696DA4657EB)
+-- p0 must be < 2
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function _QueueSavegameOperation(p0) end
+
+-- _READ_INT_AS_FLOAT  (0xD2C9126410DFA1B2)
+-- Reads the passed value as floating point value and returns it.
+-- Example: _READ_INT_AS_FLOAT(0x3F800000) returns 1.0f because 0x3F800000 is the hexadecimal representation of 1.0f.
+-- min build: 1207
+---@param value number
+---@return number
+function _ReadIntAsFloat(value) end
+
+-- _REMOVE_POP_MULTIPLIER_AREA_FOR_VOLUME  (0xBD090F5B1DB82189)
+-- min build: 1207
+---@param volume number
+---@param p1 number
+function _RemovePopMultiplierAreaForVolume(volume, p1) end
+
+-- _RESET_DISPATCH_MAX_SPAWN_DISTANCE  (0x54EC7B6BC72BAD69)
+-- min build: 1207
+function _ResetDispatchMaxSpawnDistance() end
+
+-- _RESET_DISPATCH_MIN_SPAWN_DISTANCE  (0x96498D922D8D0D0A)
+-- min build: 1207
+function _ResetDispatchMinSpawnDistance() end
+
+-- _SET_AI_MEMORY_REACTIONS_ENABLED  (0x6AC4AF46A6B8DFB2)
+-- Used in CAIConditionAmbientAIMemoryReactionsEnabled
+-- min build: 1207
+---@param enabled boolean
+function _SetAiMemoryReactionsEnabled(enabled) end
+
+-- _SET_BIT_FLAG  (0xE84AAC1B22A73E99)
+-- Similar to SET_BIT but specifically designed for large (>32 flags) bit flag sets.
+-- The flags are stored in an int array where each int has the ability to hold 32 flags.
+-- Flags 0-31 would be stored in the first int, flags 32-63 in the second int, etc.
+-- min build: 1207
+---@param flag number
+---@return any
+function _SetBitFlag(flag) end
+
+-- _SET_DISPATCH_MAX_SPAWN_DISTANCE  (0x89314FB3463E28DE)
+-- min build: 1207
+---@param maxSpawnDistance number
+function _SetDispatchMaxSpawnDistance(maxSpawnDistance) end
+
+-- _SET_DISPATCH_MIN_SPAWN_DISTANCE  (0x27A1B170AA8AF84C)
+-- min build: 1207
+---@param minSpawnDistance number
+function _SetDispatchMinSpawnDistance(minSpawnDistance) end
+
+-- _SET_GAME_LOGIC_PAUSED  (0x550F05CFFBD63C8C)
+-- Note: this native was added in build 1232.56
+-- min build: 1232
+function _SetGameLogicPaused() end
+
+-- _SET_GLOBAL_BLOCK_IS_LOADED  (0xE97240065406CB80)
+-- min build: 1207
+---@param index number
+---@param toggle boolean
+function _SetGlobalBlockIsLoaded(index, toggle) end
+
+-- _SET_INCIDENT_UNK  (0x9617B6E5F6537B63)
+-- min build: 1207
+---@param incidentId number
+function _SetIncidentUnk(incidentId) end
+
+-- _SET_LOOT_PELT_SATCHEL_ITEM  (0x9B47971234169990)
+-- min build: 1207
+---@param ped number
+---@param item any
+function _SetLootPeltSatchelItem(ped, item) end
+
+-- _SET_OVERRIDE_WEATHER  (0xBE83CAE8ED77A94F)
+-- min build: 1207
+---@param weatherType number
+function _SetOverrideWeather(weatherType) end
+
+-- _SET_SNOW_LEVEL  (0xF6BEE7E80EC5CA40)
+-- min build: 1207
+---@param level number
+function _SetSnowLevel(level) end
+
+-- _SET_WEATHER_TYPE_2  (0x2C6A07AF9AEDABD8)
+-- min build: 1207
+---@param weatherType number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+function _SetWeatherType2(weatherType, p1, p2, p3, p4) end
+
+-- _SET_WEATHER_TYPE_FROZEN  (0xD74ACDF7DB8114AF)
+-- min build: 1207
+---@param toggle boolean
+function _SetWeatherTypeFrozen(toggle) end
+
+-- _SET_WEATHER_VARIATION  (0x3373779BAF7CAF48)
+-- https://github.com/femga/rdr3_discoveries/blob/master/weather/weather_variations.lua
+-- min build: 1207
+---@param weatherType string
+---@param variation string
+function _SetWeatherVariation(weatherType, variation) end
+
+-- _SHOULD_USE_24_HOUR_CLOCK  (0x0177CF20345F44DD)
+-- min build: 1207
+---@return boolean
+function _ShouldUse24HourClock() end
+
+-- _SHOULD_USE_METRIC_MEASUREMENTS_2  (0x58BCDC75BA52110A)
+-- Same as SHOULD_USE_METRIC_MEASUREMENTS
+-- min build: 1207
+---@return boolean
+function _ShouldUseMetricMeasurements2() end
+
+-- _SHOULD_USE_METRIC_TEMPERATURE  (0xFF4AAF3275BAAB4F)
+-- min build: 1207
+---@return boolean
+function _ShouldUseMetricTemperature() end
+
+-- _SHOULD_USE_METRIC_WEIGHT  (0x8F24157FEDB85EA2)
+-- min build: 1207
+---@return boolean
+function _ShouldUseMetricWeight() end
+
+-- _STRING_SPLIT_AND_COUNT_SEGMENTS  (0x94E8CA3DEE952789)
+-- Counts the number of segments in a string separated by specified delimiters, ignoring consecutive delimiters.
+-- Example usage: int count = MISC::_STRING_SPLIT_AND_COUNT_SEGMENTS("qadr_ui-qadr_ui;qadr_ui,qadr_ui.qadr_ui;qadr_ui-", "-,;."); // Returns 6
+-- min build: 1207
+---@param inputString string
+---@param delimiters string
+---@return number
+function _StringSplitAndCountSegments(inputString, delimiters) end
+
+-- ABSF  (0x134549B388167CBF)
+-- min build: 1207
+---@param value number
+---@return number
+function Absf(value) end
+
+-- ABSI  (0x0C214D5B8A38C828)
+-- min build: 1207
+---@param value number
+---@return number
+function Absi(value) end
+
+-- ACOS  (0x586690F0176DC575)
+-- min build: 1207
+---@param p0 number
+---@return number
+function Acos(p0) end
+
+-- ACTION_MANAGER_ENABLE_ACTION  (0x7ACF124C12A2B045)
+-- Appears to remove stealth kill action from memory (?)
+-- min build: 1207
+---@param hash number
+---@param enable boolean
+function ActionManagerEnableAction(hash, enable) end
+
+-- ACTION_MANAGER_IS_ACTION_ENABLED  (0xFD0759658268FD8E)
+-- min build: 1207
+---@param hash number
+---@return boolean
+function ActionManagerIsActionEnabled(hash) end
+
+-- ACTIVITY_FEED_ACTION_START_WITH_COMMAND_LINE  (0x91D657230BC208D2)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+function ActivityFeedActionStartWithCommandLine(p0, p1) end
+
+-- ACTIVITY_FEED_ACTION_START_WITH_COMMAND_LINE_ADD  (0x1694A053DFB61A34)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 string
+function ActivityFeedActionStartWithCommandLineAdd(p0) end
+
+-- ACTIVITY_FEED_ADD_SUBSTRING_TO_CAPTION  (0x9935F76407C32539)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 string
+function ActivityFeedAddSubstringToCaption(p0) end
+
+-- ACTIVITY_FEED_CREATE  (0xCC7FC854B956A128)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+function ActivityFeedCreate(p0, p1) end
+
+-- ACTIVITY_FEED_POST  (0xB16FC7B364D86585)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function ActivityFeedPost() end
+
+-- ADD_POP_MULTIPLIER_AREA  (0x5EBDA1A3B8CB5EF7)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param pedDensity number
+---@param trafficDensity number
+---@param p8 boolean
+---@param p9 boolean
+---@return number
+function AddPopMultiplierArea(x1, y1, z1, x2, y2, z2, pedDensity, trafficDensity, p8, p9) end
+
+-- ADD_TACTICAL_NAV_MESH_POINT  (0xE4EE55E63FA9AF45)
+-- Params: p3 is 0 in R* Script utopia2
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+function AddTacticalNavMeshPoint(x, y, z, p3) end
+
+-- ARE_STRINGS_EQUAL  (0xD3852F22AB713A1F)
+-- min build: 1207
+---@param string1 string
+---@param string2 string
+---@return boolean
+function AreStringsEqual(string1, string2) end
+
+-- ASIN  (0x6E3C15D296C15583)
+-- min build: 1207
+---@param p0 number
+---@return number
+function Asin(p0) end
+
+-- ATAN  (0x503054DED0B78027)
+-- min build: 1207
+---@param p0 number
+---@return number
+function Atan(p0) end
+
+-- ATAN2  (0x965B220A066E3F07)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return number
+function Atan2(p0, p1) end
+
+-- BLOCK_DISPATCH_SERVICE_RESOURCE_CREATION  (0x66947E61A44DE2C6)
+-- dispatchService: see ENABLE_DISPATCH_SERVICE
+-- min build: 1207
+---@param dispatchService number
+---@param toggle boolean
+function BlockDispatchServiceResourceCreation(dispatchService, toggle) end
+
+-- CANCEL_ONSCREEN_KEYBOARD  (0x58A39BE597CE99CD)
+-- Old name: _CANCEL_ONSCREEN_KEYBOARD
+-- min build: 1207
+function CancelOnscreenKeyboard() end
+
+-- CLEAR_ANGLED_AREA_OF_VEHICLES  (0xA4D83115C1E02F8A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function ClearAngledAreaOfVehicles(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- CLEAR_AREA  (0x3B882A96EA77D5B1)
+-- Possible flag names:
+-- ALL_BASE = 0,
+-- PROJECTILES = 1,
+-- BROADCAST = 524288,
+-- AMBIENT_POPULATION = 1048576
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param flag number
+function ClearArea(x, y, z, radius, flag) end
+
+-- CLEAR_BIT  (0x7D1D4A3602B6AD4E)
+-- min build: 1207
+---@param offset number
+---@return number
+function ClearBit(offset) end
+
+-- CLEAR_OVERRIDE_WEATHER  (0x80A398F16FFE3CC3)
+-- min build: 1207
+function ClearOverrideWeather() end
+
+-- CLEAR_TACTICAL_NAV_MESH_POINTS  (0xD93B6516C6878267)
+-- min build: 1207
+function ClearTacticalNavMeshPoints() end
+
+-- CLEAR_WEATHER_TYPE_PERSIST  (0xD85DFE5C131E4AE9)
+-- min build: 1207
+function ClearWeatherTypePersist() end
+
+-- COMPARE_STRINGS  (0xBFBB74A15EFC149B)
+-- min build: 1207
+---@param str1 string
+---@param str2 string
+---@param matchCase boolean
+---@param maxLength number
+---@return number
+function CompareStrings(str1, str2, matchCase, maxLength) end
+
+-- COPY_SCRIPT_STRUCT  (0xF7AC7DC0DEE7C9BE)
+-- Old name: _COPY_MEMORY
+-- min build: 1207
+---@param size number
+---@return any
+---@return any
+function CopyScriptStruct(size) end
+
+-- CREATE_INCIDENT  (0x3F892CAF67444AE7)
+-- dispatchService: see ENABLE_DISPATCH_SERVICE
+-- min build: 1207
+---@param dispatchService number
+---@param x number
+---@param y number
+---@param z number
+---@param numUnits number
+---@param radius number
+---@param p7 any
+---@param p8 any
+---@return boolean
+---@return number
+function CreateIncident(dispatchService, x, y, z, numUnits, radius, p7, p8) end
+
+-- DELETE_INCIDENT  (0x5CFD0F0D6AAE0AEE)
+-- Delete an incident with a given id.
+-- min build: 1207
+---@param incidentId number
+function DeleteIncident(incidentId) end
+
+-- DISABLE_LOOTING_COMPOSITE_LOOTABLE_THIS_FRAME  (0x40D72189F46D2E15)
+-- Disables composite eat prompt.
+-- min build: 1207
+---@param compositeId number
+---@param p1 boolean
+function DisableLootingCompositeLootableThisFrame(compositeId, p1) end
+
+-- DISPLAY_ONSCREEN_KEYBOARD  (0x044131118D8DB3CD)
+-- enum eOnscreenKeyboardTextType
+-- {
+-- 	KTEXTTYPE_INVALID = -1,
+-- 	KTEXTTYPE_DEFAULT,
+-- 	KTEXTTYPE_EMAIL,
+-- 	KTEXTTYPE_PASSWORD,
+-- 	KTEXTTYPE_NUMERIC,
+-- 	KTEXTTYPE_ALPHABET,
+-- 	KTEXTTYPE_GAMERTAG,
+-- 	KTEXTTYPE_FILENAME,
+-- 	KTEXTTYPE_COUNT
+-- };
+-- min build: 1207
+---@param textType number
+---@param windowTitle string
+---@param p2 string
+---@param defaultText string
+---@param defaultConcat1 string
+---@param defaultConcat2 string
+---@param defaultConcat3 string
+---@param maxInputLength number
+function DisplayOnscreenKeyboard(textType, windowTitle, p2, defaultText, defaultConcat1, defaultConcat2, defaultConcat3, maxInputLength) end
+
+-- DOES_POP_MULTIPLIER_AREA_EXIST  (0x03BA619C81A646B3)
+-- min build: 1207
+---@param id number
+---@return boolean
+function DoesPopMultiplierAreaExist(id) end
+
+-- ENABLE_DISPATCH_SERVICE  (0x50E52637EF70EF77)
+-- enum DispatchType
+-- {
+-- 	DT_Invalid,
+-- 	DT_PoliceAutomobile,
+-- 	DT_PoliceHelicopter,
+-- 	DT_FireDepartment,
+-- 	DT_SwatAutomobile,
+-- 	DT_AmbulanceDepartment,
+-- 	DT_PoliceRiders,
+-- 	DT_PoliceVehicleRequest,
+-- 	DT_PoliceRoadBlock,
+-- 	DT_PoliceAutomobileWaitPulledOver,
+-- 	DT_PoliceAutomobileWaitCruising,
+-- 	DT_Gangs,
+-- 	DT_SwatHelicopter,
+-- 	DT_PoliceBoat,
+-- 	DT_ArmyVehicle,
+-- 	DT_OnFoot,
+-- 	DT_PoliceDogs
+-- };
+-- min build: 1207
+---@param dispatchService number
+---@param toggle boolean
+function EnableDispatchService(dispatchService, toggle) end
+
+-- FIRE_SINGLE_BULLET  (0xCBC9A21F6A2A679C)
+-- struct FireSingleBulletArgs
+-- {
+-- 	alignas(8) float  xStart;
+-- 	alignas(8) float  yStart;
+-- 	alignas(8) float  zStart;
+-- 	alignas(8) float  xEnd;
+-- 	alignas(8) float  yEnd;
+-- 	alignas(8) float  zEnd;
+-- 	alignas(8) Hash   weaponHash;
+-- 	alignas(8) float  damage;
+-- 	alignas(8) float  p8;          // often -1.0f in scripts; likely default/sentinel shot float
+-- 	alignas(8) Ped    instigator;  // confirmed ped GUID
+-- 	alignas(8) Entity entity2;     // optional entity ref; likely ignore/target-related
+-- 	alignas(8) Entity entity3;     // optional entity ref; likely ignore/target-related
+-- 	alignas(8) BOOL   p12;         // main shot behavior flag
+-- 	alignas(8) BOOL   p13;         // main shot behavior flag
+-- 	alignas(8) BOOL   p14;
+-- 	alignas(8) BOOL   p15;         // adds extra internal flag bit
+-- 	alignas(8) BOOL   p16;
+-- 	alignas(8) BOOL   p17;         // confirmed BOOL
+-- 	alignas(8) BOOL   p18;         // adds extra internal flag bit
+-- 	alignas(8) BOOL   p19;         // confirmed BOOL-like
+-- };
+-- 
+-- static_assert(sizeof(FireSingleBulletArgs) == 0xA0, "incorrect FireSingleBulletArgs size");
+-- min build: 1207
+---@return any
+function FireSingleBullet() end
+
+-- FORCE_LIGHTNING_FLASH  (0x369DB5B2510FA080)
+-- creates single lightning+thunder at random position
+-- min build: 1207
+function ForceLightningFlash() end
+
+-- GAME_FRAMEWORK_MANAGER_INIT  (0x4CABE596D632E4B0)
+-- min build: 1207
+---@param transitionMode number
+---@return boolean
+function GameFrameworkManagerInit(transitionMode) end
+
+-- GET_ANGLE_BETWEEN_2D_VECTORS  (0xD0DFE1C486097BBB)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param x2 number
+---@param y2 number
+---@return number
+function GetAngleBetween2dVectors(x1, y1, x2, y2) end
+
+-- GET_BENCHMARK_ITERATIONS  (0x22FC52CF470CC98D)
+-- Returns value of the '-benchmarkIterations' command line option.
+-- 
+-- Old name: _GET_BENCHMARK_ITERATIONS_FROM_COMMAND_LINE
+-- min build: 1207
+---@return number
+function GetBenchmarkIterations() end
+
+-- GET_BENCHMARK_PASS  (0x9297DACF3A2CDFF7)
+-- Returns value of the '-benchmarkPass' command line option.
+-- 
+-- Old name: _GET_BENCHMARK_PASS_FROM_COMMAND_LINE
+-- min build: 1207
+---@return number
+function GetBenchmarkPass() end
+
+-- GET_BITS_IN_RANGE  (0x68E1352AF48F905D)
+-- min build: 1207
+---@param var number
+---@param rangeStart number
+---@param rangeEnd number
+---@return number
+function GetBitsInRange(var, rangeStart, rangeEnd) end
+
+-- GET_CLOSEST_POINT_ON_LINE  (0x83ACC65D9ACEC5EF)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 boolean
+---@return vector3
+function GetClosestPointOnLine(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- GET_COORDS_OF_PROJECTILE_TYPE_WITHIN_DISTANCE  (0xD73C960A681052DF)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param distance number
+---@param p4 boolean
+---@param mustBeOwnedByThisPed boolean
+---@return boolean
+---@return vector3
+function GetCoordsOfProjectileTypeWithinDistance(ped, weaponHash, distance, p4, mustBeOwnedByThisPed) end
+
+-- GET_CURR_WEATHER_STATE  (0x0AC679B2342F14F2)
+-- Params: percentWeather2: 0f - 0.75f in R* Scripts
+-- 
+-- Old name: _GET_WEATHER_TYPE_TRANSITION
+-- min build: 1207
+---@return number
+---@return number
+---@return number
+function GetCurrWeatherState() end
+
+-- GET_DISTANCE_BETWEEN_COORDS  (0x0BE7F4E3CDBAFB28)
+-- If useZ is false, only the 2D plane (X-Y) will be considered for calculating the distance.
+-- 
+-- Consider using this faster native instead: BUILTIN::VDIST - DVIST always takes in consideration the 3D coordinates.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param useZ boolean
+---@return number
+function GetDistanceBetweenCoords(x1, y1, z1, x2, y2, z2, useZ) end
+
+-- GET_FRAME_COUNT  (0x77DFA958FCF100C1)
+-- min build: 1207
+---@return number
+function GetFrameCount() end
+
+-- GET_FRAME_TIME  (0x5E72022914CE3C38)
+-- Also known as "delta time"
+-- min build: 1207
+---@return number
+function GetFrameTime() end
+
+-- GET_GAME_TIMER  (0x4F67E8ECA7D3F667)
+-- min build: 1207
+---@return number
+function GetGameTimer() end
+
+-- GET_GROUND_Z_AND_NORMAL_FOR_3D_COORD  (0x2A29CA9A6319E6AB)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return number
+---@return vector3
+function GetGroundZAndNormalFor3dCoord(x, y, z) end
+
+-- GET_GROUND_Z_FOR_3D_COORD  (0x24FA4267BB8D2431)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p4 boolean
+---@return boolean
+---@return number
+function GetGroundZFor3dCoord(x, y, z, p4) end
+
+-- GET_HASH_KEY  (0xFD340785ADF8CFB7)
+-- Computes a hash for the given string. It is hashed using Jenkins' One-at-a-Time hash algorithm (https://en.wikipedia.org/wiki/Jenkins_hash_function)
+-- Note: this implementation is case-insensitive.
+-- min build: 1207
+---@param string string
+---@return number
+function GetHashKey(string) end
+
+-- GET_HEADING_FROM_VECTOR_2D  (0x38D5202FF9271C62)
+-- dx = x1 - x2
+-- dy = y1 - y2
+-- min build: 1207
+---@param dx number
+---@param dy number
+---@return number
+function GetHeadingFromVector2d(dx, dy) end
+
+-- GET_LINE_PLANE_INTERSECTION  (0xAB6A04CEC428258B)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@param p11 number
+---@return boolean
+---@return number
+function GetLinePlaneIntersection(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) end
+
+-- GET_MISSION_FLAG  (0xB15CD1CF58771DE1)
+-- min build: 1207
+---@return boolean
+function GetMissionFlag() end
+
+-- GET_MODEL_DIMENSIONS  (0xDCB8DDD5D054A7E7)
+-- min build: 1207
+---@param modelHash number
+---@return vector3
+---@return vector3
+function GetModelDimensions(modelHash) end
+
+-- GET_NUMBER_OF_FREE_STACKS_OF_THIS_SIZE  (0x40DC2907A9697EF7)
+-- min build: 1207
+---@param stackSize number
+---@return number
+function GetNumberOfFreeStacksOfThisSize(stackSize) end
+
+-- GET_NUMBER_OF_MICROSECONDS_SINCE_LAST_CALL  (0xB0CE5E5ED8BB3581)
+-- min build: 1207
+---@return number
+function GetNumberOfMicrosecondsSinceLastCall() end
+
+-- GET_ONSCREEN_KEYBOARD_RESULT  (0xAFB4CF58A4A292B1)
+-- Returns NULL unless UPDATE_ONSCREEN_KEYBOARD() returns 1 in the same tick.
+-- min build: 1207
+---@return string
+function GetOnscreenKeyboardResult() end
+
+-- GET_PROJECTILE_OF_PROJECTILE_TYPE_WITHIN_DISTANCE  (0x9578986A6105A6AD)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param distance number
+---@param p5 boolean
+---@param mustBeOwnedByThisPed boolean
+---@return boolean
+---@return vector3
+---@return number
+function GetProjectileOfProjectileTypeWithinDistance(ped, weaponHash, distance, p5, mustBeOwnedByThisPed) end
+
+-- GET_RAIN_LEVEL  (0x931B5F4CC130224B)
+-- min build: 1207
+---@return number
+function GetRainLevel() end
+
+-- GET_RANDOM_EVENT_FLAG  (0x924D54E5698AE3E0)
+-- min build: 1207
+---@return boolean
+function GetRandomEventFlag() end
+
+-- GET_RANDOM_FLOAT_IN_RANGE  (0xE29F927A961F8AAA)
+-- min build: 1207
+---@param startRange number
+---@param endRange number
+---@return number
+function GetRandomFloatInRange(startRange, endRange) end
+
+-- GET_RANDOM_INT_IN_RANGE  (0xD53343AA4FB7DD28)
+-- min build: 1207
+---@param startRange number
+---@param endRange number
+---@return number
+function GetRandomIntInRange(startRange, endRange) end
+
+-- GET_REAL_WORLD_TIME  (0x2E036F0480B8BF02)
+-- Returns GET_GAME_TIMER() / 1000
+-- Only used in rcm_pearson1.ysc
+-- min build: 1207
+---@return number
+function GetRealWorldTime() end
+
+-- GET_SCRIPT_TIME_WITHIN_FRAME_IN_MICROSECONDS  (0x63219768C586667C)
+-- min build: 1207
+---@return number
+function GetScriptTimeWithinFrameInMicroseconds() end
+
+-- GET_SNOW_LEVEL  (0x1E5D727041BE1709)
+-- min build: 1207
+---@return number
+function GetSnowLevel() end
+
+-- GET_SYSTEM_TIME  (0xBE7F225417E35A7C)
+-- min build: 1207
+---@return number
+function GetSystemTime() end
+
+-- GET_SYSTEM_TIME_STEP  (0x3F3172FEAE3AFE1C)
+-- Old name: _GET_BENCHMARK_TIME
+-- min build: 1207
+---@return number
+function GetSystemTimeStep() end
+
+-- GET_WIND_DIRECTION  (0xF703E82F3FE14A5F)
+-- min build: 1207
+---@return vector3
+function GetWindDirection() end
+
+-- GET_WIND_SPEED  (0xFFB7E74E041150A4)
+-- min build: 1207
+---@return number
+function GetWindSpeed() end
+
+-- HAS_BULLET_IMPACTED_IN_AREA  (0xC153E5BCCF411814)
+-- p3 - possibly radius?
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param p4 boolean
+---@param p5 boolean
+---@return boolean
+function HasBulletImpactedInArea(x, y, z, p3, p4, p5) end
+
+-- HAS_BULLET_IMPACTED_IN_BOX  (0x3B6A4C05FB2B33AC)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 boolean
+---@param p7 boolean
+---@return boolean
+function HasBulletImpactedInBox(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- IGNORE_NEXT_RESTART  (0x6C9FF40FF1B69F8F)
+-- min build: 1207
+---@param toggle boolean
+function IgnoreNextRestart(toggle) end
+
+-- INFORM_CODE_OF_CONTENT_ID_OF_CURRENT_UGC_MISSION  (0x708DF841B8F27AA2)
+-- min build: 1207
+---@param p0 string
+function InformCodeOfContentIdOfCurrentUgcMission(p0) end
+
+-- IS_BIT_SET  (0x4ED6CFDFE8D4131A)
+-- min build: 1207
+---@param address number
+---@param offset number
+---@return boolean
+function IsBitSet(address, offset) end
+
+-- IS_BULLET_IN_ANGLED_AREA  (0x9D09D8493747CF02)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 boolean
+---@return boolean
+function IsBulletInAngledArea(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- IS_BULLET_IN_AREA  (0xC652FD308772D79E)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+---@return boolean
+function IsBulletInArea(p0, p1, p2, p3, p4) end
+
+-- IS_BULLET_IN_BOX  (0xC128137C52152741)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 boolean
+---@return boolean
+function IsBulletInBox(p0, p1, p2, p3, p4, p5, p6) end
+
+-- IS_DURANGO_VERSION  (0xD1CCC2A2639D325F)
+-- Hardcoded to return false.
+-- Checks for XBOXONE Game Build.
+-- min build: 1207
+---@return boolean
+function IsDurangoVersion() end
+
+-- IS_GAME_SESSION_STATE_MACHINE_IDLE  (0xF9E7DBB39080640B)
+-- min build: 1207
+---@return boolean
+function IsGameSessionStateMachineIdle() end
+
+-- IS_INCIDENT_VALID  (0x39F2B1BAD412246A)
+-- min build: 1207
+---@param incidentId number
+---@return boolean
+function IsIncidentValid(incidentId) end
+
+-- IS_MAG_DEMO_1_ACTIVE  (0x5FC9357C26DAEFCE)
+-- magdemo = magazine demo, i. e. for magazines such as IGN, pre play phases to prepare articles etc. - example 2012 builds for V
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function IsMagDemo1Active() end
+
+-- IS_MINIGAME_IN_PROGRESS  (0xF4D8BCD052E7EA1B)
+-- min build: 1207
+---@return boolean
+function IsMinigameInProgress() end
+
+-- IS_ORBIS_VERSION  (0x88CFAE250D3E0C71)
+-- Hardcoded to return false.
+-- Checks for PS4 Game Build.
+-- min build: 1207
+---@return boolean
+function IsOrbisVersion() end
+
+-- IS_PC_VERSION  (0xB0FB6CFAA5A1C833)
+-- Hardcoded to return true.
+-- min build: 1207
+---@return boolean
+function IsPcVersion() end
+
+-- IS_POSITION_OCCUPIED  (0x825CA3ED43831015)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param range number
+---@param p4 boolean
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 any
+---@param p10 boolean
+---@return boolean
+function IsPositionOccupied(x, y, z, range, p4, p5, p6, p7, p8, p9, p10) end
+
+-- IS_PROJECTILE_IN_AREA  (0x05B0061EFDFC8941)
+-- Determines whether there is a projectile within the specified coordinates. The coordinates form a rectangle.
+-- 
+-- ownedByPlayer = only projectiles fired by the player will be detected.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param ownedByPlayer boolean
+---@return boolean
+function IsProjectileInArea(x1, y1, z1, x2, y2, z2, ownedByPlayer) end
+
+-- IS_PROJECTILE_TYPE_IN_ANGLED_AREA  (0x928431F4133CD3D4)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 any
+---@param p8 boolean
+---@return boolean
+function IsProjectileTypeInAngledArea(p0, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- IS_PROJECTILE_TYPE_IN_AREA  (0x04965FB9E14235C7)
+-- Determines whether there is a projectile of a specific type within the specified coordinates. The coordinates form a rectangle.
+-- min build: 1207
+---@param xMin number
+---@param yMin number
+---@param zMin number
+---@param xMax number
+---@param yMax number
+---@param zMax number
+---@param weaponType number
+---@param isPlayer boolean
+---@return boolean
+function IsProjectileTypeInArea(xMin, yMin, zMin, xMax, yMax, zMax, weaponType, isPlayer) end
+
+-- IS_PROJECTILE_TYPE_WITHIN_DISTANCE  (0xF51C9BAAD9ED64C4)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 any
+---@param p4 number
+---@param p5 boolean
+---@return boolean
+function IsProjectileTypeWithinDistance(p0, p1, p2, p3, p4, p5) end
+
+-- IS_STADIA_VERSION  (0x268AB8420A9E4ED7)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function IsStadiaVersion() end
+
+-- IS_STRING_NULL  (0x602102324604D96B)
+-- min build: 1207
+---@param string string
+---@return boolean
+function IsStringNull(string) end
+
+-- IS_STRING_NULL_OR_EMPTY  (0x2CF12F9ACF18F048)
+-- min build: 1207
+---@param string string
+---@return boolean
+function IsStringNullOrEmpty(string) end
+
+-- IS_STRING_NULL_OR_EMPTY_OR_SPACES  (0x375F5870A7B8BEC1)
+-- Returns true if the entire string consists only of space characters.
+-- min build: 1207
+---@param string string
+---@return boolean
+function IsStringNullOrEmptyOrSpaces(string) end
+
+-- NETWORK_SET_SCRIPT_IS_SAFE_FOR_NETWORK_GAME  (0x3D0EAC6385DD6100)
+-- min build: 1207
+function NetworkSetScriptIsSafeForNetworkGame() end
+
+-- NEXT_ONSCREEN_KEYBOARD_RESULT_WILL_DISPLAY_USING_THESE_FONTS  (0x5CB71EAA1429A358)
+-- min build: 1207
+---@param fontBitField number
+function NextOnscreenKeyboardResultWillDisplayUsingTheseFonts(fontBitField) end
+
+-- OVERRIDE_SAVE_HOUSE  (0xB2C69E11A37B5AF0)
+-- min build: 1207
+---@param override boolean
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param isAutosave boolean
+---@return boolean
+---@return vector3
+---@return number
+function OverrideSaveHouse(override, x, y, z, heading, isAutosave) end
+
+-- PAUSE_DEATH_ARREST_RESTART  (0x66AB6B6C7E72F393)
+-- min build: 1207
+---@param toggle boolean
+function PauseDeathArrestRestart(toggle) end
+
+-- POPULATE_NOW  (0xEA6DC3A8ADD2005F)
+-- spawns a few distant/out-of-sight peds, vehicles, animals etc each time it is called
+-- min build: 1207
+function PopulateNow() end
+
+-- REGISTER_INTERACTION_LOCKON_PROMPT  (0x870708A6E147A9AD)
+-- p3 is usually the same value of radius
+-- p8 determines whether the ILO prompt is a lock on prompt with RMB
+-- min build: 1207
+---@param entity number
+---@param text string
+---@param radius number
+---@param p3 number
+---@param flag number
+---@param p5 number
+---@param p6 number
+---@param prompt number
+---@param p8 boolean
+---@param p9 number
+---@return boolean
+function RegisterInteractionLockonPrompt(entity, text, radius, p3, flag, p5, p6, prompt, p8, p9) end
+
+-- REMOVE_DISPATCH_SPAWN_BLOCKING_AREA  (0x49F751F6868DDC5B)
+-- min build: 1207
+---@param p0 any
+function RemoveDispatchSpawnBlockingArea(p0) end
+
+-- REMOVE_POP_MULTIPLIER_AREA  (0x88CB484364EFB37A)
+-- min build: 1207
+---@param id number
+---@param p1 boolean
+function RemovePopMultiplierArea(id, p1) end
+
+-- RESET_DISPATCH_IDEAL_SPAWN_DISTANCE  (0xC7817264BC4B6377)
+-- min build: 1207
+function ResetDispatchIdealSpawnDistance() end
+
+-- RESET_END_USER_BENCHMARK  (0xECBABD0307FB216F)
+-- Begins with RESET_*. Next character in the name is either D or E.
+-- 
+-- Old name: _RESET_BENCHMARK_RECORDING
+-- min build: 1207
+function ResetEndUserBenchmark() end
+
+-- RESET_SCRIPT_TIME_WITHIN_FRAME  (0x1411A7CBC3A6EB7B)
+-- min build: 1207
+function ResetScriptTimeWithinFrame() end
+
+-- RESET_WANTED_RESPONSE_NUM_PEDS_TO_SPAWN  (0xEF42F56F69877125)
+-- min build: 1207
+function ResetWantedResponseNumPedsToSpawn() end
+
+-- SAVE_END_USER_BENCHMARK  (0xF4743E2ECC02B3DA)
+-- Saves the benchmark recording to %USERPROFILE%\Documents\Rockstar Games\Red Dead Redemption 2\Benchmarks and submits some metrics.
+-- 
+-- Old name: _SAVE_BENCHMARK_RECORDING
+-- min build: 1207
+function SaveEndUserBenchmark() end
+
+-- SCRIPT_RACE_GET_PLAYER_SPLIT_TIME  (0x769E848C66E3C2BB)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+---@return any
+---@return any
+function ScriptRaceGetPlayerSplitTime(p0) end
+
+-- SCRIPT_RACE_INIT  (0x8AE059F47158417E)
+-- min build: 1207
+---@param numCheckpoints number
+---@param numLaps number
+---@param numPlayers number
+---@param p3 any
+function ScriptRaceInit(numCheckpoints, numLaps, numPlayers, p3) end
+
+-- SCRIPT_RACE_PLAYER_HIT_CHECKPOINT  (0xBA62B4D80FA66BD6)
+-- min build: 1207
+---@param part number
+---@param checkpoint number
+---@param lap number
+---@param time number
+function ScriptRacePlayerHitCheckpoint(part, checkpoint, lap, time) end
+
+-- SCRIPT_RACE_SHUTDOWN  (0x334CE0DA4FAF330C)
+-- min build: 1207
+function ScriptRaceShutdown() end
+
+-- SET_BIT  (0xF73FBE4845C43B5B)
+-- min build: 1207
+---@param offset number
+---@return number
+function SetBit(offset) end
+
+-- SET_BITS_IN_RANGE  (0x324DC1CEF57F31E6)
+-- min build: 1207
+---@param rangeStart number
+---@param rangeEnd number
+---@param p3 number
+---@return number
+function SetBitsInRange(rangeStart, rangeEnd, p3) end
+
+-- SET_CHEAT_ACTIVE  (0xD4958E8CF0DE0DD0)
+-- Cheats are GTA IV cheats:
+-- 
+-- 0 = unknown
+-- 1 = unknown (same as 0)
+-- 2 = Max Health and Armor
+-- 3 = Raise Wanted Level
+-- 4 = Lower Wanted Level
+-- 5 = unknown (does nothing)
+-- 6 = Change Weather
+-- 7 = Spawn Annihilator
+-- 8 = Spawn NRG 900
+-- 9 = Spawn FBI
+-- 10 = Spawn Jetmax
+-- 11 = Spawn Comet
+-- 12 = Spawn Turismo
+-- 13 = Spawn Cognoscenti
+-- 14 = Spawn Super GT
+-- 15 = Spawn Sanchez
+-- 
+-- Initially used in Max Payne 3, that's why we know the name.
+-- min build: 1207
+---@param cheatId number
+function SetCheatActive(cheatId) end
+
+-- SET_CREDITS_ACTIVE  (0xD37BECF862DA726F)
+-- min build: 1207
+---@param toggle boolean
+function SetCreditsActive(toggle) end
+
+-- SET_CURR_WEATHER_STATE  (0xFA3E3CA8A1DE6D5D)
+-- Params: BOOL p3 is always true
+-- 
+-- Old name: _SET_WEATHER_TYPE_TRANSITION
+-- min build: 1207
+---@param weatherType1 number
+---@param weatherType2 number
+---@param percentWeather2 number
+---@param enabled boolean
+function SetCurrWeatherState(weatherType1, weatherType2, percentWeather2, enabled) end
+
+-- SET_DISPATCH_IDEAL_SPAWN_DISTANCE  (0xEAB6823B82FBD283)
+-- min build: 1207
+---@param fIdealSpawnDistance number
+function SetDispatchIdealSpawnDistance(fIdealSpawnDistance) end
+
+-- SET_FADE_IN_AFTER_DEATH_ARREST  (0xDF3B5846DE5904AF)
+-- Sets whether the game should fade in after the player dies or is arrested.
+-- min build: 1207
+---@param toggle boolean
+function SetFadeInAfterDeathArrest(toggle) end
+
+-- SET_FADE_IN_AFTER_LOAD  (0xAC806C4CAB973517)
+-- min build: 1207
+---@param toggle boolean
+function SetFadeInAfterLoad(toggle) end
+
+-- SET_GAME_PAUSED  (0xFAEC088D28B1DE4A)
+-- Make sure to call this from the correct thread if you're using multiple threads because all other threads except the one which is calling SET_GAME_PAUSED will be paused.
+-- min build: 1207
+---@param toggle boolean
+function SetGamePaused(toggle) end
+
+-- SET_MISSION_FLAG  (0x36694B456BE80D0A)
+-- If true, the player can't save the game.
+-- min build: 1207
+---@param toggle boolean
+function SetMissionFlag(toggle) end
+
+-- SET_PED_DECOMPOSED  (0x674B90BE1115846D)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedDecomposed(ped, toggle) end
+
+-- SET_RAIN  (0x193DFC0526830FD6)
+-- Old name: _SET_RAIN_LEVEL
+-- min build: 1207
+---@param intensity number
+function SetRain(intensity) end
+
+-- SET_RANDOM_EVENT_FLAG  (0xB1ADCCC4150C6473)
+-- If the parameter is true, sets the random event flag to true, if the parameter is false, the function does nothing at all.
+-- Does nothing if the mission flag is set.
+-- min build: 1207
+---@param toggle boolean
+function SetRandomEventFlag(toggle) end
+
+-- SET_RANDOM_SEED  (0x5CD7A49104AFCB6B)
+-- min build: 1207
+---@param seed number
+function SetRandomSeed(seed) end
+
+-- SET_RANDOM_WEATHER_TYPE  (0x6E5A7FBEECAB3C72)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+function SetRandomWeatherType(p0, p1) end
+
+-- SET_SUPER_JUMP_THIS_FRAME  (0xB3E9BE963F10C445)
+-- min build: 1207
+---@param player number
+function SetSuperJumpThisFrame(player) end
+
+-- SET_THIS_SCRIPT_CAN_BE_PAUSED  (0x3215376E79F6EA18)
+-- min build: 1207
+---@param toggle boolean
+function SetThisScriptCanBePaused(toggle) end
+
+-- SET_THIS_SCRIPT_CAN_REMOVE_BLIPS_CREATED_BY_ANY_SCRIPT  (0x8ABD939C2E5D00ED)
+-- min build: 1207
+---@param toggle boolean
+function SetThisScriptCanRemoveBlipsCreatedByAnyScript(toggle) end
+
+-- SET_TIME_SCALE  (0x9682AF6050854856)
+-- Maximum value is 1.0f
+-- At a value of 0.0f the game will still run at a minimum time scale.
+-- min build: 1207
+---@param timeScale number
+function SetTimeScale(timeScale) end
+
+-- SET_WEATHER_TYPE  (0x59174F1AFE095B5A)
+-- https://github.com/femga/rdr3_discoveries/blob/master/weather/weather_types.lua
+-- min build: 1207
+---@param weatherType number
+---@param p1 boolean
+---@param p2 boolean
+---@param transition boolean
+---@param transitionTime number
+---@param p5 boolean
+function SetWeatherType(weatherType, p1, p2, transition, transitionTime, p5) end
+
+-- SET_WIND_DIRECTION  (0xB56C4F5F57A45600)
+-- min build: 1207
+---@param direction number
+function SetWindDirection(direction) end
+
+-- SET_WIND_SPEED  (0xD00C2D82DC04A99F)
+-- min build: 1207
+---@param speed number
+function SetWindSpeed(speed) end
+
+-- SHOOT_SINGLE_BULLET_BETWEEN_COORDS  (0x867654CBC7606F2C)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param damage number
+---@param p7 boolean
+---@param weaponHash number
+---@param ownerPed number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param speed number
+---@param p13 boolean
+function ShootSingleBulletBetweenCoords(x1, y1, z1, x2, y2, z2, damage, p7, weaponHash, ownerPed, isAudible, isInvisible, speed, p13) end
+
+-- SHOULD_USE_METRIC_MEASUREMENTS  (0x4FB556ACEFA93098)
+-- Returns whether the game's measurement system is set to metric.
+-- min build: 1207
+---@return boolean
+function ShouldUseMetricMeasurements() end
+
+-- START_END_USER_BENCHMARK  (0x29D1F6DF864A094E)
+-- Begins with START_*. Next character in the name is either D or E.
+-- 
+-- Old name: _START_BENCHMARK_RECORDING
+-- min build: 1207
+function StartEndUserBenchmark() end
+
+-- STOP_CURRENT_LOADING_PROGRESS_TIMER  (0xA565FAC215CBC77D)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function StopCurrentLoadingProgressTimer() end
+
+-- STOP_END_USER_BENCHMARK  (0xB89AEC71AFF2B599)
+-- Begins with STOP_*. Next character in the name is either D or E.
+-- 
+-- Old name: _STOP_BENCHMARK_RECORDING
+-- min build: 1207
+function StopEndUserBenchmark() end
+
+-- STRING_TO_INT  (0xF2DD2298B3AF23E2)
+-- Returns false if it's a null or empty string or if the string is too long. outInteger will be set to -999 in that case.
+-- min build: 1207
+---@param string string
+---@return boolean
+---@return number
+function StringToInt(string) end
+
+-- TAN  (0x8C13DB96497B7ABF)
+-- min build: 1207
+---@param p0 number
+---@return number
+function Tan(p0) end
+
+-- UI_STARTED_END_USER_BENCHMARK  (0x4FFA0386A6216113)
+-- Hardcoded to return false.
+-- 
+-- Old name: _UI_IS_SINGLEPLAYER_PAUSE_MENU_ACTIVE
+-- min build: 1207
+---@return boolean
+function UiStartedEndUserBenchmark() end
+
+-- UNREGISTER_INTERACTION_LOCKON_PROMPT  (0xE98D55C5983F2509)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function UnregisterInteractionLockonPrompt(entity) end
+
+-- UPDATE_ONSCREEN_KEYBOARD  (0x37DF360F235A3893)
+-- Returns the current status of the onscreen keyboard, and updates the output.
+-- 
+-- Status Codes:
+-- 
+-- 0 - User still editing
+-- 1 - User has finished editing
+-- 2 - User has canceled editing
+-- 3 - Keyboard isn't active
+-- min build: 1207
+---@return number
+function UpdateOnscreenKeyboard() end
+
+-- VAR_STRING  (0xFA925AC00EB830B9)
+-- Note: The first bit in 'flags' must not be set.
+-- It is also required to pass at least one extra argument (this must be a text label string or hash).
+-- When passing a hash, flags should be 0.
+-- min build: 1207
+---@param flags number
+---@param ___ any
+---@return string
+function VarString(flags, ___) end
+
+-- WATER_OVERRIDE_SET_OCEANWAVEMAXAMPLITUDE  (0xF06C5B66DE20B2B8)
+-- Only used in smuggler2 script
+-- Also see weather.xml (OceanWaveMaxAmplitude)
+-- min build: 1207
+---@param maxAmplitude number
+function WaterOverrideSetOceanwavemaxamplitude(maxAmplitude) end
+
+-- WATER_OVERRIDE_SET_SHOREWAVEAMPLITUDE  (0x55123D5A7D9D3C42)
+-- Only used in smuggler2 script
+-- Also see weather.xml (ShoreWaveAmplitude)
+-- min build: 1207
+---@param amplitude number
+function WaterOverrideSetShorewaveamplitude(amplitude) end

--- a/.luals/redm-natives/MISSIONDATA.lua
+++ b/.luals/redm-natives/MISSIONDATA.lua
@@ -1,0 +1,118 @@
+---@meta
+
+-- RDR3 namespace: MISSIONDATA -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _MISSIONDATA_IS_REPLAY_CATEGORY_LOCKED  (0xE145864DECC34219)
+-- min build: 1232
+---@param category number
+---@return boolean
+function _MissiondataIsReplayCategoryLocked(category) end
+
+-- _MISSIONDATA_SET_MISSION_RATING  (0xE824CE7D13FCB300)
+-- MISSION_RATING_INCOMPLETE = 0,
+-- MISSION_RATING_SKIPPED,
+-- MISSION_RATING_COMPLETE,
+-- MISSION_RATING_BRONZE,
+-- MISSION_RATING_SILVER,
+-- MISSION_RATING_GOLD,
+-- min build: 1207
+---@param missionId number
+---@param rating number
+function _MissiondataSetMissionRating(missionId, rating) end
+
+-- _MISSIONDATA_SET_REPLAY_STATE_LOCKED  (0xE4E2C581F127A11C)
+-- replayState: MISSIONDATA_GET_REPLAY_STATE
+-- min build: 1207
+---@param missionId number
+---@param replayState number
+function _MissiondataSetReplayStateLocked(missionId, replayState) end
+
+-- _MISSIONDATA_TIMECYCLE_BOX_DELETE  (0x7F89E15A8FB8DE97)
+-- min build: 1207
+function _MissiondataTimecycleBoxDelete() end
+
+-- _MISSIONDATA_TIMECYCLE_BOX_EXISTS  (0x7E8F86A4FA33033C)
+-- min build: 1207
+---@return boolean
+function _MissiondataTimecycleBoxExists() end
+
+-- _MISSIONDATA_TIMECYCLE_BOX_SET_MODIFIER  (0x25855B1574BF8CD5)
+-- min build: 1207
+---@param timecycleName string
+function _MissiondataTimecycleBoxSetModifier(timecycleName) end
+
+-- MISSIONDATA_GET_CATAGORY  (0x57E798B65C45EE17)
+-- min build: 1232
+---@param missionId number
+---@return number
+function MissiondataGetCatagory(missionId) end
+
+-- MISSIONDATA_GET_HIGH_SCORE  (0x9AABABF8313C3516)
+-- min build: 1207
+---@param missionId number
+---@return number
+function MissiondataGetHighScore(missionId) end
+
+-- MISSIONDATA_GET_RATING  (0x57E798B54C45EE1A)
+-- min build: 1207
+---@param missionId number
+---@return number
+function MissiondataGetRating(missionId) end
+
+-- MISSIONDATA_GET_REPLAY_STATE  (0x8C32D86E9556ED86)
+-- min build: 1207
+---@param p0 any
+---@return number
+function MissiondataGetReplayState(p0) end
+
+-- MISSIONDATA_GET_TEXTURE_NAME  (0x57E798B56C45EE15)
+-- min build: 1207
+---@param missionId number
+---@return number
+function MissiondataGetTextureName(missionId) end
+
+-- MISSIONDATA_GET_TEXTURE_TXD  (0x57E798B57C45EE16)
+-- min build: 1207
+---@param missionId number
+---@return number
+function MissiondataGetTextureTxd(missionId) end
+
+-- MISSIONDATA_IS_REQUIRED_STORY_MISSION  (0xE824CE7D13FCB35E)
+-- min build: 1207
+---@param missionId number
+---@return boolean
+function MissiondataIsRequiredStoryMission(missionId) end
+
+-- MISSIONDATA_IS_VALID  (0xE54DC27571D5EDC5)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function MissiondataIsValid(p0) end
+
+-- MISSIONDATA_SET_HIGH_SCORE  (0x3A04F0169DA87A9D)
+-- min build: 1207
+---@param missionId number
+---@param score number
+function MissiondataSetHighScore(missionId, score) end
+
+-- MISSIONDATA_SET_RATING_SCORES  (0x12F65317708749A5)
+-- min build: 1207
+---@param missionId number
+---@param bronzeScore number
+---@param silverScore number
+---@param goldScore number
+function MissiondataSetRatingScores(missionId, bronzeScore, silverScore, goldScore) end
+
+-- MISSIONDATA_SET_REPLAY_LOCKED_FOR_CATEGORY  (0x957A830C9B4B99EA)
+-- min build: 1232
+---@param category number
+---@param locked boolean
+function MissiondataSetReplayLockedForCategory(category, locked) end
+
+-- MISSIONDATA_WAS_COMPLETED  (0xE54DC27571D5EDC4)
+-- see: missions.meta
+-- min build: 1207
+---@param missionId number
+---@return boolean
+function MissiondataWasCompleted(missionId) end

--- a/.luals/redm-natives/MONEY.lua
+++ b/.luals/redm-natives/MONEY.lua
@@ -1,0 +1,51 @@
+---@meta
+
+-- RDR3 namespace: MONEY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x07AD9E43FD478527  (0x07AD9E43FD478527)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return boolean
+function N_0x07AD9E43FD478527(p0, p1) end
+
+-- _0xA46FD001D1BE896C  (0xA46FD001D1BE896C)
+-- min build: 1207
+---@return string
+function N_0xA46FD001D1BE896C() end
+
+-- _MONEY_DECREMENT_CASH_BALANCE  (0x466BC8769CF26A7A)
+-- min build: 1207
+---@param amount number
+---@return boolean
+function _MoneyDecrementCashBalance(amount) end
+
+-- _MONEY_GET_CASH_BALANCE  (0x0C02DABFA3B98176)
+-- min build: 1207
+---@return number
+function _MoneyGetCashBalance() end
+
+-- _MONEY_INCREMENT_CASH_BALANCE  (0xBC3422DC91667621)
+-- min build: 1207
+---@param amount number
+---@param addReason number
+---@return boolean
+function _MoneyIncrementCashBalance(amount, addReason) end
+
+-- _NETWORK_GET_CASH_BALANCE  (0x8A67120DBC299525)
+-- min build: 1207
+---@return number
+function _NetworkGetCashBalance() end
+
+-- _NETWORK_GET_STRING_CASH_BALANCE  (0x282D36FF103D78DF)
+-- min build: 1207
+---@return string
+function _NetworkGetStringCashBalance() end
+
+-- _NETWORK_IS_MONEY_BALANCE_NOT_LESS_THAN  (0xAEC5F0119867E457)
+-- min build: 1207
+---@param cashBalance number
+---@param goldBarBalance number
+---@return boolean
+function _NetworkIsMoneyBalanceNotLessThan(cashBalance, goldBarBalance) end

--- a/.luals/redm-natives/NETSHOPPING.lua
+++ b/.luals/redm-natives/NETSHOPPING.lua
@@ -1,0 +1,177 @@
+---@meta
+
+-- RDR3 namespace: NETSHOPPING -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x38640A8C2DEF011B  (0x38640A8C2DEF011B)
+-- min build: 1311
+---@param p0 number
+---@return number
+function N_0x38640A8C2DEF011B(p0) end
+
+-- _0x3FA09DD57B93C0DE  (0x3FA09DD57B93C0DE)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 any
+---@param p4 number
+---@return boolean
+function N_0x3FA09DD57B93C0DE(p0, p1, p2, p3, p4) end
+
+-- _0x92A32BA29622763F  (0x92A32BA29622763F)
+-- min build: 1207
+---@param id number
+---@param index number
+---@return boolean
+---@return any
+function N_0x92A32BA29622763F(id, index) end
+
+-- _0xA0B7094629724974  (0xA0B7094629724974)
+-- min build: 1207
+---@param p0 number
+---@param p1 any
+---@return boolean
+function N_0xA0B7094629724974(p0, p1) end
+
+-- _0xA3B8D31C13CB4239  (0xA3B8D31C13CB4239)
+-- min build: 1311
+---@param p0 number
+---@param p1 number
+---@param p3 number
+---@param p5 number
+---@return boolean
+---@return any
+---@return any
+function N_0xA3B8D31C13CB4239(p0, p1, p3, p5) end
+
+-- _0xB6F4557060EF0FB4  (0xB6F4557060EF0FB4)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return number
+function N_0xB6F4557060EF0FB4(p0, p1) end
+
+-- _0xCE54C9ABE6FBC6DB  (0xCE54C9ABE6FBC6DB)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0xCE54C9ABE6FBC6DB(p0) end
+
+-- _0xD1555FBC96C88444  (0xD1555FBC96C88444)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 any
+---@param p4 number
+---@return boolean
+function N_0xD1555FBC96C88444(p0, p1, p2, p3, p4) end
+
+-- _CASHINVENTORY_INIT_SESSION_IS_FAULTED  (0xD1CE92D1D9BE170A)
+-- min build: 1207
+---@return boolean
+function _CashinventoryInitSessionIsFaulted() end
+
+-- _CASHINVENTORY_IS_SESSION_READY  (0xFCC24220FDDAC929)
+-- min build: 1207
+---@return boolean
+function _CashinventoryIsSessionReady() end
+
+-- _CASHINVENTORY_TRANSACTION_ADD_AWARD  (0x52BDE32F21BA3B6D)
+-- min build: 1207
+---@param id number
+---@param hash number
+---@return boolean
+---@return any
+---@return any
+function _CashinventoryTransactionAddAward(id, hash) end
+
+-- _CASHINVENTORY_TRANSACTION_CHECKOUT  (0x592BC00BF6629BE7)
+-- min build: 1207
+---@param id number
+---@return boolean
+function _CashinventoryTransactionCheckout(id) end
+
+-- _CASHINVENTORY_TRANSACTION_CHECKOUT_STATUS  (0x26C008791D066F37)
+-- min build: 1207
+---@param id number
+---@return boolean
+---@return number
+function _CashinventoryTransactionCheckoutStatus(id) end
+
+-- _CASHINVENTORY_TRANSACTION_DELETE  (0x59EF5D516E2D96B9)
+-- min build: 1207
+---@param id number
+---@return boolean
+function _CashinventoryTransactionDelete(id) end
+
+-- _CASHINVENTORY_TRANSACTION_FIRE_AND_FORGET_ITEM  (0xFFEA09CCEC4AF32F)
+-- min build: 1207
+---@param actionHash number
+---@param p3 number
+---@return boolean
+---@return number
+---@return any
+function _CashinventoryTransactionFireAndForgetItem(actionHash, p3) end
+
+-- _CASHINVENTORY_TRANSACTION_GET_ACTION  (0xBD2D520C51CCFF52)
+-- min build: 1207
+---@param id number
+---@return number
+function _CashinventoryTransactionGetAction(id) end
+
+-- _CASHINVENTORY_TRANSACTION_GET_BASKET_IS_VALID  (0x52A226ADF4A270D2)
+-- min build: 1207
+---@param id number
+---@return boolean
+function _CashinventoryTransactionGetBasketIsValid(id) end
+
+-- _CASHINVENTORY_TRANSACTION_GET_ITEM_INFO  (0x7616B5F0895C2D99)
+-- min build: 1207
+---@param id number
+---@param index number
+---@return boolean
+---@return any
+function _CashinventoryTransactionGetItemInfo(id, index) end
+
+-- _CASHINVENTORY_TRANSACTION_GET_NUM_OF_ITEMS  (0xCF2D04D076847478)
+-- min build: 1207
+---@param id number
+---@return number
+function _CashinventoryTransactionGetNumOfItems(id) end
+
+-- _CASHINVENTORY_TRANSACTION_RESPONSE_GET_ITEM_INFO  (0x98412398BBE73F61)
+-- min build: 1207
+---@param id number
+---@param index number
+---@return boolean
+---@return any
+function _CashinventoryTransactionResponseGetItemInfo(id, index) end
+
+-- _CASHINVENTORY_TRANSACTION_START  (0xF039EC27F4490E96)
+-- min build: 1207
+---@param type number
+---@param actionHash number
+---@return boolean
+---@return number
+function _CashinventoryTransactionStart(type, actionHash) end
+
+-- _CASHINVENTORY_TRANSACTION_VALIDATE_ITEM  (0x6C9F12700BCE69F4)
+-- min build: 1207
+---@param p0 number
+---@return number
+---@return any
+function _CashinventoryTransactionValidateItem(p0) end
+
+-- CASHINVENTORY_INIT_SESSION_STATUS  (0xC019112F8995DC1C)
+-- min build: 1207
+---@return boolean
+---@return number
+---@return number
+function CashinventoryInitSessionStatus() end
+
+-- CASHINVENTORY_IS_CONNECTION_FAULTED  (0x6CE9FB6332B5E46E)
+-- min build: 1207
+---@return boolean
+function CashinventoryIsConnectionFaulted() end

--- a/.luals/redm-natives/NETWORK.lua
+++ b/.luals/redm-natives/NETWORK.lua
@@ -1,0 +1,3635 @@
+---@meta
+
+-- RDR3 namespace: NETWORK -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x02B3CDD652B3CDD6  (0x02B3CDD652B3CDD6)
+-- Note: this native was added in build 1311.16
+-- 
+-- GET_NUM_*
+-- min build: 1311
+---@return number
+function N_0x02B3CDD652B3CDD6() end
+
+-- _0x02C4C6C2900D84DF  (0x02C4C6C2900D84DF)
+-- Only used in SP R* Script dominoes_sp: p1 = 0
+-- min build: 1207
+---@param player number
+---@param p1 any
+function N_0x02C4C6C2900D84DF(player, p1) end
+
+-- _0x039AD6B57D5179FF  (0x039AD6B57D5179FF)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@return number
+function N_0x039AD6B57D5179FF() end
+
+-- _0x039B692B3318FAB6  (0x039B692B3318FAB6)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x039B692B3318FAB6(p0) end
+
+-- _0x062842D61D0D53FD  (0x062842D61D0D53FD)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@return boolean
+function N_0x062842D61D0D53FD() end
+
+-- _0x0B6B4507AC5EA8B8  (0x0B6B4507AC5EA8B8)
+-- min build: 1207
+---@return boolean
+function N_0x0B6B4507AC5EA8B8() end
+
+-- _0x0BF90CBB6B72977B  (0x0BF90CBB6B72977B)
+-- min build: 1207
+function N_0x0BF90CBB6B72977B() end
+
+-- _0x0CC28C08613BA9E5  (0x0CC28C08613BA9E5)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 number
+function N_0x0CC28C08613BA9E5(p0) end
+
+-- _0x0D183D8490EE4366  (0x0D183D8490EE4366)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+---@param p1 number
+function N_0x0D183D8490EE4366(p0, p1) end
+
+-- _0x0E54D4DA6018FF8E  (0x0E54D4DA6018FF8E)
+-- min build: 1207
+---@return boolean
+function N_0x0E54D4DA6018FF8E() end
+
+-- _0x106CBDD5077DEDE1  (0x106CBDD5077DEDE1)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x106CBDD5077DEDE1(p0) end
+
+-- _0x13F592FC3BF0EA84  (0x13F592FC3BF0EA84)
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+---@param originalWeight number
+---@param p3 any
+---@param p4 any
+function N_0x13F592FC3BF0EA84(volume, p1, originalWeight, p3, p4) end
+
+-- _0x1413B6BF27AB7A95  (0x1413B6BF27AB7A95)
+-- min build: 1207
+---@return number
+function N_0x1413B6BF27AB7A95() end
+
+-- _0x160F0CE6D76A39C9  (0x160F0CE6D76A39C9)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@return any
+function N_0x160F0CE6D76A39C9() end
+
+-- _0x16EFB123C4451032  (0x16EFB123C4451032)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+---@return any
+function N_0x16EFB123C4451032(p0) end
+
+-- _0x18B94666CF610AEB  (0x18B94666CF610AEB)
+-- min build: 1207
+---@return boolean
+function N_0x18B94666CF610AEB() end
+
+-- _0x19447FCAE97704DC  (0x19447FCAE97704DC)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param ctx number
+---@param ec number
+---@param ex boolean
+---@param ro boolean
+function N_0x19447FCAE97704DC(ctx, ec, ex, ro) end
+
+-- _0x19B52C20B5C4757C  (0x19B52C20B5C4757C)
+-- min build: 1207
+function N_0x19B52C20B5C4757C() end
+
+-- _0x1E4E097D71D449FB  (0x1E4E097D71D449FB)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x1E4E097D71D449FB(p0) end
+
+-- _0x232E1EB23CDB313C  (0x232E1EB23CDB313C)
+-- min build: 1207
+---@return boolean
+function N_0x232E1EB23CDB313C() end
+
+-- _0x236321F1178A5446  (0x236321F1178A5446)
+-- _NETWORK_GET_A* - _NETWORK_GET_D*
+-- min build: 1207
+---@param player number
+---@param ped number
+---@return boolean
+---@return any
+function N_0x236321F1178A5446(player, ped) end
+
+-- _0x2686BD9566B65EDA  (0x2686BD9566B65EDA)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function N_0x2686BD9566B65EDA(x, y, z) end
+
+-- _0x26A867C0B7A456D1  (0x26A867C0B7A456D1)
+-- _GET_LAUNCH_PARAM_(RESPOT?)*
+-- Name is probably invalid since this native only reads data from parsed entity.
+-- min build: 1232
+---@param entity number
+---@return boolean
+function N_0x26A867C0B7A456D1(entity) end
+
+-- _0x271F95E55C663B8B  (0x271F95E55C663B8B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x271F95E55C663B8B(p0, p1) end
+
+-- _0x273E04A3A7AD1F2D  (0x273E04A3A7AD1F2D)
+-- min build: 1207
+---@return boolean
+function N_0x273E04A3A7AD1F2D() end
+
+-- _0x27B1AE4D8C652F08  (0x27B1AE4D8C652F08)
+-- min build: 1207
+---@param p0 number
+---@return number
+function N_0x27B1AE4D8C652F08(p0) end
+
+-- _0x2C4E98DDA475364F  (0x2C4E98DDA475364F)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 string
+function N_0x2C4E98DDA475364F(p0) end
+
+-- _0x2CD41AC000E6F611  (0x2CD41AC000E6F611)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0x2CD41AC000E6F611() end
+
+-- _0x3034C77C79A58880  (0x3034C77C79A58880)
+-- min build: 1207
+---@param p0 boolean
+function N_0x3034C77C79A58880(p0) end
+
+-- _0x316FD416C432C761  (0x316FD416C432C761)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@return boolean
+function N_0x316FD416C432C761() end
+
+-- _0x335AF56613CA0F49  (0x335AF56613CA0F49)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+function N_0x335AF56613CA0F49(p0) end
+
+-- _0x34BC1E79546BA543  (0x34BC1E79546BA543)
+-- _NETWORK_A* - _NETWORK_C*
+-- min build: 1232
+---@param p0 boolean
+function N_0x34BC1E79546BA543(p0) end
+
+-- _0x3AA0CDC63696166D  (0x3AA0CDC63696166D)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0x3AA0CDC63696166D(p0) end
+
+-- _0x3CBD6565D9C3B133  (0x3CBD6565D9C3B133)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+---@param p1 number
+---@param p2 number
+function N_0x3CBD6565D9C3B133(p0, p1, p2) end
+
+-- _0x3E4A16BC669E71B3  (0x3E4A16BC669E71B3)
+-- min build: 1207
+---@return boolean
+function N_0x3E4A16BC669E71B3() end
+
+-- _0x3E74A687A73979C6  (0x3E74A687A73979C6)
+-- min build: 1207
+---@param p0 boolean
+function N_0x3E74A687A73979C6(p0) end
+
+-- _0x3E8CCE6769DB5F34  (0x3E8CCE6769DB5F34)
+-- Stadia only; always returns -1 on other platforms. p0 may be a BOOL.
+-- min build: 1207
+---@param p0 number
+---@return number
+function N_0x3E8CCE6769DB5F34(p0) end
+
+-- _0x3F0ABAE38A0515AD  (0x3F0ABAE38A0515AD)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function N_0x3F0ABAE38A0515AD(p0, p1) end
+
+-- _0x3F2EE18A3E294801  (0x3F2EE18A3E294801)
+-- min build: 1207
+---@param p0 number
+---@return number
+function N_0x3F2EE18A3E294801(p0) end
+
+-- _0x405DDEFB1F531B18  (0x405DDEFB1F531B18)
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+---@param p2 any
+---@param p3 any
+function N_0x405DDEFB1F531B18(volume, p1, p2, p3) end
+
+-- _0x40FEDB13870042F1  (0x40FEDB13870042F1)
+-- Note: this native was added in build 1355.30
+-- min build: 1355
+function N_0x40FEDB13870042F1() end
+
+-- _0x41452E8A3B9C0C4B  (0x41452E8A3B9C0C4B)
+-- min build: 1207
+---@return number
+function N_0x41452E8A3B9C0C4B() end
+
+-- _0x422F9D6D6C7BC290  (0x422F9D6D6C7BC290)
+-- Note: this native was added in build 1355.30
+-- min build: 1355
+---@param p0 number
+function N_0x422F9D6D6C7BC290(p0) end
+
+-- _0x43CF999205084B4B  (0x43CF999205084B4B)
+-- min build: 1207
+function N_0x43CF999205084B4B() end
+
+-- _0x4538EE7C321590BC  (0x4538EE7C321590BC)
+-- Returns the entity associated with the given network ID.
+-- min build: 1207
+---@param networkId number
+---@return number
+function N_0x4538EE7C321590BC(networkId) end
+
+-- _0x455156F47DC6B78C  (0x455156F47DC6B78C)
+-- min build: 1207
+---@param p0 boolean
+function N_0x455156F47DC6B78C(p0) end
+
+-- _0x4835413EA6F9C9CD  (0x4835413EA6F9C9CD)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x4835413EA6F9C9CD(p0) end
+
+-- _0x49CF17A564918E8D  (0x49CF17A564918E8D)
+-- min build: 1207
+function N_0x49CF17A564918E8D() end
+
+-- _0x5133CF81924F1129  (0x5133CF81924F1129)
+-- Hardcoded to return zero.
+-- min build: 1207
+---@return number
+function N_0x5133CF81924F1129() end
+
+-- _0x51951DE06C0D1C40  (0x51951DE06C0D1C40)
+-- min build: 1207
+---@param player number
+---@param type number
+function N_0x51951DE06C0D1C40(player, type) end
+
+-- _0x564552C6AF1EEAB1  (0x564552C6AF1EEAB1)
+-- min build: 1207
+function N_0x564552C6AF1EEAB1() end
+
+-- _0x5759160AC17C13CE  (0x5759160AC17C13CE)
+-- min build: 1207
+---@param message string
+---@return any
+function N_0x5759160AC17C13CE(message) end
+
+-- _0x5A91BCEF74944E93  (0x5A91BCEF74944E93)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function N_0x5A91BCEF74944E93(player, p1) end
+
+-- _0x5B9C6AC118FD4774  (0x5B9C6AC118FD4774)
+-- min build: 1207
+function N_0x5B9C6AC118FD4774() end
+
+-- _0x5CB8B0C846D0F30B  (0x5CB8B0C846D0F30B)
+-- min build: 1207
+---@param p0 any
+function N_0x5CB8B0C846D0F30B(p0) end
+
+-- _0x5CD3AAD8FF9ED121  (0x5CD3AAD8FF9ED121)
+-- min build: 1207
+---@param p0 any
+function N_0x5CD3AAD8FF9ED121(p0) end
+
+-- _0x5D3C528B7A7DF836  (0x5D3C528B7A7DF836)
+-- _NETWORK_SPAWN_CONFIG_*
+-- min build: 1207
+---@param nsctf number
+function N_0x5D3C528B7A7DF836(nsctf) end
+
+-- _0x5ED39DA62BEB1330  (0x5ED39DA62BEB1330)
+-- min build: 1207
+---@param p0 number
+---@return any
+function N_0x5ED39DA62BEB1330(p0) end
+
+-- _0x5F0E99071582DECA  (0x5F0E99071582DECA)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@param p2 number
+---@return any
+function N_0x5F0E99071582DECA(p0, index, p2) end
+
+-- _0x5F328FC909F0E0FF  (0x5F328FC909F0E0FF)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@return boolean
+function N_0x5F328FC909F0E0FF(p0, p1, p2, p3) end
+
+-- _0x603469298A4308AF  (0x603469298A4308AF)
+-- min build: 1207
+---@param p0 boolean
+function N_0x603469298A4308AF(p0) end
+
+-- _0x61BFBAA795E712AD  (0x61BFBAA795E712AD)
+-- min build: 1207
+function N_0x61BFBAA795E712AD() end
+
+-- _0x64A36BA85CE01A81  (0x64A36BA85CE01A81)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0x64A36BA85CE01A81(p0, p1, p2, p3) end
+
+-- _0x67CCDF74C4DF7169  (0x67CCDF74C4DF7169)
+-- min build: 1207
+---@return boolean
+function N_0x67CCDF74C4DF7169() end
+
+-- _0x691E4DE5309EAEFC  (0x691E4DE5309EAEFC)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x691E4DE5309EAEFC(p0) end
+
+-- _0x6C27442A225A241A  (0x6C27442A225A241A)
+-- min build: 1207
+---@param p0 number
+---@return number
+function N_0x6C27442A225A241A(p0) end
+
+-- _0x6C7E04E9DE451789  (0x6C7E04E9DE451789)
+-- min build: 1207
+function N_0x6C7E04E9DE451789() end
+
+-- _0x6CEE2E30021DAEC6  (0x6CEE2E30021DAEC6)
+-- _NETWORK_SPAWN_CONFIG_*
+-- min build: 1207
+function N_0x6CEE2E30021DAEC6() end
+
+-- _0x6CF82A7F65A5AD5F  (0x6CF82A7F65A5AD5F)
+-- _NETWORK_GET_A* - _NETWORK_GET_D*
+-- min build: 1207
+---@param ped number
+---@return number
+---@return any
+function N_0x6CF82A7F65A5AD5F(ped) end
+
+-- _0x704F92B3AF20D857  (0x704F92B3AF20D857)
+-- min build: 1207
+---@param setting boolean
+function N_0x704F92B3AF20D857(setting) end
+
+-- _0x71FA2D1880C48032  (0x71FA2D1880C48032)
+-- Only used in R* Script fm_race_controller
+-- min build: 1207
+---@param p0 boolean
+function N_0x71FA2D1880C48032(p0) end
+
+-- _0x744BFBB0CA908161  (0x744BFBB0CA908161)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x744BFBB0CA908161(p0) end
+
+-- _0x75FC34A2BA345BD1  (0x75FC34A2BA345BD1)
+-- min build: 1207
+---@param entity number
+---@param player number
+---@return boolean
+---@return any
+function N_0x75FC34A2BA345BD1(entity, player) end
+
+-- _0x7673C0D2C5CDAC55  (0x7673C0D2C5CDAC55)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+function N_0x7673C0D2C5CDAC55() end
+
+-- _0x77B299E8799B1332  (0x77B299E8799B1332)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x77B299E8799B1332(p0, p1, p2) end
+
+-- _0x780A13F780A13F1B  (0x780A13F780A13F1B)
+-- min build: 1311
+---@param toggle boolean
+function N_0x780A13F780A13F1B(toggle) end
+
+-- _0x78271BC02AE9AF83  (0x78271BC02AE9AF83)
+-- Note: this native was added in build 1436.31
+-- min build: 1436
+---@param p0 number
+---@return number
+function N_0x78271BC02AE9AF83(p0) end
+
+-- _0x7A8E8DF782B47EB0  (0x7A8E8DF782B47EB0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x7A8E8DF782B47EB0(p0, p1, p2) end
+
+-- _0x7B3FF2D193628126  (0x7B3FF2D193628126)
+-- min build: 1207
+---@param player number
+function N_0x7B3FF2D193628126(player) end
+
+-- _0x7BCA0A3972708436  (0x7BCA0A3972708436)
+-- min build: 1207
+---@param p1 number
+---@return number
+---@return any
+function N_0x7BCA0A3972708436(p1) end
+
+-- _0x7E300B5B86AB1D1A  (0x7E300B5B86AB1D1A)
+-- min build: 1207
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@param p11 number
+---@param p12 number
+---@param p13 number
+---@param p14 number
+---@return any
+function N_0x7E300B5B86AB1D1A(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- _0x814729078AED6D30  (0x814729078AED6D30)
+-- min build: 1207
+function N_0x814729078AED6D30() end
+
+-- _0x862C5040F4888741  (0x862C5040F4888741)
+-- min build: 1207
+---@param player1 number
+---@param player2 number
+---@return boolean
+function N_0x862C5040F4888741(player1, player2) end
+
+-- _0x880A7202301E282B  (0x880A7202301E282B)
+-- Params: p5 = 50.f, p6 = 0 in R* Script net_fetch (NET_FETCH_CLIENT_UPDATE_PED_ROLE_CLUE_IDLE)
+-- min build: 1311
+---@param x number
+---@param y number
+---@param z number
+---@param p5 number
+---@param p6 any
+---@return boolean
+---@return any
+---@return any
+function N_0x880A7202301E282B(x, y, z, p5, p6) end
+
+-- _0x894B5ECAB45D2342  (0x894B5ECAB45D2342)
+-- min build: 1207
+---@param netHandle number
+---@param p1 any
+function N_0x894B5ECAB45D2342(netHandle, p1) end
+
+-- _0x917AD74BDCF8B6E9  (0x917AD74BDCF8B6E9)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x917AD74BDCF8B6E9(p0) end
+
+-- _0x923346025512DFB7  (0x923346025512DFB7)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x923346025512DFB7(p0) end
+
+-- _0x950ACD8F05B7B9DF  (0x950ACD8F05B7B9DF)
+-- Related to container entity (RANSACK_ATTACHED_LOCKBOX / RANSACK_ATTACHED_CHEST)
+-- min build: 1355
+---@param entity number
+---@return boolean
+function N_0x950ACD8F05B7B9DF(entity) end
+
+-- _0x979765465A6F25FC  (0x979765465A6F25FC)
+-- Must be called from a background script, otherwise it will do nothing.
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+function N_0x979765465A6F25FC(entity, p1) end
+
+-- _0x97BCE4C4B3191228  (0x97BCE4C4B3191228)
+-- min build: 1207
+function N_0x97BCE4C4B3191228() end
+
+-- _0x981146E5C9CE9250  (0x981146E5C9CE9250)
+-- min build: 1207
+---@param inviteIndex number
+---@return boolean
+function N_0x981146E5C9CE9250(inviteIndex) end
+
+-- _0x982D7AD755B8F62C  (0x982D7AD755B8F62C)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0x982D7AD755B8F62C(p0) end
+
+-- _0x9B39B0555CC692B5  (0x9B39B0555CC692B5)
+-- min build: 1207
+function N_0x9B39B0555CC692B5() end
+
+-- _0x9E5A47744C0F0376  (0x9E5A47744C0F0376)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+---@return boolean
+function N_0x9E5A47744C0F0376(p0) end
+
+-- _0xA2837A5E21FB5A58  (0xA2837A5E21FB5A58)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function N_0xA2837A5E21FB5A58(p0) end
+
+-- _0xA47D48D06AA5A188  (0xA47D48D06AA5A188)
+-- min build: 1207
+---@return boolean
+function N_0xA47D48D06AA5A188() end
+
+-- _0xA63E4F050F20021F  (0xA63E4F050F20021F)
+-- min build: 1207
+function N_0xA63E4F050F20021F() end
+
+-- _0xA6F1BAABFF6AD7B9  (0xA6F1BAABFF6AD7B9)
+-- min build: 1207
+---@return any
+function N_0xA6F1BAABFF6AD7B9() end
+
+-- _0xA7670F7991099680  (0xA7670F7991099680)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+function N_0xA7670F7991099680(p0) end
+
+-- _0xA94ECE191D90637A  (0xA94ECE191D90637A)
+-- min build: 1207
+---@return number
+function N_0xA94ECE191D90637A() end
+
+-- _0xA95470DA137587F5  (0xA95470DA137587F5)
+-- min build: 1207
+---@param p0 boolean
+function N_0xA95470DA137587F5(p0) end
+
+-- _0xACC44768AF229042  (0xACC44768AF229042)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0xACC44768AF229042() end
+
+-- _0xAFA14F98327791CE  (0xAFA14F98327791CE)
+-- min build: 1207
+---@return boolean
+---@return any
+function N_0xAFA14F98327791CE() end
+
+-- _0xB131E686BD97B3F8  (0xB131E686BD97B3F8)
+-- min build: 1207
+function N_0xB131E686BD97B3F8() end
+
+-- _0xB389289F031F059A  (0xB389289F031F059A)
+-- min build: 1207
+---@return number
+function N_0xB389289F031F059A() end
+
+-- _0xBAF7E2979442B29F  (0xBAF7E2979442B29F)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0xBAF7E2979442B29F(p0) end
+
+-- _0xBB1EC8C2EEF33BAA  (0xBB1EC8C2EEF33BAA)
+-- min build: 1207
+---@param entity number
+function N_0xBB1EC8C2EEF33BAA(entity) end
+
+-- _0xBB697756309D77EE  (0xBB697756309D77EE)
+-- min build: 1207
+---@param p0 boolean
+---@return any
+function N_0xBB697756309D77EE(p0) end
+
+-- _0xBC7D36946D19E60E  (0xBC7D36946D19E60E)
+-- Only used in fm_race_controller R* Script (PROCESS_LOCAL_PLAYER_INIT)
+-- min build: 1207
+---@param p0 boolean
+function N_0xBC7D36946D19E60E(p0) end
+
+-- _0xBF8276E51761F9DA  (0xBF8276E51761F9DA)
+-- min build: 1207
+---@return number
+function N_0xBF8276E51761F9DA() end
+
+-- _0xC028B3F52C707C49  (0xC028B3F52C707C49)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function N_0xC028B3F52C707C49(p0) end
+
+-- _0xC0CFFDA87C2C163D  (0xC0CFFDA87C2C163D)
+-- min build: 1207
+---@param p0 number
+---@param p1 any
+---@param p2 number
+---@return any
+function N_0xC0CFFDA87C2C163D(p0, p1, p2) end
+
+-- _0xC1968045EEB563B7  (0xC1968045EEB563B7)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+function N_0xC1968045EEB563B7(p0) end
+
+-- _0xC8B6D18E22484643  (0xC8B6D18E22484643)
+-- min build: 1207
+function N_0xC8B6D18E22484643() end
+
+-- _0xC964FCD3D1720697  (0xC964FCD3D1720697)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@return any
+function N_0xC964FCD3D1720697() end
+
+-- _0xCA58D4FD20D70F24  (0xCA58D4FD20D70F24)
+-- min build: 1207
+---@param p0 any
+---@return number
+function N_0xCA58D4FD20D70F24(p0) end
+
+-- _0xCC4E72C339461ED1  (0xCC4E72C339461ED1)
+-- min build: 1207
+---@return boolean
+function N_0xCC4E72C339461ED1() end
+
+-- _0xCD53E6CBF609C012  (0xCD53E6CBF609C012)
+-- min build: 1207
+---@param ugcRequestId number
+---@return boolean
+function N_0xCD53E6CBF609C012(ugcRequestId) end
+
+-- _0xCF23AB5BD47B384D  (0xCF23AB5BD47B384D)
+-- min build: 1207
+---@param p0 any
+function N_0xCF23AB5BD47B384D(p0) end
+
+-- _0xD1FFB246F4E088AC  (0xD1FFB246F4E088AC)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0xD1FFB246F4E088AC(p0) end
+
+-- _0xD39A72AE5EBD57E5  (0xD39A72AE5EBD57E5)
+-- min build: 1207
+function N_0xD39A72AE5EBD57E5() end
+
+-- _0xD3A3C8B9F3BDEF81  (0xD3A3C8B9F3BDEF81)
+-- min build: 1207
+---@return any
+function N_0xD3A3C8B9F3BDEF81() end
+
+-- _0xD3B6EBC6C3D77D44  (0xD3B6EBC6C3D77D44)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 number
+function N_0xD3B6EBC6C3D77D44(p0) end
+
+-- _0xD4022C7286B0DFA2  (0xD4022C7286B0DFA2)
+-- min build: 1207
+---@param p0 string
+---@param p1 number
+---@param p2 number
+---@return any
+function N_0xD4022C7286B0DFA2(p0, p1, p2) end
+
+-- _0xD42C543F73233041  (0xD42C543F73233041)
+-- min build: 1232
+---@param p0 boolean
+function N_0xD42C543F73233041(p0) end
+
+-- _0xD637D327080CD86E  (0xD637D327080CD86E)
+-- min build: 1207
+---@param p0 number
+function N_0xD637D327080CD86E(p0) end
+
+-- _0xD78A26024BB13E08  (0xD78A26024BB13E08)
+-- min build: 1207
+---@param player number
+function N_0xD78A26024BB13E08(player) end
+
+-- _0xD7BAD4062074B9C1  (0xD7BAD4062074B9C1)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function N_0xD7BAD4062074B9C1(p0) end
+
+-- _0xD7D0DF27CB1765B5  (0xD7D0DF27CB1765B5)
+-- min build: 1355
+---@param p0 number
+---@return boolean
+function N_0xD7D0DF27CB1765B5(p0) end
+
+-- _0xDA1BFED8582F61F0  (0xDA1BFED8582F61F0)
+-- min build: 1207
+---@return boolean
+function N_0xDA1BFED8582F61F0() end
+
+-- _0xDBDF80673BBA3D65  (0xDBDF80673BBA3D65)
+-- Note: this native was added in build 1491.50
+-- min build: 1491
+---@param p0 number
+---@return boolean
+function N_0xDBDF80673BBA3D65(p0) end
+
+-- _0xDC6AD5C046F33AB4  (0xDC6AD5C046F33AB4)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+function N_0xDC6AD5C046F33AB4(p0, p1) end
+
+-- _0xDCA4A74135E1DEA5  (0xDCA4A74135E1DEA5)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function N_0xDCA4A74135E1DEA5(p0) end
+
+-- _0xE10F2D7715ABABEC  (0xE10F2D7715ABABEC)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE10F2D7715ABABEC(p0) end
+
+-- _0xE31A04513237DC89  (0xE31A04513237DC89)
+-- min build: 1207
+---@param entity number
+function N_0xE31A04513237DC89(entity) end
+
+-- _0xE39600E50D608693  (0xE39600E50D608693)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return boolean
+function N_0xE39600E50D608693(p0, p1) end
+
+-- _0xE3AB5EEFCB6671A2  (0xE3AB5EEFCB6671A2)
+-- min build: 1207
+---@param setting number
+function N_0xE3AB5EEFCB6671A2(setting) end
+
+-- _0xE5634491A58C2703  (0xE5634491A58C2703)
+-- min build: 1207
+---@param p0 number
+function N_0xE5634491A58C2703(p0) end
+
+-- _0xE59F4924BD3A718D  (0xE59F4924BD3A718D)
+-- min build: 1207
+---@param p0 number
+---@return string
+function N_0xE59F4924BD3A718D(p0) end
+
+-- _0xE5FF65CFF5160752  (0xE5FF65CFF5160752)
+-- min build: 1207
+function N_0xE5FF65CFF5160752() end
+
+-- _0xE79BA3BC265895DA  (0xE79BA3BC265895DA)
+-- min build: 1207
+---@param p0 number
+---@return string
+function N_0xE79BA3BC265895DA(p0) end
+
+-- _0xE8E633215471BB5D  (0xE8E633215471BB5D)
+-- min build: 1207
+---@param p0 any
+---@return number
+function N_0xE8E633215471BB5D(p0) end
+
+-- _0xEC089F84A9C16C62  (0xEC089F84A9C16C62)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@return any
+function N_0xEC089F84A9C16C62() end
+
+-- _0xF23A6D6C11D8EC15  (0xF23A6D6C11D8EC15)
+-- min build: 1207
+---@return boolean
+---@return any
+function N_0xF23A6D6C11D8EC15() end
+
+-- _0xF260AF6F43953316  (0xF260AF6F43953316)
+-- Same Native Handler as VEH_TO_NET, PED_TO_NET, OBJ_TO_NET and NETWORK_GET_NETWORK_ID_FROM_ENTITY
+-- min build: 1207
+---@param handle number
+---@return number
+function N_0xF260AF6F43953316(handle) end
+
+-- _0xF302AB9D978352EE  (0xF302AB9D978352EE)
+-- Returns the entity's network ID.
+-- min build: 1207
+---@param entity number
+---@return number
+function N_0xF302AB9D978352EE(entity) end
+
+-- _0xF342F6BD0A8287D5  (0xF342F6BD0A8287D5)
+-- min build: 1207
+---@param p0 any
+function N_0xF342F6BD0A8287D5(p0) end
+
+-- _0xF8DC69DC1AD19072  (0xF8DC69DC1AD19072)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@param p0 boolean
+---@return number
+function N_0xF8DC69DC1AD19072(p0) end
+
+-- _0xFB3205788F8AFA3F  (0xFB3205788F8AFA3F)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@return number
+function N_0xFB3205788F8AFA3F() end
+
+-- _0xFC6FCF4C03F1BBF6  (0xFC6FCF4C03F1BBF6)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0xFC6FCF4C03F1BBF6() end
+
+-- _0xFD8112109A96877C  (0xFD8112109A96877C)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+function N_0xFD8112109A96877C() end
+
+-- _0xFE53B1F8D43F19BF  (0xFE53B1F8D43F19BF)
+-- min build: 1207
+---@param player1 number
+---@param player2 number
+---@return number
+function N_0xFE53B1F8D43F19BF(player1, player2) end
+
+-- _0xFF36F36B07E69059  (0xFF36F36B07E69059)
+-- min build: 1207
+---@param p0 any
+function N_0xFF36F36B07E69059(p0) end
+
+-- _ANIM_SCENE_TO_NET  (0xE0D73CDDEA79DDCD)
+-- min build: 1207
+---@param animScene number
+---@return number
+function _AnimSceneToNet(animScene) end
+
+-- _CLEAR_LAUNCH_PARAM  (0x782C94DB6469634D)
+-- min build: 1207
+---@param paramName string
+function _ClearLaunchParam(paramName) end
+
+-- _COMMERCE_STORE_IS_ENABLED  (0xDBC754CB6CCB9378)
+-- min build: 1232
+---@return boolean
+function _CommerceStoreIsEnabled() end
+
+-- _COMMERCE_STORE_IS_OPEN  (0xCE5E79D9E303628E)
+-- min build: 1355
+---@return boolean
+function _CommerceStoreIsOpen() end
+
+-- _GET_LAUNCH_PARAM_EXISTS  (0x02E97CE283648CD9)
+-- min build: 1207
+---@param paramName string
+---@return boolean
+function _GetLaunchParamExists(paramName) end
+
+-- _GET_LAUNCH_PARAM_STRING  (0xC59AB6A04333C502)
+-- min build: 1207
+---@return string
+function _GetLaunchParamString() end
+
+-- _GET_NUM_CREATED_MISSION_PICKUPS  (0xD2BA051B94CA9BCC)
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function _GetNumCreatedMissionPickups(p0) end
+
+-- _GET_NUM_PEER_NEGOTIATION_RESPONSES  (0x4FE932E84FE932E8)
+-- Note: this native was added in build 1311.16
+-- min build: 1311
+---@return number
+function _GetNumPeerNegotiationResponses() end
+
+-- _GET_NUM_RESERVED_MISSION_PICKUPS  (0x62BE3ECC79FBD004)
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function _GetNumReservedMissionPickups(p0) end
+
+-- _GET_PLAYER_WAYPOINT_IS_ACTIVE  (0xDCC4B7F7112E8AB7)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _GetPlayerWaypointIsActive(player) end
+
+-- _GET_RESERVED_MISSION_ENTITIES_FOR_THREAD  (0x99AAC89C510DEB0D)
+-- Only used in R* Script net_stable_manager
+-- min build: 1491
+---@param threadId number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+function _GetReservedMissionEntitiesForThread(threadId) end
+
+-- _GET_SOCIAL_MATCHMAKING_ALLOWED  (0xD0541EF28E9C4783)
+-- min build: 1207
+---@return boolean
+function _GetSocialMatchmakingAllowed() end
+
+-- _LOCAL_PLAYER_PEDSHOT_TEXTURE_DOWNLOAD_REQUEST  (0x6E2FD8CF7EB10E53)
+-- min build: 1207
+---@param playerSlot number
+---@param personaPhotoLocalCacheType number
+---@return number
+function _LocalPlayerPedshotTextureDownloadRequest(playerSlot, personaPhotoLocalCacheType) end
+
+-- _MUGSHOT_TEXTURE_DOWNLOAD_REQUEST  (0x9B5DB6CEAFAA10BB)
+-- Returns textureDownloadId
+-- min build: 1207
+---@param p1 number
+---@param name string
+---@param p3 boolean
+---@return number
+---@return any
+function _MugshotTextureDownloadRequest(p1, name, p3) end
+
+-- _NET_TO_ANIM_SCENE  (0xD7F6781A0ABAF6FB)
+-- min build: 1207
+---@param netId number
+---@return number
+function _NetToAnimScene(netId) end
+
+-- _NET_TO_PROPSET  (0xD08066E00D26C448)
+-- min build: 1207
+---@param netId number
+---@return number
+function _NetToPropset(netId) end
+
+-- _NETWORK_ADD_PLAYER_TO_RECENT_GAMERS_LIST  (0x157D8F3DE12B307F)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function _NetworkAddPlayerToRecentGamersList(player, p1) end
+
+-- _NETWORK_ALERT  (0x1BAA028F52EED310)
+-- min build: 1311
+---@param ctx number
+---@param lh number
+---@param ec number
+---@param h number
+function _NetworkAlert(ctx, lh, ec, h) end
+
+-- _NETWORK_ARE_ONLINE_NOTIFICATIONS_SHOWN_IN_STORY_MODE  (0xF5C5929E07512F80)
+-- Returns value of fwuiCachedSetting "general.onlineNotificationsInStoryMode"
+-- min build: 1207
+---@return boolean
+function _NetworkAreOnlineNotificationsShownInStoryMode() end
+
+-- _NETWORK_ARE_PLAYERS_IN_SAME_PLATFORM_PARTY  (0x11820D1AE80DEA39)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _NetworkArePlayersInSamePlatformParty() end
+
+-- _NETWORK_AUTO_SESSION_IS_AUTO_WARP_DISABLED  (0xE258570E0C116A66)
+-- min build: 1207
+---@return boolean
+function _NetworkAutoSessionIsAutoWarpDisabled() end
+
+-- _NETWORK_AUTO_SESSION_IS_INSTANCED_SESSION  (0x277865A734918AE6)
+-- min build: 1207
+---@return boolean
+function _NetworkAutoSessionIsInstancedSession() end
+
+-- _NETWORK_AUTO_SESSION_IS_PROCESSING_SESSION_SPLIT  (0xA021095C983F20D8)
+-- min build: 1207
+---@return boolean
+function _NetworkAutoSessionIsProcessingSessionSplit() end
+
+-- _NETWORK_AUTO_SESSION_SET_ALLOWED_TO_MERGE  (0x63246A24F5747510)
+-- min build: 1207
+---@param toggle boolean
+---@param p2 number
+---@return any
+function _NetworkAutoSessionSetAllowedToMerge(toggle, p2) end
+
+-- _NETWORK_AUTO_SESSION_SET_ALLOWED_TO_SPLIT  (0x0A428058079EE65C)
+-- min build: 1207
+---@param toggle boolean
+function _NetworkAutoSessionSetAllowedToSplit(toggle) end
+
+-- _NETWORK_AUTO_SESSION_SET_AUTO_WARP_ENABLED  (0x4440FEE3EFE78F54)
+-- min build: 1207
+---@param toggle boolean
+function _NetworkAutoSessionSetAutoWarpEnabled(toggle) end
+
+-- _NETWORK_AUTO_SESSION_SPLIT_SESSION_SUCCESSFUL  (0x6D87BA8EF15226CD)
+-- min build: 1207
+---@return boolean
+function _NetworkAutoSessionSplitSessionSuccessful() end
+
+-- _NETWORK_CAN_ADD_FRIEND  (0x99ABE9BF9DADA162)
+-- On PC this returns true if gamerHandle is a valid handle.
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkCanAddFriend() end
+
+-- _NETWORK_CAN_RECEIVE_INVITE_FROM_HANDLE  (0xF23D6475640D29EB)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkCanReceiveInviteFromHandle() end
+
+-- _NETWORK_CLEAR_CLOCK_OVERRIDE_OVERTIME  (0x65F040D91001ED4B)
+-- min build: 1207
+---@param milliseconds number
+function _NetworkClearClockOverrideOvertime(milliseconds) end
+
+-- _NETWORK_CLOCK_TIME_OVERRIDE  (0x669E223E64B1903C)
+-- min build: 1207
+---@param hour number
+---@param minute number
+---@param second number
+---@param transitionTime number
+---@param pauseClock boolean
+function _NetworkClockTimeOverride(hour, minute, second, transitionTime, pauseClock) end
+
+-- _NETWORK_CLOCK_TIME_OVERRIDE_2  (0xE28C13ECC36FF14E)
+-- min build: 1207
+---@param hour number
+---@param minute number
+---@param second number
+---@param transitionTime number
+---@param pauseClock boolean
+---@param clockwise boolean
+function _NetworkClockTimeOverride2(hour, minute, second, transitionTime, pauseClock, clockwise) end
+
+-- _NETWORK_DEBUG_REQUEST_ENTITY_POSITION  (0xFA38B52F91B59075)
+-- Must be called from a background script, otherwise it will do nothing.
+-- min build: 1207
+---@return any
+function _NetworkDebugRequestEntityPosition() end
+
+-- _NETWORK_DID_RECENT_GAMER_NAMES_REQUEST_SUCCEED  (0x12AEB56B489415C5)
+-- min build: 1207
+---@return boolean
+function _NetworkDidRecentGamerNamesRequestSucceed() end
+
+-- _NETWORK_GET_CURRENT_FRIEND_PAGE_DATA  (0xA3EEC0A5AFF3FC5B)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkGetCurrentFriendPageData() end
+
+-- _NETWORK_GET_DISPLAY_NAME_FROM_HANDLE  (0x7FEE4F07C54B6B3C)
+-- Example:
+-- 
+-- char displayName[64];
+-- if (_NETWORK_GET_DISPLAY_NAME_FROM_HANDLE(handle, displayName))
+-- {
+-- 	// use displayName
+-- }
+-- min build: 1207
+---@param displayName string
+---@return boolean
+---@return any
+function _NetworkGetDisplayNameFromHandle(displayName) end
+
+-- _NETWORK_GET_GAMER_SESSION_FROM_HANDLE  (0xFBDFE1C1356E12E8)
+-- min build: 1207
+---@param count number
+---@return boolean
+---@return any
+function _NetworkGetGamerSessionFromHandle(count) end
+
+-- _NETWORK_GET_GAMER_STATUS  (0xDDAEB478E58F8DEA)
+-- min build: 1207
+---@param p1 number
+---@return number
+---@return any
+function _NetworkGetGamerStatus(p1) end
+
+-- _NETWORK_GET_GAMERTAG_FROM_FRIEND  (0x5659D87BE674AB17)
+-- min build: 1207
+---@return string
+---@return any
+function _NetworkGetGamertagFromFriend() end
+
+-- _NETWORK_GET_GLOBAL_ENTITY_FLAGS  (0xDD7806FD0543BC3D)
+-- min build: 1207
+---@param entity number
+---@return number
+function _NetworkGetGlobalEntityFlags(entity) end
+
+-- _NETWORK_GET_INSTANCE_ID_OF_THREAD  (0xFB9ECED5B68F3B78)
+-- min build: 1207
+---@param threadId number
+---@return number
+function _NetworkGetInstanceIdOfThread(threadId) end
+
+-- _NETWORK_GET_NUM_RECENT_GAMERS  (0x37A834AEC6A4F74A)
+-- min build: 1207
+---@return number
+function _NetworkGetNumRecentGamers() end
+
+-- _NETWORK_GET_PLATFORM_INVITE_ID  (0x9BCF28FB5D65A9BE)
+-- min build: 1207
+---@return number
+function _NetworkGetPlatformInviteId() end
+
+-- _NETWORK_GET_PLAYER_FAST_INSTANCE_ID  (0xD9267375834C5EAB)
+-- min build: 1207
+---@param player number
+---@return number
+function _NetworkGetPlayerFastInstanceId(player) end
+
+-- _NETWORK_GET_PLAYER_OWNER_OF_NETWORK_ID  (0xA6C0787443C9583E)
+-- min build: 1207
+---@param netId number
+---@return number
+function _NetworkGetPlayerOwnerOfNetworkId(netId) end
+
+-- _NETWORK_GET_RANK  (0x32C90CDFAF40514C)
+-- min build: 1207
+---@return number
+function _NetworkGetRank() end
+
+-- _NETWORK_GET_ROS_TITLE_NAME  (0xAC6153A0722F524C)
+-- Returns CGameConfig->ConfigOnlineServices->RosTitleName (see gameconfig.xml)
+-- min build: 1207
+---@return string
+function _NetworkGetRosTitleName() end
+
+-- _NETWORK_GET_SESSION_HOST  (0x8DC9AA3B508B1A85)
+-- min build: 1207
+---@return number
+function _NetworkGetSessionHost() end
+
+-- _NETWORK_GET_SIZE_OF_HOST_BROADCAST_DATA_STORAGE  (0xBA24095EA96DFE17)
+-- min build: 1207
+---@return number
+---@return number
+function _NetworkGetSizeOfHostBroadcastDataStorage() end
+
+-- _NETWORK_GET_SIZE_OF_PLAYER_BROADCAST_DATA_STORAGE  (0x690806BC83BC8CA2)
+-- min build: 1207
+---@return number
+---@return number
+function _NetworkGetSizeOfPlayerBroadcastDataStorage() end
+
+-- _NETWORK_GET_XP  (0xDB438CC9BC6F4022)
+-- min build: 1207
+---@return number
+function _NetworkGetXp() end
+
+-- _NETWORK_HAS_COMPLETED_MP_INTRO_FLOW_ON_CURRENT_SLOT  (0xDD73C9838CE7181D)
+-- min build: 1207
+---@return boolean
+function _NetworkHasCompletedMpIntroFlowOnCurrentSlot() end
+
+-- _NETWORK_HAS_CONTROL_OF_ANIM_SCENE  (0x26A5C12FACFF8724)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function _NetworkHasControlOfAnimScene(animScene) end
+
+-- _NETWORK_HAS_CURRENT_GET_GAMER_STATUS_STARTED  (0x25189F9908E9CD65)
+-- min build: 1207
+---@return boolean
+function _NetworkHasCurrentGetGamerStatusStarted() end
+
+-- _NETWORK_IS_FRIEND_HANDLE_IN_SAME_TITLE  (0x665161D250850A9F)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkIsFriendHandleInSameTitle() end
+
+-- _NETWORK_IS_FRIEND_HANDLE_ONLINE  (0xE348D1404BD80146)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkIsFriendHandleOnline() end
+
+-- _NETWORK_IS_IN_SESSION_LOBBY  (0xC5196C42DE19F646)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function _NetworkIsInSessionLobby() end
+
+-- _NETWORK_IS_PLAYER_IN_SPECTATOR_MODE  (0x5B709519997ECF0F)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _NetworkIsPlayerInSpectatorMode(player) end
+
+-- _NETWORK_IS_PREVIOUS_UPLOAD_PENDING  (0xA21E3BAD0A42D199)
+-- _NETWORK_IS_T* - _NETWORK_RE*
+-- min build: 1207
+---@return boolean
+function _NetworkIsPreviousUploadPending() end
+
+-- _NETWORK_IS_RECENT_GAMER_NAMES_REQUEST_IN_PROGRESS  (0x4664D213A0CCAF40)
+-- min build: 1207
+---@return boolean
+function _NetworkIsRecentGamerNamesRequestInProgress() end
+
+-- _NETWORK_IS_THREAD_ACTIVE  (0x31DAD2CD6D49546E)
+-- min build: 1207
+---@param threadId number
+---@return boolean
+function _NetworkIsThreadActive(threadId) end
+
+-- _NETWORK_IS_TRACKED_PLAYER_VISIBLE  (0xE525878A35B9EEBD)
+-- min build: 1207
+---@param player number
+---@param trackedPlayer number
+---@return boolean
+function _NetworkIsTrackedPlayerVisible(player, trackedPlayer) end
+
+-- _NETWORK_PERSONA_PHOTO_WRITE_LOCAL  (0x2A48D9567940598F)
+-- Returns false if pedshot push failed
+-- min build: 1207
+---@param texture string
+---@param playerSlot number
+---@param p2 number
+---@param personaPhotoLocalCacheType number
+---@return boolean
+function _NetworkPersonaPhotoWriteLocal(texture, playerSlot, p2, personaPhotoLocalCacheType) end
+
+-- _NETWORK_PERSONA_PHOTO_WRITE_SC_PROFILE  (0xB72999D3120599DF)
+-- Returns false if pedshot push failed
+-- min build: 1207
+---@param texture string
+---@param personaPhotoType number
+---@param formatIndex number
+---@return boolean
+function _NetworkPersonaPhotoWriteScProfile(texture, personaPhotoType, formatIndex) end
+
+-- _NETWORK_REMOVE_FRIEND  (0x55F618F68AB854D3)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkRemoveFriend() end
+
+-- _NETWORK_REQUEST_CONTROL_OF_ANIM_SCENE  (0xAAA92B631B13F614)
+-- min build: 1207
+---@param animScene number
+---@return boolean
+function _NetworkRequestControlOfAnimScene(animScene) end
+
+-- _NETWORK_RESURRECT_LOCAL_PLAYER_2  (0x4154B7D8C75E5DCF)
+-- min build: 1207
+---@return any
+function _NetworkResurrectLocalPlayer2() end
+
+-- _NETWORK_SEND_SESSION_INVITE  (0xE47001B7CB8B98AE)
+-- min build: 1207
+---@param contentId string
+---@param dataSize number
+---@param p4 number
+---@param flags number
+---@return boolean
+---@return any
+---@return any
+function _NetworkSendSessionInvite(contentId, dataSize, p4, flags) end
+
+-- _NETWORK_SESSION_ADD_SESSION_FLAGS  (0xE546BDA1B3E288EE)
+-- enum eSessionFlags
+-- {
+-- 	SESSION_FLAG_NONE = 0,
+-- 	SF_INSTANCE = (1 << 0),
+-- 	SF_MATCH = (1 << 1),
+-- 	SF_PRIVATE = (1 << 2),
+-- 	SF_BLOCK_INVITES = (1 << 3),
+-- 	SF_BLOCK_JOIN_VIA_PRESENCE = (1 << 4),
+-- 	SF_BLOCK_NON_HOST_INVITES = (1 << 5),
+-- 	SF_BLOCK_IN_PROGRESS_MATCHMAKING_BACKFILL = (1 << 6),
+-- 	SF_BLOCK_IN_GAMEPLAY_MATCHMAKING_BACKFILL = (1 << 7),
+-- 	SF_BLOCK_INVITES_TEMPORARY = (1 << 8),
+-- 	SF_IN_GAMEPLAY = (1 << 9),
+-- 	SF_COMPETITIVE = (1 << 10),
+-- 	SF_MATCHMAKING_BACKFILL_IS_BLOCKED = (1 << 11)
+-- };
+-- min build: 1207
+---@param flags number
+---@return boolean
+function _NetworkSessionAddSessionFlags(flags) end
+
+-- _NETWORK_SESSION_ARE_SESSION_IDS_EQUAL  (0x4DEC5000F7B508F0)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@return boolean
+---@return any
+---@return any
+function _NetworkSessionAreSessionIdsEqual() end
+
+-- _NETWORK_SESSION_CANCEL_REQUEST  (0xE72E5C1289BD1F40)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkSessionCancelRequest() end
+
+-- _NETWORK_SESSION_GET_SESSION_ID  (0xE9B356C330C0A806)
+-- Note: this native was added in build 1311.23
+-- min build: 1311
+---@return any
+function _NetworkSessionGetSessionId() end
+
+-- _NETWORK_SESSION_GET_SESSION_REQUEST_RESULT  (0x0DD051B1BF4B8BD6)
+-- Returns result of session request:
+-- 0 - NOT_FOUND
+-- 1 - IN_PROGRESS
+-- 2 - TIMEOUT
+-- 3 - PLAYER_OFFLINE
+-- 4 - GANG_MEMBERS_CHANGED
+-- 5 - PLAYER_CANCELLED
+-- 6 - PLAYER_SET_TOO_LARGE
+-- 7 - MATCH_ACCEPTED
+-- 8 - OTHER
+-- min build: 1207
+---@return number
+---@return any
+---@return number
+function _NetworkSessionGetSessionRequestResult() end
+
+-- _NETWORK_SESSION_IS_NSRR_SUCCESS  (0x0F44A5C78D114922)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkSessionIsNsrrSuccess() end
+
+-- _NETWORK_SESSION_IS_REQUEST_IN_PROGRESS_BY_QUEUE_GROUP  (0x9E762A595CF88E4A)
+-- min build: 1207
+---@param queueGroup number
+---@return boolean
+function _NetworkSessionIsRequestInProgressByQueueGroup(queueGroup) end
+
+-- _NETWORK_SESSION_PLAYLIST_GET_UPCOMING_CONTENT  (0x8F9DB6CD03B42B58)
+-- Only used in R* Script net_rolling_playlist
+-- min build: 1436
+function _NetworkSessionPlaylistGetUpcomingContent() end
+
+-- _NETWORK_SESSION_PLAYLIST_GO_TO_NEXT_CONTENT  (0xBDE605F925B07127)
+-- Only used in R* Script net_rolling_playlist
+-- min build: 1436
+function _NetworkSessionPlaylistGoToNextContent() end
+
+-- _NETWORK_SESSION_REMOVE_PLAYER_FLAGS  (0x3215BBE34D3418C5)
+-- min build: 1207
+---@param flags number
+---@return boolean
+function _NetworkSessionRemovePlayerFlags(flags) end
+
+-- _NETWORK_SESSION_REQUEST_SESSION_NOMINATED  (0x4F4672457FF597D1)
+-- min build: 1436
+---@param flags number
+---@param userHash number
+---@param p2 number
+---@return boolean
+---@return any
+function _NetworkSessionRequestSessionNominated(flags, userHash, p2) end
+
+-- _NETWORK_SESSION_REQUEST_SESSION_ON_CALL  (0x23D9C1F2E4098EDC)
+-- category:
+-- enum eOnCallType
+-- {
+-- 	NETWORK_SESSION_REQUEST_ON_CALL_TYPE_STORY = 2,
+-- 	NETWORK_SESSION_REQUEST_ON_CALL_TYPE_MATCH = 3
+-- };
+-- min build: 1207
+---@param flags number
+---@param category number
+---@param userHash number
+---@return boolean
+---@return any
+---@return any
+function _NetworkSessionRequestSessionOnCall(flags, category, userHash) end
+
+-- _NETWORK_SESSION_SET_PLAYER_FLAGS  (0x0AE241A4A9ADEEEC)
+-- min build: 1207
+---@param flags number
+---@return boolean
+function _NetworkSessionSetPlayerFlags(flags) end
+
+-- _NETWORK_SESSION_SHUTDOWN  (0xFD4272A137703449)
+-- Only used in R* Script startup_clip
+-- min build: 1207
+function _NetworkSessionShutdown() end
+
+-- _NETWORK_SESSION_TRANSITION_TO_SESSION  (0xF20B18A330E6DB5C)
+-- min build: 1207
+---@return boolean
+---@return any
+function _NetworkSessionTransitionToSession() end
+
+-- _NETWORK_SET_IN_STATIC_SPECTATOR_MODE  (0xFBF1ECFB39A77B5F)
+-- min build: 1207
+---@param toggle boolean
+---@param x number
+---@param y number
+---@param z number
+function _NetworkSetInStaticSpectatorMode(toggle, x, y, z) end
+
+-- _NETWORK_SPAWN_CONFIG_ADD_EXCLUSION_VOLUME  (0xEEB7818B1D307212)
+-- min build: 1207
+---@param volume number
+function _NetworkSpawnConfigAddExclusionVolume(volume) end
+
+-- _NETWORK_SPAWN_CONFIG_ADD_PROPERTY_PREFERENCE  (0xEB6027FD1B4600D5)
+-- min build: 1207
+---@param configProperty number
+---@param include boolean
+---@param weight number
+function _NetworkSpawnConfigAddPropertyPreference(configProperty, include, weight) end
+
+-- _NETWORK_SPAWN_CONFIG_ADD_PROPERTY_SCRIPTED  (0x44D59EC597BBF348)
+-- min build: 1207
+---@param configProperty number
+---@param include boolean
+function _NetworkSpawnConfigAddPropertyScripted(configProperty, include) end
+
+-- _NETWORK_SPAWN_CONFIG_ADD_SPAWN_POINT  (0xFD1AC0B3858F224C)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+function _NetworkSpawnConfigAddSpawnPoint(x, y, z, heading) end
+
+-- _NETWORK_SPAWN_CONFIG_REMOVE_EXCLUSION_VOLUME  (0xA35E7BF20FA269E0)
+-- min build: 1207
+---@param volume number
+function _NetworkSpawnConfigRemoveExclusionVolume(volume) end
+
+-- _NETWORK_SPAWN_CONFIG_SEARCH_IN_PROGRESS  (0x89EC2FC89ECB1005)
+-- min build: 1207
+---@return boolean
+function _NetworkSpawnConfigSearchInProgress() end
+
+-- _NETWORK_SPAWN_CONFIG_SET_CANCEL_SEARCH  (0x765E60A1DCB8B1CE)
+-- min build: 1207
+function _NetworkSpawnConfigSetCancelSearch() end
+
+-- _NETWORK_SPAWN_CONFIG_SET_LEVEL_WATER_DEPTH  (0xBDCC671B911040F9)
+-- min build: 1207
+---@param waterDepthLevel number
+function _NetworkSpawnConfigSetLevelWaterDepth(waterDepthLevel) end
+
+-- _PEDMUGSHOT_GET_STATUS  (0xCBAC13F065C47596)
+-- min build: 1207
+---@return number
+function _PedmugshotGetStatus() end
+
+-- _PEDMUGSHOT_REQUEST_SEND  (0xFBC30B70B3CDB87E)
+-- min build: 1207
+---@return any
+function _PedmugshotRequestSend() end
+
+-- _PEDMUGSHOT_TAKE  (0xCD954F330693F5F2)
+-- min build: 1207
+---@return boolean
+function _PedmugshotTake() end
+
+-- _PROPSET_TO_NET  (0x74F99EF7EF503398)
+-- min build: 1207
+---@param propSet number
+---@return number
+function _PropsetToNet(propSet) end
+
+-- _REPORT_PLAYER  (0xA197C35F73AC0F12)
+-- min build: 1207
+---@param player number
+---@param reportType number
+---@param description string
+---@param horseName string
+function _ReportPlayer(player, reportType, description, horseName) end
+
+-- _REQUEST_PEDSHOT_TEXTURE_LOCAL_BACKUP_DOWNLOAD  (0x356F9FB0698C1FEB)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param player number
+---@param personaPhotoLocalCacheType number
+---@return string
+function _RequestPedshotTextureLocalBackupDownload(player, personaPhotoLocalCacheType) end
+
+-- _REQUEST_PEDSHOT_TEXTURE_LOCAL_DOWNLOAD  (0xCAF4CA2F87779F8F)
+-- Only used in R* SP Script map_app_event_handler
+-- min build: 1207
+---@param p1 number
+---@return string
+---@return any
+function _RequestPedshotTextureLocalDownload(p1) end
+
+-- _REQUEST_PEDSHOT_TEXTURE_MULTIPLAYER_DOWNLOAD  (0xB5C4B18B12A2AF23)
+-- min build: 1207
+---@param p1 number
+---@return string
+---@return any
+function _RequestPedshotTextureMultiplayerDownload(p1) end
+
+-- _SET_DOOR_NETWORKED  (0x51D99497ABF3F451)
+-- min build: 1207
+---@param doorHash number
+function _SetDoorNetworked(doorHash) end
+
+-- _SET_DOOR_UNNETWORKED  (0xC1E1A3D5ED7617B8)
+-- min build: 1207
+---@param p0 any
+---@param toggle boolean
+function _SetDoorUnnetworked(p0, toggle) end
+
+-- _SET_ENTITY_GHOSTED_TO_LOCAL_PLAYER  (0xEE5AE9956743BA20)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function _SetEntityGhostedToLocalPlayer(entity, toggle) end
+
+-- _SET_LAUNCH_PARAM_STRING  (0xDFFC15AA63D04AAB)
+-- min build: 1207
+---@param params string
+function _SetLaunchParamString(params) end
+
+-- _SET_LAUNCH_PARAM_VALUE  (0x668AF6E4933AC13F)
+-- min build: 1207
+---@param paramName string
+---@param value string
+function _SetLaunchParamValue(paramName, value) end
+
+-- _SET_LOCAL_PLAYER_DAMAGE_MULTIPLIER_FOR_PLAYER  (0xD041A32992A55F84)
+-- min build: 1207
+---@param player number
+---@param damageMultiplier number
+function _SetLocalPlayerDamageMultiplierForPlayer(player, damageMultiplier) end
+
+-- _SET_NETWORK_RESPOT_TIMER  (0x442B4347B6EC36E8)
+-- min build: 1207
+---@param entity number
+---@param timer number
+---@param p2 boolean
+function _SetNetworkRespotTimer(entity, timer, p2) end
+
+-- _SET_PLAYER_VISIBILITY_TO_LOCAL_PLAYER_DISABLED  (0xDCA6ABDB9288FBE4)
+-- _SET_PLAYER_V* - _SET_S*
+-- min build: 1207
+---@param player number
+---@param disabled boolean
+function _SetPlayerVisibilityToLocalPlayerDisabled(player, disabled) end
+
+-- _SET_SOCIAL_MATCHMAKING_ALLOWED  (0x777D0571A466B520)
+-- min build: 1207
+---@param toggle boolean
+function _SetSocialMatchmakingAllowed(toggle) end
+
+-- _TEXTURE_DOWNLOAD_RELEASE_BY_NAME  (0x7A17B7981560FFA5)
+-- min build: 1207
+---@param name string
+function _TextureDownloadReleaseByName(name) end
+
+-- _TEXTURE_DOWNLOAD_TEXTURE_NAME_IS_VALID  (0xE2C3CEC3C0903A00)
+-- min build: 1207
+---@param name string
+---@return boolean
+function _TextureDownloadTextureNameIsValid(name) end
+
+-- _UGC_HAS_PRIVILEGE  (0x6506BFA755FB209C)
+-- Checks if the user has ROS privilege 14.
+-- min build: 1207
+---@return boolean
+function _UgcHasPrivilege() end
+
+-- _UGC_IS_BOOK_MARKED  (0xE42D1042F09865FE)
+-- min build: 1355
+---@param contentId string
+---@return boolean
+function _UgcIsBookMarked(contentId) end
+
+-- _UGC_QUERY_BY_CATEGORY  (0x8C109958C9BB559D)
+-- Returns ugcRequestId
+-- min build: 1207
+---@param categoryType number
+---@param p1 number
+---@param maxGet number
+---@param contentTypeName string
+---@param p4 number
+---@param p5 boolean
+---@return number
+function _UgcQueryByCategory(categoryType, p1, maxGet, contentTypeName, p4, p5) end
+
+-- _UGC_QUERY_BY_CONTENT_ID  (0x69D22E183580113F)
+-- Returns ugcRequestId
+-- min build: 1207
+---@param contentId string
+---@param latestVersion boolean
+---@param contentTypeName string
+---@return number
+function _UgcQueryByContentId(contentId, latestVersion, contentTypeName) end
+
+-- _UGC_QUERY_BY_CONTENT_TYPE  (0xF40EF49B3099E98E)
+-- Returns ugcRequestId
+-- min build: 1207
+---@param p0 number
+---@param maxGet number
+---@param contentTypeName string
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@return number
+function _UgcQueryByContentType(p0, maxGet, contentTypeName, p3, p4, p5) end
+
+-- _UGC_QUERY_GET_BOOK_MARKED  (0x98539FC453AEA639)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return boolean
+function _UgcQueryGetBookMarked(p0, index) end
+
+-- _UGC_QUERY_GET_CREATOR_HANDLE  (0xADB56322EEDFBDC9)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return any
+---@return any
+function _UgcQueryGetCreatorHandle(p0, index) end
+
+-- _UGC_QUERY_GET_CREATOR_PHOTO  (0x409FE0CA6A4D1D49)
+-- Returns string for GET_STATUS_OF_LOAD_MISSION_CREATOR_PHOTO
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 any
+---@return string
+function _UgcQueryGetCreatorPhoto(p0, p1, p2) end
+
+-- _UGC_QUERY_GET_DATE  (0xE0CB4AB15CB32710)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return any
+function _UgcQueryGetDate(p0, index) end
+
+-- _UGC_QUERY_GET_LANGUAGE  (0x97764E8AC6487A9A)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return number
+function _UgcQueryGetLanguage(p0, index) end
+
+-- _UGC_QUERY_GET_MISSION_DESC_HASH  (0xA6BF569956C60A60)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return number
+function _UgcQueryGetMissionDescHash(p0, index) end
+
+-- _UGC_QUERY_GET_NAME  (0x2D053EA815702DD1)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return string
+function _UgcQueryGetName(p0, index) end
+
+-- _UGC_QUERY_GET_OWNER_ID  (0xF9F0B3028431967B)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return string
+function _UgcQueryGetOwnerId(p0, index) end
+
+-- _UGC_QUERY_GET_PLAYLIST_NAME  (0xCAF50048C8D0FBA0)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return string
+function _UgcQueryGetPlaylistName(p0, index) end
+
+-- _UGC_QUERY_GET_POSIX_PUBLISHED_DATE  (0x104080CA9E519B00)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return number
+function _UgcQueryGetPosixPublishedDate(p0, p1) end
+
+-- _UGC_QUERY_GET_POSIX_UPDATED_DATE  (0x21A99A72B00D8002)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return number
+function _UgcQueryGetPosixUpdatedDate(p0, p1) end
+
+-- _UGC_QUERY_GET_PUBLISHED  (0x9993F1E11944A3DD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return boolean
+function _UgcQueryGetPublished(p0, p1) end
+
+-- _UGC_QUERY_GET_RATING  (0x24CD8FAEA1368379)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@param p2 number
+---@return number
+function _UgcQueryGetRating(p0, index, p2) end
+
+-- _UGC_QUERY_GET_ROOT_CONTENT_ID  (0x566CEB0542EF5ECF)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return string
+function _UgcQueryGetRootContentId(p0, index) end
+
+-- _UGC_QUERY_GET_VERSION  (0x63E9DCBC8B0931ED)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@param p2 number
+---@return number
+function _UgcQueryGetVersion(p0, index, p2) end
+
+-- ACTIVATE_DAMAGE_TRACKER_ON_NETWORK_ID  (0xD45B1FFCCD52FF19)
+-- min build: 1207
+---@param netID number
+---@param toggle boolean
+function ActivateDamageTrackerOnNetworkId(netID, toggle) end
+
+-- CAN_REGISTER_MISSION_ENTITIES  (0x69778E7564BADE6D)
+-- min build: 1207
+---@param ped_amt number
+---@param vehicle_amt number
+---@param object_amt number
+---@param pickup_amt number
+---@return boolean
+function CanRegisterMissionEntities(ped_amt, vehicle_amt, object_amt, pickup_amt) end
+
+-- CAN_REGISTER_MISSION_OBJECTS  (0x800DD4721A8B008B)
+-- min build: 1207
+---@param amount number
+---@return boolean
+function CanRegisterMissionObjects(amount) end
+
+-- CAN_REGISTER_MISSION_PEDS  (0xBCBF4FEF9FA5D781)
+-- min build: 1207
+---@param amount number
+---@return boolean
+function CanRegisterMissionPeds(amount) end
+
+-- CAN_REGISTER_MISSION_PICKUPS  (0xF0460C7BF80011EA)
+-- min build: 1207
+---@param amount number
+---@return boolean
+function CanRegisterMissionPickups(amount) end
+
+-- CAN_REGISTER_MISSION_VEHICLES  (0x7277F1F2E085EE74)
+-- min build: 1207
+---@param amount number
+---@return boolean
+function CanRegisterMissionVehicles(amount) end
+
+-- CLEAR_SERVICE_EVENT_ARGUMENTS  (0x966DD84FB6A46017)
+-- Old name: _CLEAR_LAUNCH_PARAMS
+-- min build: 1207
+function ClearServiceEventArguments() end
+
+-- CLOUD_DID_REQUEST_SUCCEED  (0x3A3D5568AF297CD5)
+-- min build: 1207
+---@param id number
+---@return boolean
+function CloudDidRequestSucceed(id) end
+
+-- CLOUD_HAS_REQUEST_COMPLETED  (0x4C61B39930D045DA)
+-- min build: 1207
+---@param id number
+---@return boolean
+function CloudHasRequestCompleted(id) end
+
+-- CONVERT_POSIX_TIME  (0xAC97AF97FA68E5D5)
+-- Takes the specified time and writes it to the structure specified in the second argument.
+-- 
+-- struct date_time
+-- {
+--     int year;
+--     int PADDING1;
+--     int month;
+--     int PADDING2;
+--     int day;
+--     int PADDING3;
+--     int hour;
+--     int PADDING4;
+--     int minute;
+--     int PADDING5;
+--     int second;
+--     int PADDING6;
+-- };
+-- min build: 1207
+---@param posixTime number
+---@return any
+function ConvertPosixTime(posixTime) end
+
+-- GET_CLOUD_TIME_AS_INT  (0x9A73240B49945C76)
+-- min build: 1207
+---@return number
+function GetCloudTimeAsInt() end
+
+-- GET_LAUNCH_PARAM_VALUE  (0x65E65CA6A0FE59D4)
+-- min build: 1207
+---@param paramName string
+---@return string
+function GetLaunchParamValue(paramName) end
+
+-- GET_MAX_NUM_NETWORK_OBJECTS  (0xC7BE335216B5EC7C)
+-- Always returns 60
+-- min build: 1207
+---@return number
+function GetMaxNumNetworkObjects() end
+
+-- GET_MAX_NUM_NETWORK_PEDS  (0x0C1F7D49C39D2289)
+-- Always returns 110
+-- min build: 1207
+---@return number
+function GetMaxNumNetworkPeds() end
+
+-- GET_MAX_NUM_NETWORK_PICKUPS  (0xA72835064DD63E4C)
+-- Always returns 80
+-- min build: 1207
+---@return number
+function GetMaxNumNetworkPickups() end
+
+-- GET_MAX_NUM_NETWORK_VEHICLES  (0x0AFCE529F69B21FF)
+-- Always returns 40
+-- min build: 1207
+---@return number
+function GetMaxNumNetworkVehicles() end
+
+-- GET_NETWORK_TIME  (0x7A5487FE9FAA6B48)
+-- min build: 1207
+---@return number
+function GetNetworkTime() end
+
+-- GET_NETWORK_TIME_ACCURATE  (0x89023FBBF9200E9F)
+-- min build: 1207
+---@return number
+function GetNetworkTimeAccurate() end
+
+-- GET_NUM_CREATED_MISSION_OBJECTS  (0x12B6281B6C6706C0)
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function GetNumCreatedMissionObjects(p0) end
+
+-- GET_NUM_CREATED_MISSION_PEDS  (0xCB215C4B56A7FAE7)
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function GetNumCreatedMissionPeds(p0) end
+
+-- GET_NUM_CREATED_MISSION_VEHICLES  (0x0CD9AB83489430EA)
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function GetNumCreatedMissionVehicles(p0) end
+
+-- GET_NUM_RESERVED_MISSION_OBJECTS  (0xAA81B5F10BC43AC2)
+-- p0 appears to be for MP
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function GetNumReservedMissionObjects(p0) end
+
+-- GET_NUM_RESERVED_MISSION_PEDS  (0x1F13D5AE5CB17E17)
+-- p0 appears to be for MP
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function GetNumReservedMissionPeds(p0) end
+
+-- GET_NUM_RESERVED_MISSION_VEHICLES  (0xCF3A965906452031)
+-- p0 appears to be for MP
+-- min build: 1207
+---@param p0 boolean
+---@return number
+function GetNumReservedMissionVehicles(p0) end
+
+-- GET_RESERVED_MISSION_ENTITIES_IN_AREA  (0x5E71E72A94985214)
+-- Used in Script Function NET_ACE_CLIENT_VERIFY_ENTITY_RESERVATIONS
+-- Coords: Slot world position
+-- 
+-- Old name: _GET_RESERVATIONS_FOR_SLOT_WORLD_POSITION
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 boolean
+---@return number
+---@return number
+---@return number
+---@return number
+function GetReservedMissionEntitiesInArea(x, y, z, p3) end
+
+-- GET_STATUS_OF_TEXTURE_DOWNLOAD  (0x8BD6C6DEA20E82C6)
+-- 0 = succeeded
+-- 1 = pending
+-- 2 = failed
+-- min build: 1207
+---@param textureDownloadId number
+---@return number
+function GetStatusOfTextureDownload(textureDownloadId) end
+
+-- GET_TIME_DIFFERENCE  (0xA2C6FC031D46FFF0)
+-- Subtracts the second argument from the first.
+-- min build: 1207
+---@param timeA number
+---@param timeB number
+---@return number
+function GetTimeDifference(timeA, timeB) end
+
+-- GET_TIME_OFFSET  (0x017008CCDAD48503)
+-- Adds the first argument to the second.
+-- min build: 1207
+---@param timeA number
+---@param timeB number
+---@return number
+function GetTimeOffset(timeA, timeB) end
+
+-- GET_UNIQUE_INT_FOR_PLAYER  (0x07F723401B9D921C)
+-- min build: 1207
+---@param player number
+---@return number
+function GetUniqueIntForPlayer(player) end
+
+-- HAS_NETWORK_TIME_STARTED  (0x46718ACEEDEAFC84)
+-- min build: 1207
+---@return boolean
+function HasNetworkTimeStarted() end
+
+-- IS_DAMAGE_TRACKER_ACTIVE_ON_NETWORK_ID  (0x6E192E33AD436366)
+-- min build: 1207
+---@param netID number
+---@return boolean
+function IsDamageTrackerActiveOnNetworkId(netID) end
+
+-- IS_ENTITY_A_GHOST  (0x21D04D7BC538C146)
+-- Old name: _IS_ENTITY_GHOSTED_TO_LOCAL_PLAYER
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityAGhost(entity) end
+
+-- IS_NETWORK_ID_OWNED_BY_PARTICIPANT  (0xA1607996431332DF)
+-- min build: 1207
+---@param netId number
+---@return boolean
+function IsNetworkIdOwnedByParticipant(netId) end
+
+-- IS_OBJECT_REASSIGNMENT_IN_PROGRESS  (0x8FE9EB11EC9CC23A)
+-- Note: this native was added in build 1311.16
+-- min build: 1311
+---@return boolean
+function IsObjectReassignmentInProgress() end
+
+-- IS_SPHERE_VISIBLE_TO_ANOTHER_MACHINE  (0xD82CF8E64C8729D8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return boolean
+function IsSphereVisibleToAnotherMachine(p0, p1, p2, p3, p4) end
+
+-- IS_SPHERE_VISIBLE_TO_PLAYER  (0xDC3A310219E5DA62)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return boolean
+function IsSphereVisibleToPlayer(p0, p1, p2, p3, p4, p5) end
+
+-- IS_TIME_LESS_THAN  (0xCB2CF5148012C8D0)
+-- Subtracts the second argument from the first, then returns whether the result is negative.
+-- min build: 1207
+---@param timeA number
+---@param timeB number
+---@return boolean
+function IsTimeLessThan(timeA, timeB) end
+
+-- IS_TIME_MORE_THAN  (0xDE350F8651E4346C)
+-- Subtracts the first argument from the second, then returns whether the result is negative.
+-- min build: 1207
+---@param timeA number
+---@param timeB number
+---@return boolean
+function IsTimeMoreThan(timeA, timeB) end
+
+-- KEEP_NETWORK_ID_IN_FAST_INSTANCE  (0xE1BC73D6815BA361)
+-- min build: 1207
+---@param netId number
+---@param p1 boolean
+---@param p2 number
+function KeepNetworkIdInFastInstance(netId, p1, p2) end
+
+-- NET_TO_ENT  (0xBFFEAB45A9A9094A)
+-- gets the entity id of a network id
+-- min build: 1207
+---@param netHandle number
+---@return number
+function NetToEnt(netHandle) end
+
+-- NET_TO_OBJ  (0xD8515F5FEA14CB3F)
+-- gets the object id of a network id
+-- min build: 1207
+---@param netHandle number
+---@return number
+function NetToObj(netHandle) end
+
+-- NET_TO_PED  (0xBDCD95FC216A8B3E)
+-- gets the ped id of a network id
+-- min build: 1207
+---@param netHandle number
+---@return number
+function NetToPed(netHandle) end
+
+-- NET_TO_VEH  (0x367B936610BA360C)
+-- min build: 1207
+---@param netHandle number
+---@return number
+function NetToVeh(netHandle) end
+
+-- NETWORK_ACCEPT_RS_INVITE  (0xB2CEA5105AAC8DDE)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function NetworkAcceptRsInvite(p0) end
+
+-- NETWORK_ACCESS_TUNABLE_BOOL  (0xAA6A47A573ABB75A)
+-- min build: 1207
+---@param tunableContext number
+---@param tunableName number
+---@return boolean
+function NetworkAccessTunableBool(tunableContext, tunableName) end
+
+-- NETWORK_ACCESS_TUNABLE_INT  (0x8BE1146DFD5D4468)
+-- min build: 1207
+---@param tunableContext number
+---@param tunableName number
+---@return boolean
+---@return number
+function NetworkAccessTunableInt(tunableContext, tunableName) end
+
+-- NETWORK_ACTION_PLATFORM_INVITE  (0x3B82ACC3F4B6240C)
+-- min build: 1207
+---@return boolean
+function NetworkActionPlatformInvite() end
+
+-- NETWORK_ACTIVITY_RESET_TO_IDLE  (0x3FE141FDB990E3D1)
+-- min build: 1207
+function NetworkActivityResetToIdle() end
+
+-- NETWORK_ACTIVITY_SET_CURRENT  (0x9ADAC065D9F6706F)
+-- min build: 1207
+---@param netPlaylistActivity number
+function NetworkActivitySetCurrent(netPlaylistActivity) end
+
+-- NETWORK_ADD_FRIEND  (0x8E02D73914064223)
+-- min build: 1207
+---@param message string
+---@return boolean
+---@return any
+function NetworkAddFriend(message) end
+
+-- NETWORK_ALLOW_ALL_ENTITY_FADING_FOR_INSTANCES  (0x4B05B97BA46F419D)
+-- min build: 1207
+---@param toggle boolean
+function NetworkAllowAllEntityFadingForInstances(toggle) end
+
+-- NETWORK_ALLOW_ENTITY_FADING_FOR_INSTANCES  (0xF3354D6CA46F419D)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function NetworkAllowEntityFadingForInstances(entity, toggle) end
+
+-- NETWORK_ALLOW_REMOTE_ATTACHMENT_MODIFICATION  (0x267C78C60E806B9A)
+-- Old name: _NETWORK_ALLOW_LOCAL_ENTITY_ATTACHMENT
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function NetworkAllowRemoteAttachmentModification(entity, toggle) end
+
+-- NETWORK_ARE_HANDLES_THE_SAME  (0x57DBA049E110F217)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function NetworkAreHandlesTheSame() end
+
+-- NETWORK_ARE_PLAYERS_IN_SAME_TUTORIAL_SESSION  (0x9DE986FC9A87C474)
+-- Old name: _NETWORK_IS_PLAYER_EQUAL_TO_INDEX
+-- min build: 1207
+---@param player number
+---@param index number
+---@return boolean
+function NetworkArePlayersInSameTutorialSession(player, index) end
+
+-- NETWORK_AUTO_SESSION_CAN_SPLIT_SESSION  (0xE404BFF0ABA23CDC)
+-- min build: 1207
+---@return boolean
+---@return number
+function NetworkAutoSessionCanSplitSession() end
+
+-- NETWORK_AUTO_SESSION_FINISH_INSTANCE  (0xBB51299166B844F3)
+-- min build: 1207
+function NetworkAutoSessionFinishInstance() end
+
+-- NETWORK_AUTO_SESSION_IS_ALLOWED_TO_MERGE  (0xAADED99A6B268A27)
+-- min build: 1207
+---@return boolean
+function NetworkAutoSessionIsAllowedToMerge() end
+
+-- NETWORK_AUTO_SESSION_IS_OBJECT_CREATION_PAUSED  (0x0E2C3AEE6CE603B7)
+-- min build: 1207
+---@return boolean
+function NetworkAutoSessionIsObjectCreationPaused() end
+
+-- NETWORK_AUTO_SESSION_SPLIT_SESSION  (0xC223D299C670413D)
+-- min build: 1207
+---@param playersToTake number
+---@param maxInstancePlayers number
+---@param sessionFlags number
+---@param bucketId number
+---@return boolean
+function NetworkAutoSessionSplitSession(playersToTake, maxInstancePlayers, sessionFlags, bucketId) end
+
+-- NETWORK_AWARD_HAS_REACHED_MAXCLAIM  (0xFBE782B3165AC8EC)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function NetworkAwardHasReachedMaxclaim(p0) end
+
+-- NETWORK_CAN_ACCESS_MULTIPLAYER  (0xAF50DA1A3F8B1BA4)
+-- min build: 1207
+---@return boolean
+---@return number
+function NetworkCanAccessMultiplayer() end
+
+-- NETWORK_CAN_REFRESH_FRIEND_PAGE  (0x1AF5E28E64A76A9F)
+-- min build: 1207
+---@return boolean
+function NetworkCanRefreshFriendPage() end
+
+-- NETWORK_CAN_SESSION_END  (0x4EEBC3694E49C572)
+-- min build: 1207
+---@return boolean
+function NetworkCanSessionEnd() end
+
+-- NETWORK_CAN_VIEW_GAMER_USER_CONTENT  (0x246545C37C27A717)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkCanViewGamerUserContent() end
+
+-- NETWORK_CHECK_ACCESS_AND_ALERT_IF_FAIL  (0x2A8112A974DE1EF6)
+-- min build: 1207
+---@return boolean
+function NetworkCheckAccessAndAlertIfFail() end
+
+-- NETWORK_CHECK_COMMUNICATION_PRIVILEGES  (0x83F28CE49FBBFFBA)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function NetworkCheckCommunicationPrivileges(p0) end
+
+-- NETWORK_CHECK_USER_CONTENT_PRIVILEGES  (0x595F028698072DD9)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function NetworkCheckUserContentPrivileges(p0) end
+
+-- NETWORK_CLEAR_CLOCK_TIME_OVERRIDE  (0xD972DF67326F966E)
+-- min build: 1207
+function NetworkClearClockTimeOverride() end
+
+-- NETWORK_CLEAR_FOUND_GAMERS  (0x6D14CCEE1B40381A)
+-- min build: 1207
+function NetworkClearFoundGamers() end
+
+-- NETWORK_CLEAR_GET_GAMER_STATUS  (0x86E0660E4F5C956D)
+-- min build: 1207
+function NetworkClearGetGamerStatus() end
+
+-- NETWORK_CLEAR_PLATFORM_INVITE  (0xA4484173759749B1)
+-- min build: 1207
+function NetworkClearPlatformInvite() end
+
+-- NETWORK_CONCEAL_PLAYER  (0xBBDF066252829606)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function NetworkConcealPlayer(player, toggle) end
+
+-- NETWORK_DID_FIND_GAMERS_SUCCEED  (0xF9B83B77929D8863)
+-- min build: 1207
+---@return boolean
+function NetworkDidFindGamersSucceed() end
+
+-- NETWORK_DID_GET_GAMER_STATUS_SUCCEED  (0x5AE17C6B0134B7F1)
+-- min build: 1207
+---@return boolean
+function NetworkDidGetGamerStatusSucceed() end
+
+-- NETWORK_DISABLE_LEAVE_REMOTE_PED_BEHIND  (0xC505036A35AFD01B)
+-- min build: 1207
+---@param toggle boolean
+function NetworkDisableLeaveRemotePedBehind(toggle) end
+
+-- NETWORK_DISABLE_PROXIMITY_MIGRATION  (0x407091CF6037118E)
+-- min build: 1207
+---@param netID number
+function NetworkDisableProximityMigration(netID) end
+
+-- NETWORK_DISABLE_REALTIME_MULTIPLAYER  (0x236905C700FDB54D)
+-- min build: 1207
+function NetworkDisableRealtimeMultiplayer() end
+
+-- NETWORK_DISPLAYNAMES_FROM_HANDLES_START  (0xD66C9E72B3CC4982)
+-- Hardcoded to return -1.
+-- min build: 1207
+---@param p1 any
+---@return number
+---@return any
+function NetworkDisplaynamesFromHandlesStart(p1) end
+
+-- NETWORK_DOES_NETWORK_ID_EXIST  (0x38CE16C96BD11344)
+-- min build: 1207
+---@param netID number
+---@return boolean
+function NetworkDoesNetworkIdExist(netID) end
+
+-- NETWORK_DOES_TUNABLE_EXIST  (0x85E5F8B9B898B20A)
+-- min build: 1207
+---@param tunableContext number
+---@param tunableName number
+---@return boolean
+function NetworkDoesTunableExist(tunableContext, tunableName) end
+
+-- NETWORK_DUMP_NET_IF_CONFIG  (0xAEDF1BC1C133D6E3)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function NetworkDumpNetIfConfig() end
+
+-- NETWORK_END_TUTORIAL_SESSION  (0xD0AFAFF5A51D72F7)
+-- min build: 1207
+function NetworkEndTutorialSession() end
+
+-- NETWORK_GET_ASSISTED_DAMAGE_OF_ENTITY  (0x4CACA84440FA26F6)
+-- min build: 1207
+---@param player number
+---@param entity number
+---@return boolean
+---@return number
+function NetworkGetAssistedDamageOfEntity(player, entity) end
+
+-- NETWORK_GET_AVERAGE_LATENCY  (0xD414BE129BB81B32)
+-- Old name: _NETWORK_GET_AVERAGE_LATENCY_FOR_PLAYER
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetAverageLatency(player) end
+
+-- NETWORK_GET_AVERAGE_PACKET_LOSS  (0x350C23949E43686C)
+-- Old name: _NETWORK_GET_AVERAGE_PACKET_LOSS_FOR_PLAYER
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetAveragePacketLoss(player) end
+
+-- NETWORK_GET_AVERAGE_PING  (0x0E3A041ED6AC2B45)
+-- Same as NETWORK_GET_AVERAGE_LATENCY (0xD414BE129BB81B32)
+-- 
+-- Old name: _NETWORK_GET_AVERAGE_LATENCY_FOR_PLAYER_2
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetAveragePing(player) end
+
+-- NETWORK_GET_DESTROYER_OF_NETWORK_ID  (0x7A1ADEEF01740A24)
+-- min build: 1207
+---@param netId number
+---@return number
+---@return number
+function NetworkGetDestroyerOfNetworkId(netId) end
+
+-- NETWORK_GET_DISPLAYNAMES_FROM_HANDLES  (0x58CC181719256197)
+-- Hardcoded to return zero.
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return number
+function NetworkGetDisplaynamesFromHandles(p0, p1, p2) end
+
+-- NETWORK_GET_ENTITY_FROM_NETWORK_ID  (0xCE4E5D9B0A4FF560)
+-- min build: 1207
+---@param netId number
+---@return number
+function NetworkGetEntityFromNetworkId(netId) end
+
+-- NETWORK_GET_ENTITY_IS_NETWORKED  (0xC7827959479DCC78)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function NetworkGetEntityIsNetworked(entity) end
+
+-- NETWORK_GET_ENTITY_KILLER_OF_PLAYER  (0x42B2DAA6B596F5F8)
+-- min build: 1207
+---@param player number
+---@return number
+---@return number
+function NetworkGetEntityKillerOfPlayer(player) end
+
+-- NETWORK_GET_GAME_MODE  (0x225640E09EFFDC3F)
+-- min build: 1207
+---@return number
+function NetworkGetGameMode() end
+
+-- NETWORK_GET_GAMERTAG_FROM_HANDLE  (0x426141162EBE5CDB)
+-- Always returns a null string.
+-- min build: 1207
+---@return string
+---@return any
+function NetworkGetGamertagFromHandle() end
+
+-- NETWORK_GET_GLOBAL_CLOCK  (0x11A7ADCD629E170F)
+-- min build: 1207
+---@return boolean
+---@return number
+---@return number
+---@return number
+function NetworkGetGlobalClock() end
+
+-- NETWORK_GET_GLOBAL_MULTIPLAYER_CLOCK  (0x6D03BFBD643B2A02)
+-- min build: 1207
+---@return number
+---@return number
+---@return number
+function NetworkGetGlobalMultiplayerClock() end
+
+-- NETWORK_GET_HIGHEST_RELIABLE_RESEND_COUNT  (0x52C1EADAF7B10302)
+-- Old name: _NETWORK_GET_OLDEST_RESEND_COUNT_FOR_PLAYER
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetHighestReliableResendCount(player) end
+
+-- NETWORK_GET_HOST_OF_SCRIPT  (0x1D6A14F1F9A736FC)
+-- min build: 1436
+---@param scriptName string
+---@param p1 number
+---@param p2 number
+---@return number
+function NetworkGetHostOfScript(scriptName, p1, p2) end
+
+-- NETWORK_GET_HOST_OF_THIS_SCRIPT  (0xC7B4D79B01FA7A5C)
+-- min build: 1232
+---@return number
+function NetworkGetHostOfThisScript() end
+
+-- NETWORK_GET_HOST_OF_THREAD  (0xB4A25351D79B444C)
+-- min build: 1207
+---@param threadId number
+---@return number
+function NetworkGetHostOfThread(threadId) end
+
+-- NETWORK_GET_INSTANCE_ID_OF_THIS_SCRIPT  (0x638A3A81733086DB)
+-- min build: 1207
+---@return number
+function NetworkGetInstanceIdOfThisScript() end
+
+-- NETWORK_GET_LOCAL_HANDLE  (0xE86051786B66CD8E)
+-- min build: 1207
+---@return any
+function NetworkGetLocalHandle() end
+
+-- NETWORK_GET_MAX_NUM_PARTICIPANTS  (0xA6C90FBC38E395EE)
+-- Seems to always return 0, but it's used in quite a few loops.
+-- 
+-- for (num3 = 0; num3 < NETWORK::0xCCD8C02D(); num3++)
+--     {
+--         if (NETWORK::NETWORK_IS_PARTICIPANT_ACTIVE(PLAYER::0x98F3B274(num3)) != 0)
+--         {
+--             var num5 = NETWORK::NETWORK_GET_PLAYER_INDEX(PLAYER::0x98F3B274(num3));
+-- min build: 1207
+---@return number
+function NetworkGetMaxNumParticipants() end
+
+-- NETWORK_GET_NET_STATISTICS_INFO  (0x6FD992C4A1C1B986)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function NetworkGetNetStatisticsInfo() end
+
+-- NETWORK_GET_NETWORK_ID_FROM_ENTITY  (0xA11700682F3AD45C)
+-- min build: 1207
+---@param entity number
+---@return number
+function NetworkGetNetworkIdFromEntity(entity) end
+
+-- NETWORK_GET_NETWORK_ID_FROM_ROPE_ID  (0x42871327315EDAE8)
+-- min build: 1207
+---@param ropeId number
+---@return number
+function NetworkGetNetworkIdFromRopeId(ropeId) end
+
+-- NETWORK_GET_NP_UNAVAILABLE_REASON  (0x74FB3E29E6D10FA9)
+-- Hardcoded to return zero.
+-- 
+-- ==== PS4 specific info ====
+-- 
+-- Returns some sort of unavailable reason:
+-- -1 = REASON_INVALID
+--  0 = REASON_OTHER
+--  1 = REASON_SYSTEM_UPDATE
+--  2 = REASON_GAME_UPDATE
+--  3 = REASON_SIGNED_OUT
+--  4 = REASON_AGE
+--  5 = REASON_CONNECTION
+-- 
+-- =================================
+-- min build: 1207
+---@return number
+function NetworkGetNpUnavailableReason() end
+
+-- NETWORK_GET_NUM_CONNECTED_PLAYERS  (0xA4A79DD2D9600654)
+-- Returns the amount of players connected in the current session. Only works when connected to a session/server.
+-- min build: 1207
+---@return number
+function NetworkGetNumConnectedPlayers() end
+
+-- NETWORK_GET_NUM_PARTICIPANTS  (0x18D0456E86604654)
+-- min build: 1207
+---@return number
+function NetworkGetNumParticipants() end
+
+-- NETWORK_GET_NUM_SCRIPT_PARTICIPANTS  (0x3658E8CD94FC121A)
+-- min build: 1207
+---@param scriptName string
+---@param instanceId number
+---@param position number
+---@return number
+function NetworkGetNumScriptParticipants(scriptName, instanceId, position) end
+
+-- NETWORK_GET_NUM_UNACKED_RELIABLES  (0xFF8FCF9FFC458A1C)
+-- Old name: _NETWORK_GET_NUM_UNACKED_FOR_PLAYER
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetNumUnackedReliables(player) end
+
+-- NETWORK_GET_PARTICIPANT_INDEX  (0x1B84DF6AF2A46938)
+-- min build: 1207
+---@param index number
+---@return number
+function NetworkGetParticipantIndex(index) end
+
+-- NETWORK_GET_PLAYER_FROM_GAMER_HANDLE  (0xCE5F689CF5A0A49D)
+-- min build: 1207
+---@return number
+---@return any
+function NetworkGetPlayerFromGamerHandle() end
+
+-- NETWORK_GET_PLAYER_INDEX  (0x24FB80D107371267)
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetPlayerIndex(player) end
+
+-- NETWORK_GET_PLAYER_INDEX_FROM_PED  (0x6C0E2E0125610278)
+-- Returns the Player associated to a given Ped when in an online session.
+-- min build: 1207
+---@param ped number
+---@return number
+function NetworkGetPlayerIndexFromPed(ped) end
+
+-- NETWORK_GET_PROMOTION_DLG_SEEN_COUNT  (0x2FB53C631A49BE92)
+-- Hardcoded to return zero.
+-- min build: 1207
+---@return number
+function NetworkGetPromotionDlgSeenCount() end
+
+-- NETWORK_GET_RANDOM_INT_RANGED  (0xE30CF56F1EFA5F43)
+-- min build: 1207
+---@param rangeStart number
+---@param rangeEnd number
+---@return number
+function NetworkGetRandomIntRanged(rangeStart, rangeEnd) end
+
+-- NETWORK_GET_RECENT_GAMER_NAMES  (0xFEFCC345CE357453)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param dataSize number
+---@return boolean
+---@return any
+function NetworkGetRecentGamerNames(p0, p1, dataSize) end
+
+-- NETWORK_GET_ROPE_ID_FROM_NETWORK_ID  (0xEB1A4DD8352EC828)
+-- min build: 1207
+---@param netId number
+---@return number
+function NetworkGetRopeIdFromNetworkId(netId) end
+
+-- NETWORK_GET_SCRIPT_STATUS  (0x57D158647A6BFABF)
+-- min build: 1207
+---@return number
+function NetworkGetScriptStatus() end
+
+-- NETWORK_GET_THIS_SCRIPT_IS_NETWORK_SCRIPT  (0x2910669969E9535E)
+-- min build: 1207
+---@return boolean
+function NetworkGetThisScriptIsNetworkScript() end
+
+-- NETWORK_GET_TIMEOUT_TIME  (0x5ED0356A0CE3A34F)
+-- min build: 1207
+---@return number
+function NetworkGetTimeoutTime() end
+
+-- NETWORK_GET_TOTAL_NUM_FRIENDS  (0xDB7ABDD203FA3704)
+-- min build: 1207
+---@return number
+function NetworkGetTotalNumFriends() end
+
+-- NETWORK_GET_TOTAL_NUM_PLAYERS  (0xCF61D4B4702EE9EB)
+-- min build: 1207
+---@return number
+function NetworkGetTotalNumPlayers() end
+
+-- NETWORK_GET_TUNABLE_CLOUD_CRC  (0x10BD227A753B0D84)
+-- min build: 1436
+---@return number
+function NetworkGetTunableCloudCrc() end
+
+-- NETWORK_GET_UNRELIABLE_RESEND_COUNT  (0x3765C3A3E8192E10)
+-- Old name: _NETWORK_GET_UNRELIABLE_RESEND_COUNT_FOR_PLAYER
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkGetUnreliableResendCount(player) end
+
+-- NETWORK_HANDLE_FROM_FRIEND  (0xD45CB817D7E177D2)
+-- min build: 1207
+---@param friendIndex number
+---@return any
+function NetworkHandleFromFriend(friendIndex) end
+
+-- NETWORK_HANDLE_FROM_PLAYER  (0x388EB2B86C73B6B3)
+-- min build: 1207
+---@param player number
+---@return any
+function NetworkHandleFromPlayer(player) end
+
+-- NETWORK_HAS_CONTROL_OF_ENTITY  (0x01BF60A500E28887)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function NetworkHasControlOfEntity(entity) end
+
+-- NETWORK_HAS_CONTROL_OF_NETWORK_ID  (0x4D36070FE0215186)
+-- min build: 1207
+---@param netId number
+---@return boolean
+function NetworkHasControlOfNetworkId(netId) end
+
+-- NETWORK_HAS_CONTROL_OF_PICKUP  (0x5BC9495F0B3B6FA6)
+-- min build: 1207
+---@param pickup number
+---@return boolean
+function NetworkHasControlOfPickup(pickup) end
+
+-- NETWORK_HAS_CONTROL_OF_PICKUP_PLACEMENT  (0x51EABCF2786515AB)
+-- min build: 1311
+---@param p0 any
+---@return boolean
+function NetworkHasControlOfPickupPlacement(p0) end
+
+-- NETWORK_HAS_ENTITY_BEEN_REGISTERED_WITH_THIS_THREAD  (0xB07D3185E11657A5)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function NetworkHasEntityBeenRegisteredWithThisThread(entity) end
+
+-- NETWORK_HAS_PENDING_INVITE_FAILURE  (0xD0498AD30E16B6BD)
+-- min build: 1207
+---@return boolean
+function NetworkHasPendingInviteFailure() end
+
+-- NETWORK_HAS_RECEIVED_HOST_BROADCAST_DATA  (0x5D10B3795F3FC886)
+-- min build: 1207
+---@return boolean
+function NetworkHasReceivedHostBroadcastData() end
+
+-- NETWORK_HAS_ROS_PRIVILEGE  (0xA699957E60D80214)
+-- min build: 1207
+---@param index number
+---@return boolean
+function NetworkHasRosPrivilege(index) end
+
+-- NETWORK_HAS_SOCIAL_CLUB_ACCOUNT  (0x67A5589628E0CFF6)
+-- min build: 1207
+---@return boolean
+function NetworkHasSocialClubAccount() end
+
+-- NETWORK_HAS_VALID_ROS_CREDENTIALS  (0x85443FF4C328F53B)
+-- Returns whether the signed-in user has valid Rockstar Online Services (ROS) credentials.
+-- min build: 1207
+---@return boolean
+function NetworkHasValidRosCredentials() end
+
+-- NETWORK_HASH_FROM_PLAYER_HANDLE  (0xBC1D768F2F5D6C05)
+-- min build: 1207
+---@param player number
+---@return number
+function NetworkHashFromPlayerHandle(player) end
+
+-- NETWORK_HAVE_ONLINE_PRIVILEGES  (0x25CB5A9F37BFD063)
+-- min build: 1207
+---@return boolean
+function NetworkHaveOnlinePrivileges() end
+
+-- NETWORK_HAVE_ROS_BANNED_PRIV  (0x8020A73847E0CA7D)
+-- min build: 1207
+---@return boolean
+function NetworkHaveRosBannedPriv() end
+
+-- NETWORK_IS_AIM_CAM_ACTIVE  (0x8E7CE19219669AEB)
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsAimCamActive(player) end
+
+-- NETWORK_IS_CLOCK_TIME_OVERRIDDEN  (0xD7C95D322FF57522)
+-- min build: 1207
+---@return boolean
+function NetworkIsClockTimeOverridden() end
+
+-- NETWORK_IS_CLOUD_AVAILABLE  (0x9A4CF4F48AD77302)
+-- min build: 1207
+---@return boolean
+function NetworkIsCloudAvailable() end
+
+-- NETWORK_IS_CONNECTED_VIA_RELAY  (0x16D3D49902F697BB)
+-- Old name: _NETWORK_IS_CONNECTION_ENDPOINT_RELAY_SERVER
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsConnectedViaRelay(player) end
+
+-- NETWORK_IS_CUSTOM_UPSELL_ENABLED  (0x78A9535AF83715C6)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function NetworkIsCustomUpsellEnabled() end
+
+-- NETWORK_IS_FEATURE_SUPPORTED  (0x9C725D149622BFDE)
+-- min build: 1207
+---@param featureId number
+---@return boolean
+function NetworkIsFeatureSupported(featureId) end
+
+-- NETWORK_IS_FINDING_GAMERS  (0xDDDF64C91BFCF0AA)
+-- min build: 1207
+---@return boolean
+function NetworkIsFindingGamers() end
+
+-- NETWORK_IS_FRIEND  (0x1A24A179F9B31654)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkIsFriend() end
+
+-- NETWORK_IS_GAME_IN_PROGRESS  (0x10FAB35428CCC9D7)
+-- min build: 1207
+---@return boolean
+function NetworkIsGameInProgress() end
+
+-- NETWORK_IS_GAMER_IN_MY_SESSION  (0x0F10B05DDF8D16E9)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkIsGamerInMySession() end
+
+-- NETWORK_IS_HANDLE_VALID  (0x6F79B93B0A8E4133)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkIsHandleValid() end
+
+-- NETWORK_IS_HOST  (0x8DB296B814EDDA07)
+-- If you are host, returns true else returns false.
+-- min build: 1207
+---@return boolean
+function NetworkIsHost() end
+
+-- NETWORK_IS_HOST_OF_THIS_SCRIPT  (0x83CD99A1E6061AB5)
+-- min build: 1207
+---@return boolean
+function NetworkIsHostOfThisScript() end
+
+-- NETWORK_IS_IN_MP_CUTSCENE  (0x6CC27C9FA2040220)
+-- min build: 1207
+---@return boolean
+function NetworkIsInMpCutscene() end
+
+-- NETWORK_IS_IN_PLATFORM_PARTY  (0x2FC5650B0271CB57)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function NetworkIsInPlatformParty() end
+
+-- NETWORK_IS_IN_PLATFORM_PARTY_CHAT  (0xFD8B834A8BA05048)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function NetworkIsInPlatformPartyChat() end
+
+-- NETWORK_IS_IN_SESSION  (0xCA97246103B63917)
+-- min build: 1207
+---@return boolean
+function NetworkIsInSession() end
+
+-- NETWORK_IS_IN_SPECTATOR_MODE  (0x048746E388762E11)
+-- min build: 1207
+---@return boolean
+function NetworkIsInSpectatorMode() end
+
+-- NETWORK_IS_IN_TUTORIAL_SESSION  (0xADA24309FE08DACF)
+-- min build: 1207
+---@return boolean
+function NetworkIsInTutorialSession() end
+
+-- NETWORK_IS_PARTICIPANT_ACTIVE  (0x6FF8FF40B6357D45)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function NetworkIsParticipantActive(p0) end
+
+-- NETWORK_IS_PENDING_FRIEND  (0x0BE73DA6984A6E33)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkIsPendingFriend() end
+
+-- NETWORK_IS_PLATFORM_INVITE_PENDING  (0xFC4165C9165C166F)
+-- min build: 1207
+---@return boolean
+function NetworkIsPlatformInvitePending() end
+
+-- NETWORK_IS_PLAYER_A_PARTICIPANT  (0x3CA58F6CB7CBD784)
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsPlayerAParticipant(player) end
+
+-- NETWORK_IS_PLAYER_A_PARTICIPANT_ON_SCRIPT  (0x1AD5B71586B94820)
+-- min build: 1207
+---@param p0 number
+---@param p2 any
+---@return boolean
+---@return any
+function NetworkIsPlayerAParticipantOnScript(p0, p2) end
+
+-- NETWORK_IS_PLAYER_ACTIVE  (0xB8DFD30D6973E135)
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsPlayerActive(player) end
+
+-- NETWORK_IS_PLAYER_CONCEALED  (0x919B3C98ED8292F9)
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsPlayerConcealed(player) end
+
+-- NETWORK_IS_PLAYER_CONNECTED  (0x93DC1BE4E1ABE9D1)
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsPlayerConnected(player) end
+
+-- NETWORK_IS_PLAYER_IN_MP_CUTSCENE  (0x63F9EE203C3619F2)
+-- Note: scripts seem to indicate that this was renamed to NETWORK_IS_PLAYER_IN_MP_FAST_INSTANCE
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsPlayerInMpCutscene(player) end
+
+-- NETWORK_IS_PLAYER_INDEX_VALID  (0x255A5EF65EDA9167)
+-- Returns true if the passed value is less than 32.
+-- min build: 1207
+---@param player number
+---@return boolean
+function NetworkIsPlayerIndexValid(player) end
+
+-- NETWORK_IS_PROMOTION_ENABLED  (0x8FF6059DA26E688A)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function NetworkIsPromotionEnabled() end
+
+-- NETWORK_IS_RESETTING_POPULATION  (0x1BB50CD340A996E6)
+-- min build: 1207
+---@return boolean
+function NetworkIsResettingPopulation() end
+
+-- NETWORK_IS_SCRIPT_ACTIVE  (0x9D40DF90FAD26098)
+-- min build: 1207
+---@param scriptName string
+---@param p1 number
+---@param p2 boolean
+---@param p3 number
+---@return boolean
+function NetworkIsScriptActive(scriptName, p1, p2, p3) end
+
+-- NETWORK_IS_SCRIPT_ACTIVE_BY_HASH  (0x1B89BC43B6E69107)
+-- min build: 1207
+---@param scriptHash number
+---@param p1 number
+---@param p2 boolean
+---@param p3 number
+---@return boolean
+function NetworkIsScriptActiveByHash(scriptHash, p1, p2, p3) end
+
+-- NETWORK_IS_SESSION_ACTIVE  (0xD83C2B94E7508980)
+-- min build: 1207
+---@return boolean
+function NetworkIsSessionActive() end
+
+-- NETWORK_IS_SESSION_STARTED  (0x9DE624D2FC4B603F)
+-- min build: 1207
+---@return boolean
+function NetworkIsSessionStarted() end
+
+-- NETWORK_IS_SIGNED_ONLINE  (0x1077788E268557C2)
+-- min build: 1207
+---@return boolean
+function NetworkIsSignedOnline() end
+
+-- NETWORK_IS_TUNABLE_CLOUD_REQUEST_PENDING  (0x0467C11ED88B7D28)
+-- min build: 1207
+---@return boolean
+function NetworkIsTunableCloudRequestPending() end
+
+-- NETWORK_IS_TUTORIAL_SESSION_CHANGE_PENDING  (0x35F0B98A8387274D)
+-- min build: 1207
+---@return boolean
+function NetworkIsTutorialSessionChangePending() end
+
+-- NETWORK_PREVENT_SCRIPT_HOST_MIGRATION  (0x2302C0264EA58D31)
+-- min build: 1207
+function NetworkPreventScriptHostMigration() end
+
+-- NETWORK_REFRESH_CURRENT_FRIEND_PAGE  (0x1F51F367B710A832)
+-- min build: 1207
+---@return boolean
+function NetworkRefreshCurrentFriendPage() end
+
+-- NETWORK_REGISTER_ENTITY_AS_NETWORKED  (0x06FAACD625D80CAA)
+-- min build: 1207
+---@param entity number
+function NetworkRegisterEntityAsNetworked(entity) end
+
+-- NETWORK_REGISTER_HOST_BROADCAST_VARIABLES  (0x3E9B2F01C50DF595)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function NetworkRegisterHostBroadcastVariables(p0, p1, p2) end
+
+-- NETWORK_REGISTER_PLAYER_BROADCAST_VARIABLES  (0x3364AA97340CA215)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function NetworkRegisterPlayerBroadcastVariables(p0, p1, p2) end
+
+-- NETWORK_REQUEST_CLOUD_TUNABLES  (0x42FB3B532D526E6C)
+-- Note: this native was added in build 1311.23, but was only used after build 1436.25
+-- min build: 1311
+function NetworkRequestCloudTunables() end
+
+-- NETWORK_REQUEST_CONTROL_OF_ENTITY  (0xB69317BF5E782347)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function NetworkRequestControlOfEntity(entity) end
+
+-- NETWORK_REQUEST_CONTROL_OF_NETWORK_ID  (0xA670B3662FAFFBD0)
+-- min build: 1207
+---@param netId number
+---@return boolean
+function NetworkRequestControlOfNetworkId(netId) end
+
+-- NETWORK_REQUEST_CONTROL_OF_PICKUP_PLACEMENT  (0x56ED2C48558DAB78)
+-- min build: 1311
+---@param p0 any
+---@return boolean
+function NetworkRequestControlOfPickupPlacement(p0) end
+
+-- NETWORK_REQUEST_JOIN  (0xE483BB6BE686F632)
+-- min build: 1207
+---@param p0 any
+---@return number
+function NetworkRequestJoin(p0) end
+
+-- NETWORK_REQUEST_RECENT_GAMER_NAMES  (0x6D206D383BB5F6B1)
+-- min build: 1207
+---@param p0 number
+---@param playerCount number
+---@return boolean
+function NetworkRequestRecentGamerNames(p0, playerCount) end
+
+-- NETWORK_REQUEST_SESSION_SEAMLESS  (0x04019AE4956D4393)
+-- flags:
+-- enum eSessionRequestOptionFlags
+-- {
+-- 	SESSION_REQUEST_OPTION_FLAG_INCLUDE_GANG_MEMBERS = (1 << 1),
+-- 	SESSION_REQUEST_OPTION_FLAG_LEADER_KEEPS_GANG = (1 << 7),
+-- };
+-- 
+-- seamlessType:
+-- enum eSeamlessType
+-- {
+-- 	SEAMLESS_TYPE_NORMAL,
+-- 	SEAMLESS_TYPE_PVE,
+-- 	SEAMLESS_TYPE_DEV,
+-- 	SEAMLESS_TYPE_NO_SEAMLESS
+-- };
+-- min build: 1207
+---@param flags number
+---@param seamlessType number
+---@return boolean
+---@return any
+function NetworkRequestSessionSeamless(flags, seamlessType) end
+
+-- NETWORK_RESET_POPULATION  (0x101F538C25ABB39A)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 number
+---@return boolean
+function NetworkResetPopulation(p0, p1) end
+
+-- NETWORK_RESURRECT_LOCAL_PLAYER  (0xEA23C49EAA83ACFB)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p4 number
+---@param p5 boolean
+---@param p6 any
+---@param p7 boolean
+function NetworkResurrectLocalPlayer(x, y, z, heading, p4, p5, p6, p7) end
+
+-- NETWORK_SEED_RANDOM_NUMBER_GENERATOR  (0xF1B84178F8674195)
+-- min build: 1207
+---@param seed number
+function NetworkSeedRandomNumberGenerator(seed) end
+
+-- NETWORK_SESSION_GET_SESSION_FLAGS  (0x51F33DBC1A41CBFD)
+-- min build: 1207
+---@return number
+function NetworkSessionGetSessionFlags() end
+
+-- NETWORK_SESSION_GET_SESSION_TYPE  (0xF0C0C94B404206FA)
+-- min build: 1207
+---@return number
+function NetworkSessionGetSessionType() end
+
+-- NETWORK_SESSION_IS_ANY_REQUEST_IN_PROGRESS  (0xBAFFDE5F953720D9)
+-- min build: 1207
+---@return boolean
+function NetworkSessionIsAnyRequestInProgress() end
+
+-- NETWORK_SESSION_IS_PRIVATE  (0xCEF70AA5B3F89BA1)
+-- Checks for session flag 'SF_PRIVATE'
+-- min build: 1207
+---@return boolean
+function NetworkSessionIsPrivate() end
+
+-- NETWORK_SESSION_IS_REQUEST_IN_PROGRESS  (0x8FB7C254CFCBF78E)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkSessionIsRequestInProgress() end
+
+-- NETWORK_SESSION_IS_REQUEST_PENDING_TRANSITION  (0xCCF878D50F8AB10D)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkSessionIsRequestPendingTransition() end
+
+-- NETWORK_SESSION_IS_SESSION_REQUEST_ID_VALID  (0x2F54B146D3EDCE4D)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkSessionIsSessionRequestIdValid() end
+
+-- NETWORK_SESSION_IS_TRANSITIONING  (0xF2CBC969C4F090C7)
+-- min build: 1207
+---@return boolean
+function NetworkSessionIsTransitioning() end
+
+-- NETWORK_SESSION_LEAVE_SESSION  (0x17C21B7319A05047)
+-- min build: 1207
+---@return boolean
+function NetworkSessionLeaveSession() end
+
+-- NETWORK_SESSION_LEFT_QUEUE_OR_REQUESTED_SESSION  (0xECE6A0C1B59CD8BE)
+-- min build: 1207
+---@return boolean
+---@return any
+function NetworkSessionLeftQueueOrRequestedSession() end
+
+-- NETWORK_SESSION_REMOVE_SESSION_FLAGS  (0x78335E12DB0BF961)
+-- See _NETWORK_SESSION_ADD_SESSION_FLAGS
+-- min build: 1207
+---@param flags number
+---@return boolean
+function NetworkSessionRemoveSessionFlags(flags) end
+
+-- NETWORK_SESSION_REQUEST_SESSION_COMPETITIVE  (0x309BBEBEA8A3986C)
+-- matchType:
+-- enum eMatchType
+-- {
+-- 	MATCHTYPE_DEPRECATED,
+-- 	MATCHTYPE_UGCPLAYLIST,
+-- 	MATCHTYPE_UGCMISSION,
+-- 	MATCHTYPE_MINIGAME,
+-- 	MATCHTYPE_SEAMLESS,
+-- 	MATCHTYPE_PRIVATE_DO_NOT_USE
+-- };
+-- min build: 1207
+---@param flags number
+---@param matchType number
+---@param userHash number
+---@param p3 number
+---@return boolean
+---@return any
+function NetworkSessionRequestSessionCompetitive(flags, matchType, userHash, p3) end
+
+-- NETWORK_SESSION_REQUEST_SESSION_PRIVATE  (0x39A8EF7AF29A192C)
+-- Session flag 'SF_PRIVATE' is set internally
+-- p1 represents max amount of players in private session
+-- min build: 1207
+---@param flags number
+---@param numPlayers number
+---@param userHash number
+---@return boolean
+---@return any
+function NetworkSessionRequestSessionPrivate(flags, numPlayers, userHash) end
+
+-- NETWORK_SESSION_REQUEST_SESSION_SEAMLESS  (0x2989E131FDE37E97)
+-- Equivalent to NETWORK_REQUEST_SESSION_SEAMLESS if userHash == 0.
+-- Otherwise it is equivalent to NETWORK_SESSION_REQUEST_SESSION_COMPETITIVE(flags, MATCHTYPE_SEAMLESS, userHash, 0, sessionRequestId);
+-- 
+-- p1 is unused
+-- min build: 1207
+---@param flags number
+---@param seamlessType number
+---@param userHash number
+---@return boolean
+---@return any
+function NetworkSessionRequestSessionSeamless(flags, seamlessType, userHash) end
+
+-- NETWORK_SET_COMPLETED_MP_INTRO_FLOW_ON_CURRENT_SLOT  (0x2C5BD9A43987AA27)
+-- min build: 1207
+---@param completed boolean
+---@return boolean
+function NetworkSetCompletedMpIntroFlowOnCurrentSlot(completed) end
+
+-- NETWORK_SET_ENTITY_ONLY_EXISTS_FOR_PARTICIPANTS  (0xF1CA12B18AEF5298)
+-- if set to true other network players can't see it
+-- if set to false other network player can see it
+-- =========================================
+-- ^^ I attempted this by grabbing an object with GET_ENTITY_PLAYER_IS_FREE_AIMING_AT and setting this naive no matter the toggle he could still see it.
+-- 
+-- pc or last gen?
+-- 
+-- ^^ last-gen
+-- 
+-- Old name: _NETWORK_SET_ENTITY_INVISIBLE_TO_NETWORK
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function NetworkSetEntityOnlyExistsForParticipants(entity, toggle) end
+
+-- NETWORK_SET_ENTITY_REMAINS_WHEN_UNNETWORKED  (0xD785864798258032)
+-- min build: 1207
+---@param entity number
+---@param toggle boolean
+function NetworkSetEntityRemainsWhenUnnetworked(entity, toggle) end
+
+-- NETWORK_SET_FRIENDLY_FIRE_OPTION  (0xF808475FA571D823)
+-- min build: 1207
+---@param toggle boolean
+function NetworkSetFriendlyFireOption(toggle) end
+
+-- NETWORK_SET_IN_MP_CUTSCENE  (0x9CA5DE655269FEC4)
+-- min build: 1207
+---@param p0 boolean
+---@param p1 boolean
+---@param p2 number
+---@param p3 boolean
+function NetworkSetInMpCutscene(p0, p1, p2, p3) end
+
+-- NETWORK_SET_IN_SPECTATOR_MODE  (0x423DE3854BB50894)
+-- min build: 1207
+---@param toggle boolean
+---@param playerPed number
+function NetworkSetInSpectatorMode(toggle, playerPed) end
+
+-- NETWORK_SET_LOCAL_PLAYER_INVINCIBLE_TIME  (0x2D95C7E2D7E07307)
+-- min build: 1207
+---@param time number
+function NetworkSetLocalPlayerInvincibleTime(time) end
+
+-- NETWORK_SET_LOCAL_PLAYER_PENDING_FAST_INSTANCE_ID  (0x007FF852DCF49DA4)
+-- min build: 1207
+---@param instanceId number
+function NetworkSetLocalPlayerPendingFastInstanceId(instanceId) end
+
+-- NETWORK_SET_LOCAL_PLAYER_SYNC_LOOK_AT  (0x524FF0AEFF9C3973)
+-- min build: 1207
+---@param toggle boolean
+function NetworkSetLocalPlayerSyncLookAt(toggle) end
+
+-- NETWORK_SET_MISSION_FINISHED  (0x3B3D11CD9FFCDFC9)
+-- min build: 1207
+function NetworkSetMissionFinished() end
+
+-- NETWORK_SET_MP_MISSION_FLAG_ON_CURRENT_SLOT  (0x86FD10251A7118A4)
+-- min build: 1207
+---@param enabled boolean
+---@param flagIndex number
+---@return boolean
+function NetworkSetMpMissionFlagOnCurrentSlot(enabled, flagIndex) end
+
+-- NETWORK_SET_PLAYER_IS_PASSIVE  (0x9C25E8EC4C535FBD)
+-- Old name: _NETWORK_SET_PASSIVE_MODE_OPTION
+-- min build: 1207
+---@param toggle boolean
+function NetworkSetPlayerIsPassive(toggle) end
+
+-- NETWORK_SET_RECENT_GAMERS_ENABLED  (0x29FE035D35B8589C)
+-- min build: 1207
+---@param toggle boolean
+function NetworkSetRecentGamersEnabled(toggle) end
+
+-- NETWORK_SET_RICH_PRESENCE  (0x1DCCACDCFC569362)
+-- min build: 1207
+---@param p0 number
+---@param p2 number
+---@param p3 number
+---@return any
+function NetworkSetRichPresence(p0, p2, p3) end
+
+-- NETWORK_SET_SCRIPT_READY_FOR_EVENTS  (0x7AC752103856FB20)
+-- min build: 1207
+---@param toggle boolean
+function NetworkSetScriptReadyForEvents(toggle) end
+
+-- NETWORK_SET_THIS_SCRIPT_IS_NETWORK_SCRIPT  (0x1CA59E306ECB80A5)
+-- min build: 1207
+---@param maxNumMissionParticipants number
+---@param p1 boolean
+---@param instanceId number
+function NetworkSetThisScriptIsNetworkScript(maxNumMissionParticipants, p1, instanceId) end
+
+-- NETWORK_SHOULD_SHOW_PROMOTION_DLG  (0xDA4B1A479C414FB2)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function NetworkShouldShowPromotionDlg() end
+
+-- NETWORK_SHOW_ACCOUNT_UPGRADE_UI  (0x83FE8D7229593017)
+-- min build: 1207
+function NetworkShowAccountUpgradeUi() end
+
+-- NETWORK_SHOW_CHAT_RESTRICTION_MSC  (0x6BFF5F84102DF80A)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param player number
+function NetworkShowChatRestrictionMsc(player) end
+
+-- NETWORK_SHOW_PROFILE_UI  (0x859ED1CEA343FCA8)
+-- min build: 1207
+---@return any
+function NetworkShowProfileUi() end
+
+-- NETWORK_SHOW_PSN_UGC_RESTRICTION  (0x5C497525F803486B)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function NetworkShowPsnUgcRestriction() end
+
+-- NETWORK_SPAWN_CONFIG_SET_FLAGS  (0xF94A0D5B254375DF)
+-- min build: 1207
+---@param flags number
+function NetworkSpawnConfigSetFlags(flags) end
+
+-- NETWORK_SPAWN_CONFIG_SET_GROUND_TO_ROOT_OFFSET  (0x59577799F6AE2F34)
+-- min build: 1207
+---@param offset number
+function NetworkSpawnConfigSetGroundToRootOffset(offset) end
+
+-- NETWORK_SPAWN_CONFIG_SET_TUNING_FLOAT  (0x0608326F7B98C08D)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function NetworkSpawnConfigSetTuningFloat(p0, p1) end
+
+-- NETWORK_START_SOLO_TUTORIAL_SESSION  (0x17E0198B3882C2CB)
+-- min build: 1207
+function NetworkStartSoloTutorialSession() end
+
+-- NETWORK_START_USER_CONTENT_PERMISSIONS_CHECK  (0xDEB2B99A1AF1A2A6)
+-- Always returns -1. Seems to be XB1 specific.
+-- min build: 1207
+---@return number
+---@return any
+function NetworkStartUserContentPermissionsCheck() end
+
+-- NETWORK_TRIGGER_DAMAGE_EVENT_FOR_ZERO_DAMAGE  (0x0C8BC052AE87D744)
+-- Old name: _NETWORK_SET_VEHICLE_WHEELS_DESTRUCTIBLE
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+function NetworkTriggerDamageEventForZeroDamage(entity, p1) end
+
+-- NETWORK_TRY_ACCESS_TUNABLE_BOOL_HASH  (0xB2AD5D29A99D4B26)
+-- min build: 1207
+---@param tunableContext number
+---@param tunableName number
+---@param defaultValue boolean
+---@return boolean
+function NetworkTryAccessTunableBoolHash(tunableContext, tunableName, defaultValue) end
+
+-- NETWORK_TRY_ACCESS_TUNABLE_FLOAT_HASH  (0xA18393089C05E49C)
+-- min build: 1207
+---@param tunableContext number
+---@param tunableName number
+---@param defaultValue number
+---@return number
+function NetworkTryAccessTunableFloatHash(tunableContext, tunableName, defaultValue) end
+
+-- NETWORK_TRY_ACCESS_TUNABLE_INT_HASH  (0xA25E006B36719774)
+-- min build: 1207
+---@param tunableContext number
+---@param tunableName number
+---@param defaultValue number
+---@return number
+function NetworkTryAccessTunableIntHash(tunableContext, tunableName, defaultValue) end
+
+-- OBJ_TO_NET  (0x99BFDC94A603E541)
+-- Returns the network ID of the given object.
+-- min build: 1207
+---@param object number
+---@return number
+function ObjToNet(object) end
+
+-- PARTICIPANT_ID  (0x90986E8876CE0A83)
+-- Return the local Participant ID
+-- min build: 1207
+---@return number
+function ParticipantId() end
+
+-- PARTICIPANT_ID_TO_INT  (0x57A3BDDAD8E5AA0A)
+-- Return the local Participant ID.
+-- 
+-- This native is exactly the same as 'PARTICIPANT_ID' native.
+-- min build: 1207
+---@return number
+function ParticipantIdToInt() end
+
+-- PED_TO_NET  (0x0EDEC3C276198689)
+-- Returns the network ID of the given ped.
+-- min build: 1207
+---@param ped number
+---@return number
+function PedToNet(ped) end
+
+-- PREVENT_MIGRATION_OF_ENTITIES_IN_FAST_INSTANCE_FOR_LOCAL_PLAYER  (0x89D803CD48622150)
+-- min build: 1207
+---@param toggle boolean
+function PreventMigrationOfEntitiesInFastInstanceForLocalPlayer(toggle) end
+
+-- PREVENT_NETWORK_ID_MIGRATION  (0x7182EDDA1EE7DB5A)
+-- min build: 1207
+---@param netId number
+function PreventNetworkIdMigration(netId) end
+
+-- RESERVE_NETWORK_CLIENT_MISSION_OBJECTS  (0xE7DDA8BD3BCF751C)
+-- min build: 1207
+---@param amount number
+function ReserveNetworkClientMissionObjects(amount) end
+
+-- RESERVE_NETWORK_CLIENT_MISSION_PEDS  (0x807E119F80231732)
+-- min build: 1207
+---@param amount number
+function ReserveNetworkClientMissionPeds(amount) end
+
+-- RESERVE_NETWORK_MISSION_OBJECTS  (0x4E5C93BD0C32FBF8)
+-- min build: 1207
+---@param amount number
+function ReserveNetworkMissionObjects(amount) end
+
+-- RESERVE_NETWORK_MISSION_PEDS  (0xB60FEBA45333D36F)
+-- min build: 1207
+---@param amount number
+function ReserveNetworkMissionPeds(amount) end
+
+-- RESERVE_NETWORK_MISSION_PICKUPS  (0x4D40E7D749BC6E6D)
+-- min build: 1207
+---@param amount number
+function ReserveNetworkMissionPickups(amount) end
+
+-- RESERVE_NETWORK_MISSION_VEHICLES  (0x76B02E21ED27A469)
+-- min build: 1207
+---@param amount number
+function ReserveNetworkMissionVehicles(amount) end
+
+-- SET_ENTITY_VISIBLE_IN_CUTSCENE  (0xE0031D3C8F36AB82)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 number
+function SetEntityVisibleInCutscene(entity, p1, p2, p3) end
+
+-- SET_LOCAL_PLAYER_AS_GHOST  (0x5FFE9B4144F9712F)
+-- Old name: _SET_LOCAL_PLAYER_AS_GHOST
+-- min build: 1207
+---@param toggle boolean
+function SetLocalPlayerAsGhost(toggle) end
+
+-- SET_LOCAL_PLAYER_INVISIBLE_LOCALLY  (0xE5F773C1A1D9D168)
+-- min build: 1207
+---@param p0 boolean
+function SetLocalPlayerInvisibleLocally(p0) end
+
+-- SET_LOCAL_PLAYER_VISIBLE_IN_CUTSCENE  (0xD1065D68947E7B6E)
+-- min build: 1207
+---@param local_ boolean
+---@param remote boolean
+---@param instanceId number
+function SetLocalPlayerVisibleInCutscene(local_, remote, instanceId) end
+
+-- SET_NETWORK_ID_ALWAYS_EXISTS_FOR_PLAYER  (0xA8A024587329F36A)
+-- min build: 1207
+---@param netId number
+---@param player number
+---@param toggle boolean
+function SetNetworkIdAlwaysExistsForPlayer(netId, player, toggle) end
+
+-- SET_NETWORK_ID_EXISTS_ON_ALL_MACHINES  (0xE05E81A888FA63C8)
+-- min build: 1207
+---@param netId number
+---@param toggle boolean
+function SetNetworkIdExistsOnAllMachines(netId, toggle) end
+
+-- SET_NETWORK_ID_STOP_CLONING  (0x9ED3108D6847760A)
+-- min build: 1207
+---@param networkId number
+---@param bStopCloning boolean
+function SetNetworkIdStopCloning(networkId, bStopCloning) end
+
+-- SET_NETWORK_ID_VISIBLE_IN_CUTSCENE  (0xA6928482543022B4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function SetNetworkIdVisibleInCutscene(p0, p1, p2, p3) end
+
+-- SET_PLAYER_INVISIBLE_LOCALLY  (0x12B37D54667DB0B8)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerInvisibleLocally(player, toggle) end
+
+-- SET_PLAYER_VISIBLE_LOCALLY  (0xFAA10F1FAFB11AF2)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerVisibleLocally(player, toggle) end
+
+-- TEXTURE_DOWNLOAD_GET_NAME  (0x3448505B6E35262D)
+-- min build: 1207
+---@param textureDownloadId number
+---@return string
+function TextureDownloadGetName(textureDownloadId) end
+
+-- TEXTURE_DOWNLOAD_RELEASE  (0x487EB90B98E9FB19)
+-- min build: 1207
+---@param textureDownloadId number
+function TextureDownloadRelease(textureDownloadId) end
+
+-- TEXTURE_DOWNLOAD_REQUEST  (0x16160DA74A8E74A2)
+-- Returns textureDownloadId
+-- min build: 1207
+---@param filePath string
+---@param name string
+---@param p3 boolean
+---@return number
+---@return any
+function TextureDownloadRequest(filePath, name, p3) end
+
+-- UGC_CLEAR_QUERY_RESULTS  (0xE931354FEA710038)
+-- min build: 1207
+---@param ugcRequestId number
+function UgcClearQueryResults(ugcRequestId) end
+
+-- UGC_DID_DESCRIPTION_REQUEST_SUCCEED  (0x162C23CA83ED0A62)
+-- min build: 1207
+---@param description number
+---@return boolean
+function UgcDidDescriptionRequestSucceed(description) end
+
+-- UGC_DID_REQUEST_SUCCEED  (0x0B6009A90B8495F1)
+-- min build: 1207
+---@param ugcRequestId number
+---@return boolean
+function UgcDidRequestSucceed(ugcRequestId) end
+
+-- UGC_GET_CACHED_DESCRIPTION  (0x40F7E66472DF3E5C)
+-- min build: 1207
+---@param description number
+---@param length number
+---@return string
+function UgcGetCachedDescription(description, length) end
+
+-- UGC_HAS_DESCRIPTION_REQUEST_FINISHED  (0xEBFA8D50ADDC54C4)
+-- min build: 1207
+---@param description number
+---@return boolean
+function UgcHasDescriptionRequestFinished(description) end
+
+-- UGC_HAS_REQUEST_FINISHED  (0xA9EB4D606076615D)
+-- min build: 1207
+---@param ugcRequestId number
+---@return boolean
+function UgcHasRequestFinished(ugcRequestId) end
+
+-- UGC_IS_DESCRIPTION_REQUEST_IN_PROGRESS  (0x2D5DC831176D0114)
+-- min build: 1207
+---@param description number
+---@return boolean
+function UgcIsDescriptionRequestInProgress(description) end
+
+-- UGC_IS_LANGUAGE_SUPPORTED  (0xF53E48461B71EECB)
+-- min build: 1207
+---@param languageId number
+---@return boolean
+function UgcIsLanguageSupported(languageId) end
+
+-- UGC_IS_REQUEST_PENDING  (0xF4AC4FA844FD559A)
+-- min build: 1207
+---@param ugcRequestId number
+---@return boolean
+function UgcIsRequestPending(ugcRequestId) end
+
+-- UGC_QUERY_GET_CONTENT_HAS_PLAYER_RECORD  (0xF794765390A6DCA5)
+-- min build: 1207
+---@param p0 any
+---@param index number
+---@return boolean
+function UgcQueryGetContentHasPlayerRecord(p0, index) end
+
+-- UGC_QUERY_GET_CONTENT_NUM  (0x76160E0396142765)
+-- min build: 1207
+---@param ugcRequestId number
+---@return number
+function UgcQueryGetContentNum(ugcRequestId) end
+
+-- UGC_QUERY_WAS_FORCE_CANCELLED  (0xF8F0705E77A0E705)
+-- min build: 1207
+---@param ugcRequestId number
+---@return boolean
+function UgcQueryWasForceCancelled(ugcRequestId) end
+
+-- UGC_RELEASE_ALL_CACHED_DESCRIPTIONS  (0x68103E2247887242)
+-- min build: 1207
+function UgcReleaseAllCachedDescriptions() end
+
+-- UGC_RELEASE_CACHED_DESCRIPTION  (0x5A34CD9C3C5BEC44)
+-- min build: 1207
+---@param description number
+---@return boolean
+function UgcReleaseCachedDescription(description) end
+
+-- UGC_REQUEST_CACHED_DESCRIPTION  (0x5E0165278F6339EE)
+-- min build: 1207
+---@param description number
+---@return number
+function UgcRequestCachedDescription(description) end
+
+-- UGC_REQUEST_CONTENT_DATA_FROM_PARAMS  (0x7FD2990AF016795E)
+-- min build: 1207
+---@param contentTypeName string
+---@param contentId string
+---@param fileId number
+---@param fileVersion number
+---@param languageId number
+---@return number
+function UgcRequestContentDataFromParams(contentTypeName, contentId, fileId, fileVersion, languageId) end
+
+-- UGC_SET_QUERY_DATA_FROM_OFFLINE  (0xF98DDE0A8ED09323)
+-- min build: 1207
+---@param p0 boolean
+function UgcSetQueryDataFromOffline(p0) end
+
+-- UGC_TEXTURE_DOWNLOAD_REQUEST  (0x308F96458B7087CC)
+-- min build: 1207
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p5 boolean
+---@return number
+---@return any
+---@return any
+function UgcTextureDownloadRequest(p1, p2, p3, p5) end
+
+-- VEH_TO_NET  (0xB4C94523F023419C)
+-- Returns the network ID of the given vehicle.
+-- min build: 1207
+---@param vehicle number
+---@return number
+function VehToNet(vehicle) end

--- a/.luals/redm-natives/OBJECT.lua
+++ b/.luals/redm-natives/OBJECT.lua
@@ -1,0 +1,1152 @@
+---@meta
+
+-- RDR3 namespace: OBJECT -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x08C5825A2932EA7B  (0x08C5825A2932EA7B)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x08C5825A2932EA7B(p0) end
+
+-- _0x0C0A373D181BF900  (0x0C0A373D181BF900)
+-- min build: 1207
+---@param p0 any
+function N_0x0C0A373D181BF900(p0) end
+
+-- _0x1F5E07E14A86FAFC  (0x1F5E07E14A86FAFC)
+-- _SET_A(MBIENT_PICKUP_?)*
+-- min build: 1207
+---@param p0 boolean
+function N_0x1F5E07E14A86FAFC(p0) end
+
+-- _0x20135AF9C10D2A3D  (0x20135AF9C10D2A3D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x20135AF9C10D2A3D(p0) end
+
+-- _0x22031584496CFB70  (0x22031584496CFB70)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x22031584496CFB70(p0, p1) end
+
+-- _0x235C863DA77BD88D  (0x235C863DA77BD88D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x235C863DA77BD88D(p0, p1, p2) end
+
+-- _0x250EBB11E81A10BE  (0x250EBB11E81A10BE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x250EBB11E81A10BE(p0) end
+
+-- _0x2BF1953C0C21AC88  (0x2BF1953C0C21AC88)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2BF1953C0C21AC88(p0) end
+
+-- _0x3A77DAE8B4FD7586  (0x3A77DAE8B4FD7586)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3A77DAE8B4FD7586(p0, p1) end
+
+-- _0x3DF1A0A58498E209  (0x3DF1A0A58498E209)
+-- _SET_FORCE* - _SET_LOCAL*
+-- min build: 1436
+---@param object number
+---@param p1 boolean
+function N_0x3DF1A0A58498E209(object, p1) end
+
+-- _0x3E2616E7EA539480  (0x3E2616E7EA539480)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x3E2616E7EA539480(p0) end
+
+-- _0x46CBCF0E98A4E156  (0x46CBCF0E98A4E156)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x46CBCF0E98A4E156(p0, p1) end
+
+-- _0x491439AEF410A2FC  (0x491439AEF410A2FC)
+-- min build: 1207
+---@param p0 any
+function N_0x491439AEF410A2FC(p0) end
+
+-- _0x4AE07EBA3462C5D5  (0x4AE07EBA3462C5D5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x4AE07EBA3462C5D5(p0, p1) end
+
+-- _0x57C242543B7B8FB9  (0x57C242543B7B8FB9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x57C242543B7B8FB9(p0, p1) end
+
+-- _0x614D0B4533F842D3  (0x614D0B4533F842D3)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x614D0B4533F842D3(p0) end
+
+-- _0x6579860A5558524A  (0x6579860A5558524A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x6579860A5558524A(p0, p1) end
+
+-- _0x7D4411D6736CD295  (0x7D4411D6736CD295)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x7D4411D6736CD295(p0, p1) end
+
+-- _0x7F458B543006C8FE  (0x7F458B543006C8FE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x7F458B543006C8FE(p0, p1) end
+
+-- _0x9A74A9CADFA8A598  (0x9A74A9CADFA8A598)
+-- min build: 1207
+---@param p0 any
+function N_0x9A74A9CADFA8A598(p0) end
+
+-- _0xACD4F9831DFAD7F5  (0xACD4F9831DFAD7F5)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xACD4F9831DFAD7F5(p0) end
+
+-- _0xCBFBD38F2E0A263B  (0xCBFBD38F2E0A263B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCBFBD38F2E0A263B(p0, p1) end
+
+-- _0xCEAB54F4632C6EF6  (0xCEAB54F4632C6EF6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCEAB54F4632C6EF6(p0, p1) end
+
+-- _0xD91E55B6C005EB09  (0xD91E55B6C005EB09)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xD91E55B6C005EB09(p0, p1) end
+
+-- _0xDE116ECFFDD4B997  (0xDE116ECFFDD4B997)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDE116ECFFDD4B997(p0, p1) end
+
+-- _0xDFA1237F5228263F  (0xDFA1237F5228263F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDFA1237F5228263F(p0, p1) end
+
+-- _0xF65EDE5D02A7A760  (0xF65EDE5D02A7A760)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xF65EDE5D02A7A760(p0, p1) end
+
+-- _0xF6E88489B4E6EBE5  (0xF6E88489B4E6EBE5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xF6E88489B4E6EBE5(p0, p1) end
+
+-- _0xFA99E8E575F2FEF8  (0xFA99E8E575F2FEF8)
+-- min build: 1436
+---@param p0 any
+---@return any
+function N_0xFA99E8E575F2FEF8(p0) end
+
+-- _ADD_DOOR_TO_SYSTEM_NEW  (0xD99229FE93B46286)
+-- Registers a door, hashes: https://github.com/femga/rdr3_discoveries/tree/master/doorHashes
+-- min build: 1207
+---@param doorHash number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param threadId number
+---@param p5 number
+---@param p6 boolean
+function _AddDoorToSystemNew(doorHash, p1, p2, p3, threadId, p5, p6) end
+
+-- _CHECK_DOOR_ACTION_FLAG  (0x0943113E02322164)
+-- Checks whether a specific door-related action/state flag is active for the given door object.
+-- 
+-- Observed flags:
+-- - 32: true while the door is being kicked
+-- - 23: true if the door was previously opened by kicking
+-- - 8: true when attempting to open the door while it is locked
+-- min build: 1207
+---@param doorObject number
+---@param flag number
+---@return boolean
+function _CheckDoorActionFlag(doorObject, flag) end
+
+-- _DAMAGE_BONE_ON_PROP  (0xE4EFB315BCD2A838)
+-- min build: 1207
+---@param object number
+---@param bone number
+function _DamageBoneOnProp(object, bone) end
+
+-- _DAMAGE_OBJECT_FRAGMENT_BY_INDEX  (0xAAACF33CBF9B990A)
+-- Damages or breaks a specific predefined fragment/section of an object.
+-- The index selects one of the object's internal fracture sections. Different index values cause different fragments to detach or break.
+-- Pair with _GET_OBJECT_FRAGMENT_COUNT to determine the valid index range.
+-- min build: 1207
+---@param object number
+---@param index number
+function _DamageObjectFragmentByIndex(object, index) end
+
+-- _DOOR_SYSTEM_CHANGE_SCRIPT_OWNER  (0x985767F5FA45BC44)
+-- min build: 1207
+---@param doorHash number
+function _DoorSystemChangeScriptOwner(doorHash) end
+
+-- _DOOR_SYSTEM_CHECK_ACTION_FLAG  (0x6E2AA80BB0C03728)
+-- Checks whether a specific door action/state flag is active for the given door hash.
+-- Door-system-hash equivalent of _CHECK_DOOR_ACTION_FLAG.
+-- 
+-- Observed flags:
+-- - 32: true while the door is being kicked
+-- - 23: true after the door has been opened by kicking
+-- - 8: true when trying to open a locked door
+-- min build: 1207
+---@param doorHash number
+---@param flag number
+---@return boolean
+function _DoorSystemCheckActionFlag(doorHash, flag) end
+
+-- _DOOR_SYSTEM_CLEAR_FORCED_OPEN_PLAYER  (0x5230BF34EB0EC645)
+-- Clears the stored player ID for a door that was force-opened via physical interaction such as kicking or shoulder bashing.
+-- Resets the value returned by _DOOR_SYSTEM_GET_FORCED_OPEN_PLAYER.
+-- min build: 1207
+---@param doorHash number
+function _DoorSystemClearForcedOpenPlayer(doorHash) end
+
+-- _DOOR_SYSTEM_FORCE_SHUT  (0x276AAF0F1C7F2494)
+-- min build: 1207
+---@param doorHash number
+---@param p1 boolean
+function _DoorSystemForceShut(doorHash, p1) end
+
+-- _DOOR_SYSTEM_GET_AUTOMATIC_RATE  (0x8433E1954BE323FC)
+-- min build: 1207
+---@param doorHash number
+---@return number
+function _DoorSystemGetAutomaticRate(doorHash) end
+
+-- _DOOR_SYSTEM_GET_FORCED_OPEN_PLAYER  (0xEBA314768FB35D58)
+-- Returns the player who forced the specified door open using a physical interaction such as kicking or shoulder bashing.
+-- Returns 255 if no valid player is associated or the door was not force-opened.
+-- Only works for player-driven forced interactions on door-system registered doors; normal door opening and NPC interactions do not populate this value.
+-- min build: 1207
+---@param doorHash number
+---@return number
+function _DoorSystemGetForcedOpenPlayer(doorHash) end
+
+-- _DOOR_SYSTEM_SET_ABLE_TO_CHANGE_OPEN_RATIO_WHILE_LOCKED  (0x1F1FABFE9B2A1254)
+-- min build: 1207
+---@param doorHash number
+---@param p1 boolean
+function _DoorSystemSetAbleToChangeOpenRatioWhileLocked(doorHash, p1) end
+
+-- _DOOR_SYSTEM_SET_AUTOMATIC_STATE  (0x1BC47A9DEDC8DF5D)
+-- _ALLOW_* - _ATTACH_*
+-- min build: 1207
+---@param doorHash number
+---@param disable boolean
+function _DoorSystemSetAutomaticState(doorHash, disable) end
+
+-- _DOOR_SYSTEM_SWING_OPEN  (0xB3B1546D23DF8DE1)
+-- Applies an impulse to a door, causing it to swing open with animation.
+-- 
+-- Notes:
+-- - Requires DOOR_SYSTEM_SET_DOOR_STATE(doorHash, 0) beforehand.
+-- - If the door is locked, the impulse is ignored.
+-- - dirX/dirY/dirZ are normalized internally and do not appear to control force or speed.
+-- - reverseDirection inverts the opening direction, useful for double doors swinging apart.
+-- min build: 1207
+---@param doorHash number
+---@param dirX number
+---@param dirY number
+---@param dirZ number
+---@param reverseDirection boolean
+function _DoorSystemSwingOpen(doorHash, dirX, dirY, dirZ, reverseDirection) end
+
+-- _GET_AMMO_TYPE_FROM_PICKUP_TYPE  (0x44B09A23D728045A)
+-- min build: 1207
+---@param pickupHash number
+---@return number
+function _GetAmmoTypeFromPickupType(pickupHash) end
+
+-- _GET_DOOR_KNOCKING_WHEN_LOCKED  (0x4D8611DFE1126478)
+-- Returns whether the specified door has the locked-door knocking interaction enabled.
+-- Getter counterpart of _SET_DOOR_KNOCKING_WHEN_LOCKED.
+-- min build: 1207
+---@param doorHash number
+---@return boolean
+function _GetDoorKnockingWhenLocked(doorHash) end
+
+-- _GET_LIGHT_INTENSITY_FROM_OBJECT  (0xFA3B61EC249B4674)
+-- min build: 1207
+---@param object number
+---@return number
+function _GetLightIntensityFromObject(object) end
+
+-- _GET_OBJECT_FRAGMENT_COUNT  (0x58DE624FA7FB0E7F)
+-- Returns the number of breakable fragments/indexed sections defined for the specified object.
+-- Objects without fracture data typically return 0. The returned count corresponds to the valid index range used by _DAMAGE_OBJECT_FRAGMENT_BY_INDEX.
+-- min build: 1207
+---@param object number
+---@return number
+function _GetObjectFragmentCount(object) end
+
+-- _GET_OBJECT_LIGHT_INTENSITY  (0x3397CD4E0353DFBA)
+-- Returns float value to be used with _SET_LIGHT_INTENSITY_FOR_OBJECT
+-- min build: 1207
+---@param object number
+---@return number
+function _GetObjectLightIntensity(object) end
+
+-- _HIDE_PICKUP_OBJECT  (0x2777150CC7D9365E)
+-- min build: 1207
+---@param pickupObject number
+---@param toggle boolean
+function _HidePickupObject(pickupObject, toggle) end
+
+-- _IS_DOOR_REGISTERED_WITH_NETWORK  (0xB5DED7B65C604FDF)
+-- min build: 1207
+---@param doorHash number
+---@return boolean
+function _IsDoorRegisteredWithNetwork(doorHash) end
+
+-- _IS_DOOR_REGISTERED_WITH_OWNER  (0x4F89DAD4156BA145)
+-- Returns true if door is alredy registered with owner
+-- min build: 1207
+---@param doorHash number
+---@return boolean
+function _IsDoorRegisteredWithOwner(doorHash) end
+
+-- _IS_PICKUP_PICKABLE_FOR_TEAM  (0x9F52AD67D1A91BAD)
+-- Returns whether the pickup object is pickable for the specified team.
+-- Observed with portable pickups: after SET_TEAM_PICKUP_OBJECT disables pickup for team 1, this returns false for team 1 while remaining true for another team.
+-- min build: 1207
+---@param object number
+---@param teamId number
+---@return boolean
+function _IsPickupPickableForTeam(object, teamId) end
+
+-- _IS_PICKUP_TYPE_VALID  (0x007BD043587F7C82)
+-- min build: 1207
+---@param pickupHash number
+---@return boolean
+function _IsPickupTypeValid(pickupHash) end
+
+-- _MAKE_ITEM_CARRIABLE  (0x1461DF6DB886BE3F)
+-- _PRE* or _Q* or _RE*
+-- min build: 1207
+---@param object number
+function _MakeItemCarriable(object) end
+
+-- _RESET_OBJECT_VELOCITY  (0xF40AB58D83C35027)
+-- min build: 1207
+---@param object number
+function _ResetObjectVelocity(object) end
+
+-- _SET_AMBIENT_PICKUP_LIFETIME  (0xAC9AE68F0A463752)
+-- min build: 1207
+---@param lifetime number
+function _SetAmbientPickupLifetime(lifetime) end
+
+-- _SET_AUTO_JUMPABLE_BY_HORSE  (0x98D2D9C053A1F449)
+-- Sets object as auto-jumpable by horse.
+-- min build: 1207
+---@param object number
+---@param p1 boolean
+function _SetAutoJumpableByHorse(object, p1) end
+
+-- _SET_DOOR_KICK_PROMPT_ENABLED  (0xC07B91B996C1DE89)
+-- Enables or disables the Kick interaction prompt for a specific door.
+-- When enabled, a locked door can show a kick prompt so the player can force it open.
+-- If the door is already unlocked, the kick prompt typically will not appear regardless of this setting.
+-- min build: 1207
+---@param doorHash number
+---@param toggle boolean
+function _SetDoorKickPromptEnabled(doorHash, toggle) end
+
+-- _SET_DOOR_KNOCKING_WHEN_LOCKED  (0xA93F925F1942E434)
+-- Changes the interaction behavior for a locked door.
+-- When enabled, interacting with a locked door makes the character knock/tap instead of trying the handle.
+-- This does not unlock or open the door and only changes the locked-door interaction behavior/animation.
+-- min build: 1207
+---@param doorHash number
+---@param toggle boolean
+function _SetDoorKnockingWhenLocked(doorHash, toggle) end
+
+-- _SET_LIGHT_INTENSITY_FOR_OBJECT  (0xF49574E2332A8F06)
+-- min build: 1207
+---@param object number
+---@param lightIntensity number
+function _SetLightIntensityForObject(object, lightIntensity) end
+
+-- _SET_LIGHT_SCATTERING_DISABLED_FOR_OBJECT  (0x04D1D4E411CE52D0)
+-- min build: 1207
+---@param object number
+---@param disable boolean
+function _SetLightScatteringDisabledForObject(object, disable) end
+
+-- _SET_LIGHT_TRANSLUCENCY_FOR_OBJECT  (0x63E39F09310F481F)
+-- Params: value = 0.0 - 586.67 (?)
+-- min build: 1207
+---@param object number
+---@param value number
+function _SetLightTranslucencyForObject(object, value) end
+
+-- _SET_NETWORK_PICKUP_USABLE_FOR_PLAYER  (0x94F3D956BFAEAE18)
+-- Params: p2 controls whether to make pickups usable/collectable or not in networked games
+-- min build: 1207
+---@param player number
+---@param pickupHash number
+---@param isUsable boolean
+function _SetNetworkPickupUsableForPlayer(player, pickupHash, isUsable) end
+
+-- _SET_NOT_JUMPABLE_BY_HORSE  (0xE1C708BA4885796B)
+-- Sets object as not jumpable by horse.
+-- min build: 1207
+---@param object number
+---@param p1 boolean
+function _SetNotJumpableByHorse(object, p1) end
+
+-- _SET_OBJECT_BREAK_SCALE  (0xFFB99FFD17F65889)
+-- min build: 1207
+---@param object number
+---@param scale number
+function _SetObjectBreakScale(object, scale) end
+
+-- _SET_OBJECT_BURN_INTENSITY  (0xC8E21C1677DC5E6F)
+-- min build: 1207
+---@param object number
+---@param intensity number
+function _SetObjectBurnIntensity(object, intensity) end
+
+-- _SET_OBJECT_BURN_LEVEL  (0x2797C633DCDBBAC5)
+-- Seems to mostly have effect on wood-made objects https://imgur.com/a/32oQvOn
+-- min build: 1207
+---@param object number
+---@param burnLevel number
+---@param affectAsh boolean
+function _SetObjectBurnLevel(object, burnLevel, affectAsh) end
+
+-- _SET_OBJECT_BURN_OPACITY  (0x7D7285EFEAB5AF15)
+-- min build: 1207
+---@param object number
+---@param opacity number
+function _SetObjectBurnOpacity(object, opacity) end
+
+-- _SET_OBJECT_BURN_SPEED  (0x646564A3B7DF68F8)
+-- p2 is usually the same as speed parameter
+-- min build: 1207
+---@param object number
+---@param speed number
+---@param p2 number
+function _SetObjectBurnSpeed(object, speed, p2) end
+
+-- _SET_OBJECT_INTERACTION_PRESET  (0xCAAF2BCCFEF37F77)
+-- Writes an interaction state/flags byte and sets an expiry.
+-- Lower 3 bits = timeout preset: 0=none, 1=5s, 2=30s, 3=60s, 4=120s (5=custom, unused here).
+-- Bits 3-5 = category (0-7). Bit 6 (0x40) = extra behavior flag.
+-- Examples: https://pastebin.com/mwAi5iQY
+-- min build: 1207
+---@param object number
+---@param presetFlags number
+function _SetObjectInteractionPreset(object, presetFlags) end
+
+-- _SET_OBJECT_KICKABLE  (0xB7017DA4D498269F)
+-- min build: 1207
+---@param object number
+---@param kickable boolean
+function _SetObjectKickable(object, kickable) end
+
+-- _SET_OBJECT_LANTERN_LIGHT_DISABLED  (0x7FCD49388BC9B775)
+-- Enables or disables light emission for a dropped lantern object.
+-- Primarily used on lantern weapon entities after they have been dropped.
+-- Has no effect while the lantern is equipped/held by a ped.
+-- The toggle behaves as a disable-light flag: true turns the lantern light off, false leaves it on.
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function _SetObjectLanternLightDisabled(object, toggle) end
+
+-- _SET_OBJECT_MARKABLE_IN_DEADEYE  (0xE157A8A336C7F04A)
+-- Sets whether the specified object can be marked while Dead Eye is active.
+-- 
+-- When enabled, the object becomes a valid Dead Eye mark target.
+-- When disabled, Dead Eye can still be activated normally, but this object will not accept mark placement.
+-- 
+-- More specific than general targetability such as SET_OBJECT_TARGETTABLE.
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function _SetObjectMarkableInDeadeye(object, toggle) end
+
+-- _SET_OBJECT_PROMPT_NAME  (0xAEE6C800E124CFE1)
+-- _SET_FORCE* - _SET_LOCAL*
+-- min build: 1207
+---@param object number
+---@param name string
+function _SetObjectPromptName(object, name) end
+
+-- _SET_OBJECT_PROMPT_NAME_FROM_GXT_ENTRY  (0xD503D6F0986D58BC)
+-- _SET_FORCE* - _SET_LOCAL*
+-- min build: 1207
+---@param object number
+---@param name number
+function _SetObjectPromptNameFromGxtEntry(object, name) end
+
+-- _SET_OBJECT_TARGETTABLE_2  (0x581EDBE56E8D62C9)
+-- min build: 1207
+---@param object number
+---@param targettable boolean
+function _SetObjectTargettable2(object, targettable) end
+
+-- _SET_OBJECT_TARGETTABLE_FOCUS  (0xA22712E8471AA08E)
+-- When p1 and p2 are true you can focus on the object (similar to when you focus a ped)
+-- min build: 1207
+---@param object number
+---@param p1 boolean
+---@param p2 boolean
+function _SetObjectTargettableFocus(object, p1, p2) end
+
+-- _SET_PICKUP_COLLECTABLE_ON_MOUNT  (0x00EE08603EADEE92)
+-- min build: 1207
+---@param object number
+function _SetPickupCollectableOnMount(object) end
+
+-- ALLOW_DAMAGE_EVENTS_FOR_NON_NETWORKED_OBJECTS  (0xE2B3B852B537C398)
+-- min build: 1207
+---@param enabled boolean
+function AllowDamageEventsForNonNetworkedObjects(enabled) end
+
+-- ATTACH_PORTABLE_PICKUP_TO_PED  (0x8DC39368BDD57755)
+-- min build: 1207
+---@param pickupObject number
+---@param ped number
+function AttachPortablePickupToPed(pickupObject, ped) end
+
+-- BLOCK_PICKUP_FROM_PLAYER_COLLECTION  (0xB8F5062070BB6DBD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function BlockPickupFromPlayerCollection(p0, p1) end
+
+-- BREAK_ALL_OBJECT_FRAGMENT_BONES  (0x8462BE2341A55B6F)
+-- min build: 1207
+---@param object number
+function BreakAllObjectFragmentBones(object) end
+
+-- BREAK_OBJECT_FRAGMENT_CHILD  (0xE7E4C198B0185900)
+-- min build: 1207
+---@param object number
+---@param p1 any
+---@param p2 boolean
+function BreakObjectFragmentChild(object, p1, p2) end
+
+-- CONVERT_OLD_PICKUP_TYPE_TO_NEW  (0x5EAAD83F8CFB4575)
+-- Old name: _GET_PICKUP_HASH
+-- min build: 1207
+---@param pickupHash number
+---@return number
+function ConvertOldPickupTypeToNew(pickupHash) end
+
+-- CREATE_AMBIENT_PICKUP  (0x673966A0C0FD7171)
+-- flags: see CREATE_PICKUP
+-- min build: 1207
+---@param pickupHash number
+---@param x number
+---@param y number
+---@param z number
+---@param flags number
+---@param amount number
+---@param customModel number
+---@param createAsScriptObject boolean
+---@param scriptHostObject boolean
+---@param customAmmoType number
+---@param p10 number
+---@return number
+function CreateAmbientPickup(pickupHash, x, y, z, flags, amount, customModel, createAsScriptObject, scriptHostObject, customAmmoType, p10) end
+
+-- CREATE_OBJECT  (0x509D5878EB39E842)
+-- min build: 1207
+---@param modelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param isNetwork boolean
+---@param bScriptHostObj boolean
+---@param dynamic boolean
+---@param p7 boolean
+---@param p8 boolean
+---@return number
+function CreateObject(modelHash, x, y, z, isNetwork, bScriptHostObj, dynamic, p7, p8) end
+
+-- CREATE_OBJECT_NO_OFFSET  (0x9A294B2138ABB884)
+-- min build: 1207
+---@param modelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param isNetwork boolean
+---@param bScriptHostObj boolean
+---@param dynamic boolean
+---@param p7 boolean
+---@return number
+function CreateObjectNoOffset(modelHash, x, y, z, isNetwork, bScriptHostObj, dynamic, p7) end
+
+-- CREATE_OBJECT_SKELETON  (0xB6CBD40F8EA69E8A)
+-- min build: 1207
+---@param object number
+---@return boolean
+function CreateObjectSkeleton(object) end
+
+-- CREATE_PICKUP  (0xFBA08C503DD5FA58)
+-- https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/Placement%20Flags
+-- https://github.com/femga/rdr3_discoveries/blob/master/objects/pickup_list.lua
+-- min build: 1207
+---@param pickupHash number
+---@param x number
+---@param y number
+---@param z number
+---@param flags number
+---@param p5 number
+---@param p6 boolean
+---@param modelHash number
+---@param p8 number
+---@param p9 number
+---@param p10 any
+---@return number
+function CreatePickup(pickupHash, x, y, z, flags, p5, p6, modelHash, p8, p9, p10) end
+
+-- CREATE_PICKUP_ROTATE  (0x891804727E0A98B7)
+-- flags: see CREATE_PICKUP
+-- min build: 1207
+---@param pickupHash number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param flags number
+---@param p8 number
+---@param p9 number
+---@param p10 boolean
+---@param modelHash number
+---@param p12 number
+---@param p13 number
+---@param p14 any
+---@return number
+function CreatePickupRotate(pickupHash, posX, posY, posZ, rotX, rotY, rotZ, flags, p8, p9, p10, modelHash, p12, p13, p14) end
+
+-- CREATE_PORTABLE_PICKUP  (0x2EAF1FDB2FB55698)
+-- min build: 1207
+---@param pickupHash number
+---@param x number
+---@param y number
+---@param z number
+---@param placeOnGround boolean
+---@param modelHash number
+---@return number
+function CreatePortablePickup(pickupHash, x, y, z, placeOnGround, modelHash) end
+
+-- DELETE_OBJECT  (0x931914268722C263)
+-- Deletes the specified object, then sets the handle pointed to by the pointer to NULL.
+-- min build: 1207
+---@return number
+function DeleteObject() end
+
+-- DETACH_PORTABLE_PICKUP_FROM_PED  (0xCF463D1E9A0AECB1)
+-- min build: 1207
+---@param pickupObject number
+function DetachPortablePickupFromPed(pickupObject) end
+
+-- DOES_OBJECT_OF_TYPE_EXIST_AT_COORDS  (0xBFA48E2FF417213F)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param hash number
+---@param p5 boolean
+---@return boolean
+function DoesObjectOfTypeExistAtCoords(x, y, z, radius, hash, p5) end
+
+-- DOES_PICKUP_EXIST  (0xAFC1CA75AD4074D1)
+-- min build: 1207
+---@param pickup number
+---@return boolean
+function DoesPickupExist(pickup) end
+
+-- DOES_PICKUP_OBJECT_EXIST  (0xD9EFB6DBF7DAAEA3)
+-- min build: 1207
+---@param pickupObject number
+---@return boolean
+function DoesPickupObjectExist(pickupObject) end
+
+-- DOES_PICKUP_OF_TYPE_EXIST_IN_AREA  (0xF9C36251F6E48E33)
+-- min build: 1207
+---@param pickupHash number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function DoesPickupOfTypeExistInArea(pickupHash, x, y, z, radius) end
+
+-- DOES_RAYFIRE_MAP_OBJECT_EXIST  (0x52AF537A0C5B8AAD)
+-- min build: 1207
+---@param object number
+---@return boolean
+function DoesRayfireMapObjectExist(object) end
+
+-- DOOR_SYSTEM_GET_DOOR_STATE  (0x160AA1B32F6139B8)
+-- min build: 1207
+---@param doorHash number
+---@return number
+function DoorSystemGetDoorState(doorHash) end
+
+-- DOOR_SYSTEM_GET_OPEN_RATIO  (0x65499865FCA6E5EC)
+-- min build: 1207
+---@param doorHash number
+---@return number
+function DoorSystemGetOpenRatio(doorHash) end
+
+-- DOOR_SYSTEM_SET_AUTOMATIC_DISTANCE  (0x9BA001CB45CBF627)
+-- min build: 1207
+---@param doorHash number
+---@param distance number
+function DoorSystemSetAutomaticDistance(doorHash, distance) end
+
+-- DOOR_SYSTEM_SET_AUTOMATIC_RATE  (0x03C27E13B42A0E82)
+-- min build: 1207
+---@param doorHash number
+---@param rate number
+function DoorSystemSetAutomaticRate(doorHash, rate) end
+
+-- DOOR_SYSTEM_SET_DOOR_STATE  (0x6BAB9442830C7F53)
+-- Door lock states:
+-- enum eDoorState
+-- {
+-- 	DOORSTATE_INVALID = -1,
+-- 	DOORSTATE_UNLOCKED,
+-- 	DOORSTATE_LOCKED_UNBREAKABLE,
+-- 	DOORSTATE_LOCKED_BREAKABLE,
+-- 	DOORSTATE_HOLD_OPEN_POSITIVE,
+-- 	DOORSTATE_HOLD_OPEN_NEGATIVE
+-- };
+-- min build: 1207
+---@param doorHash number
+---@param state number
+function DoorSystemSetDoorState(doorHash, state) end
+
+-- DOOR_SYSTEM_SET_OPEN_RATIO  (0xB6E6FBA95C7324AC)
+-- Sets the ajar angle of a door.
+-- Ranges from -1.0 to 1.0, and 0.0 is closed / default.
+-- min build: 1207
+---@param doorHash number
+---@param ajar number
+---@param forceUpdate boolean
+function DoorSystemSetOpenRatio(doorHash, ajar, forceUpdate) end
+
+-- FIX_OBJECT_FRAGMENT  (0xF9C1681347C8BD15)
+-- min build: 1207
+---@param object number
+function FixObjectFragment(object) end
+
+-- FORCE_PICKUP_REGENERATE  (0x758A5C1B3B1E1990)
+-- min build: 1207
+---@param p0 any
+function ForcePickupRegenerate(p0) end
+
+-- GET_CLOSEST_OBJECT_OF_TYPE  (0xE143FA2249364369)
+-- missionScriptObject - if true won't return mission script objects
+-- scriptHostObject - if true won't return script host objects
+-- networkObject - if true won't return networked objects
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param modelHash number
+---@param missionScriptObject boolean
+---@param scriptHostObject boolean
+---@param networkObject boolean
+---@return number
+function GetClosestObjectOfType(x, y, z, radius, modelHash, missionScriptObject, scriptHostObject, networkObject) end
+
+-- GET_OBJECT_FRAGMENT_DAMAGE_HEALTH  (0xB6FBFD079B8D0596)
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+---@return number
+function GetObjectFragmentDamageHealth(p0, p1) end
+
+-- GET_OFFSET_FROM_COORD_AND_HEADING_IN_WORLD_COORDS  (0x163E252DE035A133)
+-- Old name: _GET_OBJECT_OFFSET_FROM_COORDS
+-- min build: 1207
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param heading number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@return vector3
+function GetOffsetFromCoordAndHeadingInWorldCoords(xPos, yPos, zPos, heading, xOffset, yOffset, zOffset) end
+
+-- GET_PICKUP_COORDS  (0x225B8B35C88029B3)
+-- min build: 1207
+---@param pickup number
+---@return vector3
+function GetPickupCoords(pickup) end
+
+-- GET_PICKUP_OBJECT  (0x5099BC55630B25AE)
+-- min build: 1207
+---@param pickup number
+---@return number
+function GetPickupObject(pickup) end
+
+-- GET_RAYFIRE_MAP_OBJECT  (0xB48FCED898292E52)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param name string
+---@return number
+function GetRayfireMapObject(x, y, z, radius, name) end
+
+-- GET_RAYFIRE_MAP_OBJECT_ANIM_PHASE  (0x260EE4FDBDF4DB01)
+-- min build: 1207
+---@param object number
+---@return number
+function GetRayfireMapObjectAnimPhase(object) end
+
+-- GET_SAFE_PICKUP_COORDS  (0x6E16BC2503FF1FF0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return vector3
+function GetSafePickupCoords(p0, p1, p2, p3, p4, p5) end
+
+-- GET_STATE_OF_RAYFIRE_MAP_OBJECT  (0x899BA936634A322E)
+-- min build: 1207
+---@param object number
+---@return number
+function GetStateOfRayfireMapObject(object) end
+
+-- GET_WEAPON_TYPE_FROM_PICKUP_TYPE  (0x08F96CA6C551AD51)
+-- min build: 1207
+---@param pickupHash number
+---@return number
+function GetWeaponTypeFromPickupType(pickupHash) end
+
+-- HAS_CLOSEST_OBJECT_OF_TYPE_BEEN_BROKEN  (0x761B0E69AC4D007E)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param modelHash number
+---@param p5 any
+---@return boolean
+function HasClosestObjectOfTypeBeenBroken(p0, p1, p2, p3, modelHash, p5) end
+
+-- HAS_OBJECT_BEEN_BROKEN  (0x8ABFB70C49CC43E2)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function HasObjectBeenBroken(p0) end
+
+-- HAS_PICKUP_BEEN_COLLECTED  (0x80EC48E6679313F9)
+-- min build: 1207
+---@param pickup number
+---@return boolean
+function HasPickupBeenCollected(pickup) end
+
+-- IS_DOOR_CLOSED  (0xC531EE8A1145A149)
+-- min build: 1207
+---@param doorHash number
+---@return boolean
+function IsDoorClosed(doorHash) end
+
+-- IS_DOOR_REGISTERED_WITH_SYSTEM  (0xC153C43EA202C8C1)
+-- min build: 1207
+---@param doorHash number
+---@return boolean
+function IsDoorRegisteredWithSystem(doorHash) end
+
+-- IS_OBJECT_A_PORTABLE_PICKUP  (0x0378C08504160D0D)
+-- min build: 1207
+---@param object number
+---@return boolean
+function IsObjectAPortablePickup(object) end
+
+-- IS_OBJECT_VISIBLE  (0x8B32ACE6326A7546)
+-- min build: 1207
+---@param object number
+---@return boolean
+function IsObjectVisible(object) end
+
+-- IS_POINT_IN_ANGLED_AREA  (0x2A70BAE8883E4C81)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 boolean
+---@param p11 boolean
+---@return boolean
+function IsPointInAngledArea(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) end
+
+-- ONLY_CLEAN_UP_OBJECT_WHEN_OUT_OF_RANGE  (0xADBE4809F19F927A)
+-- Old name: _MARK_OBJECT_FOR_DELETION
+-- min build: 1207
+---@param object number
+function OnlyCleanUpObjectWhenOutOfRange(object) end
+
+-- PLACE_OBJECT_ON_GROUND_PROPERLY  (0x58A850EAEE20FAA3)
+-- min build: 1207
+---@param object number
+---@param p1 boolean
+---@return boolean
+function PlaceObjectOnGroundProperly(object, p1) end
+
+-- PREVENT_COLLECTION_OF_PORTABLE_PICKUP  (0x92AEFB5F6E294023)
+-- min build: 1207
+---@param object number
+---@param p1 boolean
+---@param p2 boolean
+function PreventCollectionOfPortablePickup(object, p1, p2) end
+
+-- REMOVE_ALL_PICKUPS_OF_TYPE  (0x27F9D613092159CF)
+-- min build: 1207
+---@param pickupHash number
+function RemoveAllPickupsOfType(pickupHash) end
+
+-- REMOVE_DOOR_FROM_SYSTEM  (0x464D8E1427156FE4)
+-- min build: 1207
+---@param doorHash number
+function RemoveDoorFromSystem(doorHash) end
+
+-- REMOVE_PICKUP  (0x3288D8ACAECD2AB2)
+-- min build: 1207
+---@param pickup number
+function RemovePickup(pickup) end
+
+-- SET_ACTIVATE_OBJECT_PHYSICS_AS_SOON_AS_IT_IS_UNFROZEN  (0x406137F8EF90EAF5)
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function SetActivateObjectPhysicsAsSoonAsItIsUnfrozen(object, toggle) end
+
+-- SET_CUSTOM_TEXTURES_ON_OBJECT  (0xE124889AE0521FCF)
+-- min build: 1207
+---@param object number
+---@param txdHash number
+---@param p2 any
+---@param p3 any
+function SetCustomTexturesOnObject(object, txdHash, p2, p3) end
+
+-- SET_FORCE_OBJECT_THIS_FRAME  (0xF538081986E49E9D)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+function SetForceObjectThisFrame(x, y, z, p3) end
+
+-- SET_LOCAL_PLAYER_CAN_COLLECT_PORTABLE_PICKUPS  (0x78857FC65CADB909)
+-- min build: 1207
+---@param toggle boolean
+function SetLocalPlayerCanCollectPortablePickups(toggle) end
+
+-- SET_LOCAL_PLAYER_PERMITTED_TO_COLLECT_PICKUPS_WITH_MODEL  (0x88EAEC617CD26926)
+-- Maximum amount of pickup models that can be disallowed is 10.
+-- 
+-- Old name: _SET_LOCAL_PLAYER_CAN_USE_PICKUPS_WITH_THIS_MODEL
+-- min build: 1207
+---@param modelHash number
+---@param toggle boolean
+function SetLocalPlayerPermittedToCollectPickupsWithModel(modelHash, toggle) end
+
+-- SET_MAX_NUM_PORTABLE_PICKUPS_CARRIED_BY_PLAYER  (0x0BF3B3BD47D79C08)
+-- min build: 1207
+---@param modelHash number
+---@param p1 number
+function SetMaxNumPortablePickupsCarriedByPlayer(modelHash, p1) end
+
+-- SET_OBJECT_ALLOW_LOW_LOD_BUOYANCY  (0x4D89D607CB3DD1D2)
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function SetObjectAllowLowLodBuoyancy(object, toggle) end
+
+-- SET_OBJECT_PHYSICS_PARAMS  (0xF6DF6E90DE7DF90F)
+-- Adjust the physics parameters of a prop, or otherwise known as "object". This is useful for simulated gravity.
+-- 
+-- Other parameters seem to be unknown.
+-- 
+-- p2: seems to be weight and gravity related. Higher value makes the obj fall faster. Very sensitive?
+-- p3: seems similar to p2
+-- p4: makes obj fall slower the higher the value
+-- p5: similar to p4
+-- min build: 1207
+---@param object number
+---@param weight number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param gravity number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@param buoyancy number
+function SetObjectPhysicsParams(object, weight, p2, p3, p4, p5, gravity, p7, p8, p9, p10, buoyancy) end
+
+-- SET_OBJECT_TAKES_DAMAGE_FROM_COLLIDING_WITH_BUILDINGS  (0xEB6F1A9B5510A5D2)
+-- min build: 1207
+---@param object number
+---@param enabled boolean
+function SetObjectTakesDamageFromCollidingWithBuildings(object, enabled) end
+
+-- SET_OBJECT_TARGETTABLE  (0x8A7391690F5AFD81)
+-- min build: 1207
+---@param object number
+---@param targettable boolean
+function SetObjectTargettable(object, targettable) end
+
+-- SET_OBJECT_TINT_INDEX  (0x971DA0055324D033)
+-- Alt name: _SET_OBJECT_TINT
+-- 
+-- Old name: _SET_OBJECT_TEXTURE_VARIATION
+-- min build: 1207
+---@param object number
+---@param textureVariation number
+function SetObjectTintIndex(object, textureVariation) end
+
+-- SET_PICKUP_DO_NOT_AUTO_PLACE_ON_GROUND  (0x634C19521485AB25)
+-- min build: 1207
+---@param pickupObject number
+function SetPickupDoNotAutoPlaceOnGround(pickupObject) end
+
+-- SET_PICKUP_GENERATION_RANGE_MULTIPLIER  (0x318516E02DE3ECE2)
+-- min build: 1207
+---@param multiplier number
+function SetPickupGenerationRangeMultiplier(multiplier) end
+
+-- SET_PICKUP_HIDDEN_WHEN_UNCOLLECTABLE  (0x81218CE01B672219)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function SetPickupHiddenWhenUncollectable(p0, p1) end
+
+-- SET_PICKUP_NOT_LOOTABLE  (0x92E87F60F21A0C3A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function SetPickupNotLootable(p0, p1) end
+
+-- SET_PICKUP_PARTICLE_FX_HIGHLIGHT  (0x1607C7D9B3021DF5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function SetPickupParticleFxHighlight(p0, p1) end
+
+-- SET_PICKUP_PARTICLE_FX_SPAWN  (0xEB9740A38FD6D634)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function SetPickupParticleFxSpawn(p0, p1) end
+
+-- SET_PICKUP_REGENERATION_TIME  (0x78015C9B4B3ECC9D)
+-- min build: 1207
+---@param pickup number
+---@param duration number
+function SetPickupRegenerationTime(pickup, duration) end
+
+-- SET_PICKUP_UNCOLLECTABLE  (0x4A8CB328CD6F1C9B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function SetPickupUncollectable(p0, p1) end
+
+-- SET_STATE_OF_RAYFIRE_MAP_OBJECT  (0x5C29F698D404C5E1)
+-- min build: 1207
+---@param object number
+---@param state number
+function SetStateOfRayfireMapObject(object, state) end
+
+-- SET_TEAM_PICKUP_OBJECT  (0x53E0DF1A2A3CF0CA)
+-- min build: 1207
+---@param object number
+---@param p1 any
+---@param p2 boolean
+function SetTeamPickupObject(object, p1, p2) end
+
+-- SLIDE_OBJECT  (0x2FDFF4107B8C1147)
+-- min build: 1207
+---@param object number
+---@param toX number
+---@param toY number
+---@param toZ number
+---@param speedX number
+---@param speedY number
+---@param speedZ number
+---@param collision boolean
+---@return boolean
+function SlideObject(object, toX, toY, toZ, speedX, speedY, speedZ, collision) end
+
+-- SUPPRESS_PICKUP_REWARD_TYPE  (0xF92099527DB8E2A7)
+-- min build: 1207
+---@param rewardType number
+---@param suppress boolean
+function SuppressPickupRewardType(rewardType, suppress) end
+
+-- TRACK_OBJECT_VISIBILITY  (0xB252BC036B525623)
+-- min build: 1207
+---@param object number
+function TrackObjectVisibility(object) end

--- a/.luals/redm-natives/PAD.lua
+++ b/.luals/redm-natives/PAD.lua
@@ -1,0 +1,290 @@
+---@meta
+
+-- RDR3 namespace: PAD -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x1252C029FC8EBB4D  (0x1252C029FC8EBB4D)
+-- _IS_R* - _IS_S*
+-- min build: 1207
+---@return boolean
+function N_0x1252C029FC8EBB4D() end
+
+-- _0x43F35DDB2905D945  (0x43F35DDB2905D945)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x43F35DDB2905D945(p0, p1) end
+
+-- _0x52C68E92D6E23ADD  (0x52C68E92D6E23ADD)
+-- min build: 1311
+---@param p0 any
+function N_0x52C68E92D6E23ADD(p0) end
+
+-- _0x5F217BC1190503D8  (0x5F217BC1190503D8)
+-- rumbleCurve: common_0/data/rumblecurves.meta
+-- min build: 1207
+---@param rumbleCurve string
+---@param p1 number
+function N_0x5F217BC1190503D8(rumbleCurve, p1) end
+
+-- _0x709BA8C08C5C008D  (0x709BA8C08C5C008D)
+-- min build: 1207
+function N_0x709BA8C08C5C008D() end
+
+-- _0xBD629C1C4F501C80  (0xBD629C1C4F501C80)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xBD629C1C4F501C80(p0) end
+
+-- _GET_CURRENT_CONTROL_CONTEXT  (0xDDCEB0F26C89C00F)
+-- Gets the current control context. See: _SET_CONTROL_CONTEXT
+-- min build: 1207
+---@param control number
+---@return number
+function _GetCurrentControlContext(control) end
+
+-- _GET_DISABLED_CONTROL_HOW_LONG_AGO  (0x771DFCB24D19C2F6)
+-- min build: 1207
+---@param control number
+---@return number
+function _GetDisabledControlHowLongAgo(control) end
+
+-- _IS_CONTROL_ACTION_VALID  (0xBC0884BC590951C7)
+-- min build: 1207
+---@param action number
+---@param control number
+---@return boolean
+function _IsControlActionValid(action, control) end
+
+-- _SET_CONTROL_CONTEXT  (0x2804658EB7D8A50B)
+-- Sets the current control context. Must be called every frame.
+-- 
+-- context: https://alloc8or.re/rdr3/doc/misc/input_contexts.txt
+-- For more information, see common:/data/control/settings.meta
+-- https://github.com/femga/rdr3_discoveries/tree/master/Controls
+-- min build: 1207
+---@param control number
+---@param context number
+function _SetControlContext(control, context) end
+
+-- CLEAR_CONTROL_LIGHT_EFFECT  (0xCB0360EFEFB2580D)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param control number
+function ClearControlLightEffect(control) end
+
+-- CLEAR_CONTROL_SHAKE_SUPPRESSED_ID  (0xA0CEFCEA390AAB9B)
+-- Old name: _CLEAR_SUPPRESSED_PAD_RUMBLE
+-- min build: 1207
+---@param control number
+function ClearControlShakeSuppressedId(control) end
+
+-- DISABLE_ALL_CONTROL_ACTIONS  (0x5F4B6931816E599B)
+-- min build: 1207
+---@param control number
+function DisableAllControlActions(control) end
+
+-- DISABLE_CONTROL_ACTION  (0xFE99B66D079CF6BC)
+-- min build: 1207
+---@param control number
+---@param action number
+---@param disableRelatedActions boolean
+function DisableControlAction(control, action, disableRelatedActions) end
+
+-- ENABLE_CONTROL_ACTION  (0x351220255D64C155)
+-- min build: 1207
+---@param control number
+---@param action number
+---@param enableRelatedActions boolean
+function EnableControlAction(control, action, enableRelatedActions) end
+
+-- GET_CONTROL_HOW_LONG_AGO  (0xD7D22F5592AED8BA)
+-- Returns time in ms since last input.
+-- min build: 1207
+---@param control number
+---@return number
+function GetControlHowLongAgo(control) end
+
+-- GET_CONTROL_NORMAL  (0xEC3C9B8D5327B563)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return number
+function GetControlNormal(control, action) end
+
+-- GET_CONTROL_UNBOUND_NORMAL  (0x5B84D09CEC5209C5)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return number
+function GetControlUnboundNormal(control, action) end
+
+-- GET_CONTROL_VALUE  (0xD95E79E8686D2C27)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return number
+function GetControlValue(control, action) end
+
+-- GET_DISABLED_CONTROL_NORMAL  (0x11E65974A982637C)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return number
+function GetDisabledControlNormal(control, action) end
+
+-- GET_DISABLED_CONTROL_UNBOUND_NORMAL  (0x4F8A26A890FD62FB)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return number
+function GetDisabledControlUnboundNormal(control, action) end
+
+-- HAVE_CONTROLS_CHANGED  (0x6CD79468A1E595C6)
+-- min build: 1207
+---@param control number
+---@return boolean
+function HaveControlsChanged(control) end
+
+-- IS_CONTROL_ENABLED  (0x1CEA6BFDF248E5D9)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsControlEnabled(control, action) end
+
+-- IS_CONTROL_JUST_PRESSED  (0x580417101DDB492F)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsControlJustPressed(control, action) end
+
+-- IS_CONTROL_JUST_RELEASED  (0x50F940259D3841E6)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsControlJustReleased(control, action) end
+
+-- IS_CONTROL_PRESSED  (0xF3A21BCD95725A4A)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsControlPressed(control, action) end
+
+-- IS_CONTROL_RELEASED  (0x648EE3E7F38877DD)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsControlReleased(control, action) end
+
+-- IS_DISABLED_CONTROL_JUST_PRESSED  (0x91AEF906BCA88877)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsDisabledControlJustPressed(control, action) end
+
+-- IS_DISABLED_CONTROL_JUST_RELEASED  (0x305C8DCD79DA8B0F)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsDisabledControlJustReleased(control, action) end
+
+-- IS_DISABLED_CONTROL_PRESSED  (0xE2587F8CBBD87B1D)
+-- min build: 1207
+---@param control number
+---@param action number
+---@return boolean
+function IsDisabledControlPressed(control, action) end
+
+-- IS_LOOK_INVERTED  (0x77B612531280010D)
+-- min build: 1207
+---@return boolean
+function IsLookInverted() end
+
+-- IS_USING_KEYBOARD_AND_MOUSE  (0xA571D46727E2B718)
+-- padIndex is not used
+-- 
+-- Old name: _IS_USING_KEYBOARD
+-- min build: 1207
+---@param control number
+---@return boolean
+function IsUsingKeyboardAndMouse(control) end
+
+-- SET_CONTROL_LIGHT_EFFECT_COLOR  (0x8290252FFF36ACB5)
+-- nullsub, doesn't do anything
+-- 
+-- Old name: _SET_CONTROL_GROUP_COLOR
+-- min build: 1207
+---@param control number
+---@param red number
+---@param green number
+---@param blue number
+function SetControlLightEffectColor(control, red, green, blue) end
+
+-- SET_CONTROL_LIGHT_EFFECT_FLASHING_COLOR  (0xA45884DB10EC7EE3)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param control number
+---@param red number
+---@param green number
+---@param blue number
+function SetControlLightEffectFlashingColor(control, red, green, blue) end
+
+-- SET_CONTROL_SHAKE  (0x48B3886C1358D0D5)
+-- Old name: SET_PAD_SHAKE
+-- min build: 1207
+---@param control number
+---@param duration number
+---@param frequency number
+function SetControlShake(control, duration, frequency) end
+
+-- SET_CONTROL_SHAKE_SUPPRESSED_ID  (0xF239400E16C23E08)
+-- Old name: SET_PAD_SHAKE_SUPPRESSED_ID
+-- min build: 1207
+---@param control number
+---@param uniqueId number
+function SetControlShakeSuppressedId(control, uniqueId) end
+
+-- SET_CONTROL_TRIGGER_SHAKE  (0x14D29BB12D47F68C)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param control number
+---@param leftDuration number
+---@param leftFrequency number
+---@param rightDuration number
+---@param rightFrequency number
+function SetControlTriggerShake(control, leftDuration, leftFrequency, rightDuration, rightFrequency) end
+
+-- SET_CONTROL_VALUE_NEXT_FRAME  (0xE8A25867FBA3B05E)
+-- This is for simulating player input.
+-- value is a float value from 0 - 1
+-- 
+-- control: see IS_CONTROL_ENABLED
+-- 
+-- Old name: _SET_CONTROL_NORMAL
+-- min build: 1207
+---@param control number
+---@param action number
+---@param value number
+---@return boolean
+function SetControlValueNextFrame(control, action, value) end
+
+-- SET_INPUT_EXCLUSIVE  (0xEDE476E5EE29EDB1)
+-- min build: 1207
+---@param control number
+---@param action number
+function SetInputExclusive(control, action) end
+
+-- STOP_CONTROL_SHAKE  (0x38C16A305E8CDC8D)
+-- Old name: STOP_PAD_SHAKE
+-- min build: 1207
+---@param control number
+function StopControlShake(control) end

--- a/.luals/redm-natives/PATH.lua
+++ b/.luals/redm-natives/PATH.lua
@@ -1,0 +1,689 @@
+---@meta
+
+-- RDR3 namespace: PATH -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x264E9A5CD78C338F  (0x264E9A5CD78C338F)
+-- min build: 1207
+---@param p0 any
+function N_0x264E9A5CD78C338F(p0) end
+
+-- _0x34C9AF25649172D0  (0x34C9AF25649172D0)
+-- min build: 1207
+---@param p0 any
+function N_0x34C9AF25649172D0(p0) end
+
+-- _0x4358BCF14C91761C  (0x4358BCF14C91761C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function N_0x4358BCF14C91761C(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _0x4BDEBEA5702B97A9  (0x4BDEBEA5702B97A9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0x4BDEBEA5702B97A9(p0, p1, p2, p3, p4, p5) end
+
+-- _0x54F4D7B6670FBB5A  (0x54F4D7B6670FBB5A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0x54F4D7B6670FBB5A(p0, p1, p2, p3, p4) end
+
+-- _0x5A3B54ADDF5472A3  (0x5A3B54ADDF5472A3)
+-- min build: 1207
+---@param p0 string
+---@return number
+function N_0x5A3B54ADDF5472A3(p0) end
+
+-- _0x5A4E1A41E3A02AD0  (0x5A4E1A41E3A02AD0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x5A4E1A41E3A02AD0(p0, p1, p2) end
+
+-- _0x665B21666351CB37  (0x665B21666351CB37)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x665B21666351CB37(p0, p1, p2) end
+
+-- _0x6C3F12ECEB6D2E2A  (0x6C3F12ECEB6D2E2A)
+-- min build: 1207
+---@param xMin number
+---@param yMin number
+---@param zMin number
+---@param xMax number
+---@param yMax number
+---@param zMax number
+---@param p6 any
+---@param p7 any
+function N_0x6C3F12ECEB6D2E2A(xMin, yMin, zMin, xMax, yMax, zMax, p6, p7) end
+
+-- _0x6DAD6630AE4A74CB  (0x6DAD6630AE4A74CB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x6DAD6630AE4A74CB(p0, p1) end
+
+-- _0x869A7015BD4606E9  (0x869A7015BD4606E9)
+-- min build: 1207
+---@param p0 any
+function N_0x869A7015BD4606E9(p0) end
+
+-- _0xA33914B00CA55756  (0xA33914B00CA55756)
+-- min build: 1207
+---@param p0 string
+---@param p1 number
+---@return any
+function N_0xA33914B00CA55756(p0, p1) end
+
+-- _0xAFE2AE66F6251C66  (0xAFE2AE66F6251C66)
+-- min build: 1207
+---@param xMin number
+---@param yMin number
+---@param zMin number
+---@param xMax number
+---@param yMax number
+---@param zMax number
+---@param p6 number
+---@param p7 any
+function N_0xAFE2AE66F6251C66(xMin, yMin, zMin, xMax, yMax, zMax, p6, p7) end
+
+-- _0xB03944057FD735BA  (0xB03944057FD735BA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xB03944057FD735BA(p0, p1, p2) end
+
+-- _0xCA27A86CAA4E98ED  (0xCA27A86CAA4E98ED)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0xCA27A86CAA4E98ED(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xCF213A5FC3ABFC08  (0xCF213A5FC3ABFC08)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xCF213A5FC3ABFC08(p0, p1, p2) end
+
+-- _0xE5EF9DE716FF737E  (0xE5EF9DE716FF737E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xE5EF9DE716FF737E(p0, p1, p2) end
+
+-- _0xEFC535C9FAF563B3  (0xEFC535C9FAF563B3)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xEFC535C9FAF563B3(p0) end
+
+-- _0xF2A2177AC848B3A8  (0xF2A2177AC848B3A8)
+-- GPS disabled zone: p1 = 0
+-- Clearing GPS disabled zone: p1 = 1
+-- min build: 1207
+---@param volume number
+---@param p1 number
+---@param p2 number
+function N_0xF2A2177AC848B3A8(volume, p1, p2) end
+
+-- _ADD_NAVMESH_BLOCKING_VOLUME  (0x19C7567D2F2287D6)
+-- min build: 1207
+---@param volume number
+---@param flags number
+---@return boolean
+function _AddNavmeshBlockingVolume(volume, flags) end
+
+-- _DOES_NAVMESH_BLOCKING_VOLUME_EXIST  (0xDE0EA444735C1368)
+-- min build: 1207
+---@param volume number
+---@return boolean
+function _DoesNavmeshBlockingVolumeExist(volume) end
+
+-- _GET_SPAWN_DATA_FOR_ROAD_NODE  (0xA3791B915B8B84C6)
+-- min build: 1207
+---@param nodeId number
+---@param x number
+---@param y number
+---@param z number
+---@return vector3
+---@return number
+function _GetSpawnDataForRoadNode(nodeId, x, y, z) end
+
+-- _NAVMESH_ACTIVATE_SWAP  (0x7C334FF4D9215912)
+-- min build: 1207
+---@param name string
+---@return boolean
+function _NavmeshActivateSwap(name) end
+
+-- _NAVMESH_ASSIGN_NAVMESH_TO_VEHICLE  (0x44026E3DB3CED602)
+-- min build: 1207
+---@param vehicle number
+---@param navMeshName string
+---@return boolean
+function _NavmeshAssignNavmeshToVehicle(vehicle, navMeshName) end
+
+-- _NAVMESH_CLEAR_REQUESTED_PATH  (0x661BB1E1FF77742D)
+-- Called in scripts after finished with requested pathes. Immediately resets all values connected to the path handle except query status, which changes from 1 to 2 before eventually becoming fully invalidated to 0.
+-- min build: 1207
+---@param path number
+---@return boolean
+function _NavmeshClearRequestedPath(path) end
+
+-- _NAVMESH_DEACTIVATE_SWAP  (0x527B97C203BB8606)
+-- min build: 1207
+---@param name string
+---@return boolean
+function _NavmeshDeactivateSwap(name) end
+
+-- _NAVMESH_DOES_SWAP_EXIST  (0x495CFAB2924237C7)
+-- min build: 1207
+---@param name string
+---@return boolean
+function _NavmeshDoesSwapExist(name) end
+
+-- _NAVMESH_IS_SWAP_ACTIVE  (0x5AC0944C156E5F44)
+-- min build: 1207
+---@param name string
+---@return boolean
+function _NavmeshIsSwapActive(name) end
+
+-- _NAVMESH_REQUESTED_PATH_NUM_WAYPOINTS  (0xD470725E0703D22F)
+-- Returns the number of waypoints for a requested path (NAVMESH_REQUEST_PATH) if the query is completed (_NAVMESH_REQUESTED_PATH_QUERY_STATUS). For use with _NAVMESH_REQUESTED_PATH_WAYPOINT_BY_INDEX
+-- min build: 1207
+---@param path number
+---@return number
+function _NavmeshRequestedPathNumWaypoints(path) end
+
+-- _NAVMESH_REQUESTED_PATH_QUERY_STATUS  (0x3A0F82F6EE2291C8)
+-- Returns eNavMeshQueryStatus
+-- enum eNavMeshQueryStatus
+-- {
+-- 	QS_NOT_FOUND,
+-- 	QS_COMPLETE,
+-- 	QS_PENDING
+-- };
+-- 
+-- It appears that the pending state of 2 is at least also used when cleaning up a request (_NAVMESH_CLEAR_REQUESTED_PATH) or if a request never completes. Eventually queries are invalidated and return 0.
+-- 
+-- Old name: _NAVMESH_QUERY_STATUS, _NAVMESH_REQUESTED_QUERY_STATUS
+-- min build: 1207
+---@param path number
+---@return number
+function _NavmeshRequestedPathQueryStatus(path) end
+
+-- _NAVMESH_REQUESTED_PATH_WAYPOINT_BY_INDEX  (0x430F8319AE56C8A9)
+-- Returns a vector3 waypoint at the specified index for a path. Use _NAVMESH_REQUESTED_PATH_NUM_WAYPOINTS to get available indexes.
+-- min build: 1207
+---@param path number
+---@param waypointIndex number
+---@return vector3
+function _NavmeshRequestedPathWaypointByIndex(path, waypointIndex) end
+
+-- _NAVMESH_REQUESTED_PATH_WAYPOINTS_FOUND  (0x8800776E410EB669)
+-- Returns true if a path of waypoints was found. Waypoints can be retrieved with _NAVMESH_REQUESTED_PATH_NUM_WAYPOINTS and _NAVMESH_REQUESTED_PATH_WAYPOINT_BY_INDEX
+-- min build: 1207
+---@param path number
+---@return boolean
+function _NavmeshRequestedPathWaypointsFound(path) end
+
+-- _NAVMESH_REQUESTED_PATH_WAYPOINTS_TERRAIN  (0xF61CFEDEAB627BFA)
+-- Returns a bit flag for seemingly terrain within the waypoints in the path. Checked against bit value 2 to match water in the path, seems to always contain at least 1 though regardless of location/ped.
+-- min build: 1207
+---@param path number
+---@return number
+function _NavmeshRequestedPathWaypointsTerrain(path) end
+
+-- _REMOVE_NAVMESH_BLOCKING_VOLUME  (0x2C87C3E1C7B96EE2)
+-- min build: 1207
+---@param volume number
+function _RemoveNavmeshBlockingVolume(volume) end
+
+-- _SIMULATED_ROUTE_CREATE  (0xFD5BB35AAB83FD48)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p6 number
+---@return any
+function _SimulatedRouteCreate(x1, y1, z1, x2, y2, z2, p6) end
+
+-- _SIMULATED_ROUTE_DELETE  (0x4907D0E4FB26EE65)
+-- min build: 1207
+---@param p0 any
+function _SimulatedRouteDelete(p0) end
+
+-- _SIMULATED_ROUTE_EXISTS  (0x65A8196B8D7F5E0B)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function _SimulatedRouteExists(p0) end
+
+-- ADD_NAVMESH_BLOCKING_OBJECT  (0xFCD5C8E06E502F5A)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 boolean
+---@param p8 any
+---@return number
+function AddNavmeshBlockingObject(p0, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- ADD_NAVMESH_REQUIRED_REGION  (0x387EAD7EE42F6685)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param radius number
+function AddNavmeshRequiredRegion(x, y, radius) end
+
+-- ARE_NODES_LOADED_FOR_AREA  (0xF7B79A50B905A30D)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param x2 number
+---@param y2 number
+---@return boolean
+function AreNodesLoadedForArea(x1, y1, x2, y2) end
+
+-- DOES_NAVMESH_BLOCKING_OBJECT_EXIST  (0x0EAEB0DB4B132399)
+-- min build: 1207
+---@param object number
+---@return boolean
+function DoesNavmeshBlockingObjectExist(object) end
+
+-- GET_APPROX_FLOOR_FOR_POINT  (0x336511A34F2E5185)
+-- Returns CGameWorldHeightMap's minimum Z value at specified point (grid node).
+-- min build: 1207
+---@param x number
+---@param y number
+---@return number
+function GetApproxFloorForPoint(x, y) end
+
+-- GET_CLOSEST_ROAD  (0x132F52BBA570FE92)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param p4 number
+---@param p10 boolean
+---@return boolean
+---@return vector3
+---@return vector3
+---@return any
+---@return any
+---@return number
+function GetClosestRoad(x, y, z, p3, p4, p10) end
+
+-- GET_CLOSEST_VEHICLE_NODE  (0x240A18690AE96513)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param nodeType number
+---@param p5 number
+---@param p6 number
+---@return boolean
+---@return vector3
+function GetClosestVehicleNode(x, y, z, nodeType, p5, p6) end
+
+-- GET_CLOSEST_VEHICLE_NODE_WITH_HEADING  (0x23CFFD4CCB243354)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param nodeType number
+---@param p6 number
+---@param p7 number
+---@return boolean
+---@return vector3
+---@return number
+function GetClosestVehicleNodeWithHeading(x, y, z, nodeType, p6, p7) end
+
+-- GET_GPS_BLIP_ROUTE_FOUND  (0x869DAACBBE9FA006)
+-- min build: 1207
+---@return boolean
+function GetGpsBlipRouteFound() end
+
+-- GET_GPS_BLIP_ROUTE_LENGTH  (0xBBB45C3CF5C8AA85)
+-- min build: 1207
+---@return number
+function GetGpsBlipRouteLength() end
+
+-- GET_NTH_CLOSEST_VEHICLE_NODE  (0x5A6D8DF6FBC5D0C4)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param nthClosest number
+---@param unknown1 number
+---@param unknown2 number
+---@param unknown3 any
+---@return boolean
+---@return vector3
+function GetNthClosestVehicleNode(x, y, z, nthClosest, unknown1, unknown2, unknown3) end
+
+-- GET_NTH_CLOSEST_VEHICLE_NODE_FAVOUR_DIRECTION  (0x2FAC235A6062F14A)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param desiredX number
+---@param desiredY number
+---@param desiredZ number
+---@param nthClosest number
+---@param nodetype number
+---@param p10 any
+---@param p11 any
+---@return boolean
+---@return vector3
+---@return number
+function GetNthClosestVehicleNodeFavourDirection(x, y, z, desiredX, desiredY, desiredZ, nthClosest, nodetype, p10, p11) end
+
+-- GET_NTH_CLOSEST_VEHICLE_NODE_ID  (0x116443008E5CEFC3)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param nth number
+---@param nodetype number
+---@param p5 number
+---@param p6 number
+---@return number
+function GetNthClosestVehicleNodeId(x, y, z, nth, nodetype, p5, p6) end
+
+-- GET_NTH_CLOSEST_VEHICLE_NODE_ID_WITH_HEADING  (0x4114EAA8A7F7766D)
+-- Returns the nth closest vehicle node with a heading to a coord
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param nthClosest number
+---@param nodeFlags number
+---@param zMeasureMult number
+---@param zTolerance number
+---@return number
+---@return number
+---@return number
+function GetNthClosestVehicleNodeIdWithHeading(x, y, z, nthClosest, nodeFlags, zMeasureMult, zTolerance) end
+
+-- GET_NTH_CLOSEST_VEHICLE_NODE_WITH_HEADING  (0x591B40D4390DB54A)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param nthClosest number
+---@param unknown2 number
+---@param unknown3 number
+---@param unknown4 number
+---@return boolean
+---@return vector3
+---@return number
+---@return any
+function GetNthClosestVehicleNodeWithHeading(x, y, z, nthClosest, unknown2, unknown3, unknown4) end
+
+-- GET_NUM_NAVMESHES_EXISTING_IN_AREA  (0x01708E8DD3FF8C65)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@return number
+function GetNumNavmeshesExistingInArea(p0, p1, p2, p3, p4, p5) end
+
+-- GET_RANDOM_VEHICLE_NODE  (0x93E0DB8440B73A7D)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param minLanes number
+---@param avoidDeadEnds boolean
+---@param avoidHighways boolean
+---@return boolean
+---@return vector3
+---@return number
+function GetRandomVehicleNode(x, y, z, radius, minLanes, avoidDeadEnds, avoidHighways) end
+
+-- GET_SAFE_COORD_FOR_PED  (0xB61C8E878A4199CA)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param onGround boolean
+---@param flags number
+---@return boolean
+---@return vector3
+function GetSafeCoordForPed(x, y, z, onGround, flags) end
+
+-- GET_VEHICLE_NODE_IS_SWITCHED_OFF  (0x28533DBDDF7C2C97)
+-- min build: 1207
+---@param nodeID number
+---@return boolean
+function GetVehicleNodeIsSwitchedOff(nodeID) end
+
+-- GET_VEHICLE_NODE_POSITION  (0x8E8D72FF24DEE1FB)
+-- min build: 1207
+---@param nodeId number
+---@return vector3
+function GetVehicleNodePosition(nodeId) end
+
+-- IS_NAVMESH_LOADED_IN_AREA  (0xF813C7E63F9062A5)
+-- Returns whether navmesh for the region is loaded.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@return boolean
+function IsNavmeshLoadedInArea(x1, y1, z1, x2, y2, z2) end
+
+-- IS_POINT_ON_ROAD  (0x125BF4ABFC536B09)
+-- Gets a value indicating whether the specified position is on a road.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param vehicle number
+---@return boolean
+function IsPointOnRoad(x, y, z, vehicle) end
+
+-- IS_VEHICLE_NODE_ID_VALID  (0x5829A02AF4F0B3CB)
+-- Returns true if the id is non zero.
+-- min build: 1207
+---@param vehicleNodeId number
+---@return boolean
+function IsVehicleNodeIdValid(vehicleNodeId) end
+
+-- NAVMESH_REQUEST_PATH  (0x348F211CA2404039)
+-- Starts a nav mesh query for a path between coordinates with a given ped and returns a handle to be validated by _NAVMESH_REQUESTED_PATH_QUERY_STATUS and then _NAVMESH_REQUESTED_PATH_WAYPOINTS_FOUND
+-- 
+-- Only bit flag values used in scripts are 0, 23, and 29. 23 is used with dogs and horses. 29 with legendary animals.
+-- min build: 1207
+---@param ped number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param bitFlag number
+---@return number
+function NavmeshRequestPath(ped, x1, y1, z1, x2, y2, z2, bitFlag) end
+
+-- REMOVE_NAVMESH_BLOCKING_OBJECT  (0x46399A7895957C0E)
+-- min build: 1207
+---@param object number
+function RemoveNavmeshBlockingObject(object) end
+
+-- REQUEST_PATH_NODES_IN_AREA_THIS_FRAME  (0x07FB139B592FA687)
+-- Old name: REQUEST_PATHS_PREFER_ACCURATE_BOUNDINGSTRUCT
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param x2 number
+---@param y2 number
+---@return boolean
+function RequestPathNodesInAreaThisFrame(x1, y1, x2, y2) end
+
+-- RESET_ROADS_IN_VOLUME  (0xD17672447692478E)
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+function ResetRoadsInVolume(volume, p1) end
+
+-- SET_AMBIENT_PED_RANGE_MULTIPLIER_THIS_FRAME  (0x0B919E1FB47CC4E0)
+-- min build: 1207
+---@param multiplier number
+function SetAmbientPedRangeMultiplierThisFrame(multiplier) end
+
+-- SET_IGNORE_NO_GPS_FLAG  (0x72751156E7678833)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param toggle boolean
+function SetIgnoreNoGpsFlag(toggle) end
+
+-- SET_PED_PATHS_BACK_TO_ORIGINAL  (0xE04B48F2CC926253)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function SetPedPathsBackToOriginal(p0, p1, p2, p3, p4, p5, p6) end
+
+-- SET_PED_PATHS_IN_AREA  (0x34F060F4BF92E018)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param unknown boolean
+---@param p7 any
+function SetPedPathsInArea(x1, y1, z1, x2, y2, z2, unknown, p7) end
+
+-- SET_ROADS_BACK_TO_ORIGINAL  (0x1EE7063B80FFC77C)
+-- min build: 1207
+---@param xMin number
+---@param yMin number
+---@param zMin number
+---@param xMax number
+---@param yMax number
+---@param zMax number
+---@param p6 any
+---@param p7 any
+function SetRoadsBackToOriginal(xMin, yMin, zMin, xMax, yMax, zMax, p6, p7) end
+
+-- SET_ROADS_BACK_TO_ORIGINAL_IN_ANGLED_AREA  (0x0027501B9F3B407E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function SetRoadsBackToOriginalInAngledArea(p0, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- SET_ROADS_IN_ANGLED_AREA  (0x1A5AA1208AF5DB59)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function SetRoadsInAngledArea(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- SET_ROADS_IN_AREA  (0xBF1A602B5BA52FEE)
+-- min build: 1207
+---@param xMin number
+---@param yMin number
+---@param zMin number
+---@param xMax number
+---@param yMax number
+---@param zMax number
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function SetRoadsInArea(xMin, yMin, zMin, xMax, yMax, zMax, p6, p7, p8) end
+
+-- SET_ROADS_IN_VOLUME  (0xC1799FAFD2FDF52B)
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+function SetRoadsInVolume(volume, p1, p2, p3) end
+
+-- SIMULATED_ROUTE_GET_ETA  (0x2DD5F78D73B24172)
+-- min build: 1207
+---@param p0 any
+---@return number
+function SimulatedRouteGetEta(p0) end
+
+-- SIMULATED_ROUTE_IS_LOADED  (0x240915043CB799D7)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function SimulatedRouteIsLoaded(p0) end
+
+-- SIMULATED_ROUTE_TRAVEL_TO_POINT  (0xA1A3DE1C215C7394)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+function SimulatedRouteTravelToPoint(p0, p1, p2) end

--- a/.luals/redm-natives/PED.lua
+++ b/.luals/redm-natives/PED.lua
@@ -1,0 +1,7790 @@
+---@meta
+
+-- RDR3 namespace: PED -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x00B380FF2DF6AB7A  (0x00B380FF2DF6AB7A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x00B380FF2DF6AB7A(p0, p1) end
+
+-- _0x024EC9B649111915  (0x024EC9B649111915)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x024EC9B649111915(ped, p1) end
+
+-- _0x02E741E19E39628C  (0x02E741E19E39628C)
+-- _SET_PLAYER_SN* - _SET_PLAYER_STAMINA*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x02E741E19E39628C(ped, p1) end
+
+-- _0x0455546F23FF08E4  (0x0455546F23FF08E4)
+-- _DOES_GROUP_* - _DOES_N*
+-- min build: 1207
+---@param groupId number
+---@return boolean
+function N_0x0455546F23FF08E4(groupId) end
+
+-- _0x06A10B4D7F50B0C3  (0x06A10B4D7F50B0C3)
+-- _GET_PED_D*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x06A10B4D7F50B0C3(ped) end
+
+-- _0x070A3841406C43D5  (0x070A3841406C43D5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x070A3841406C43D5(p0, p1) end
+
+-- _0x07EA5B053FA60AC7  (0x07EA5B053FA60AC7)
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0x07EA5B053FA60AC7(groupId, p1) end
+
+-- _0x09171A6F8FDE5DC1  (0x09171A6F8FDE5DC1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x09171A6F8FDE5DC1(p0, p1, p2, p3, p4) end
+
+-- _0x095C2277FED731DB  (0x095C2277FED731DB)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x095C2277FED731DB(p0) end
+
+-- _0x09D7AFD3716DA8E1  (0x09D7AFD3716DA8E1)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function N_0x09D7AFD3716DA8E1(ped, p1) end
+
+-- _0x0A4618FFD517E24D  (0x0A4618FFD517E24D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0A4618FFD517E24D(p0, p1) end
+
+-- _0x0ADA3EC589E1736E  (0x0ADA3EC589E1736E)
+-- min build: 1207
+function N_0x0ADA3EC589E1736E() end
+
+-- _0x0B787A37EEDD226F  (0x0B787A37EEDD226F)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+function N_0x0B787A37EEDD226F(p0, p1) end
+
+-- _0x0D3B1568917EBDA0  (0x0D3B1568917EBDA0)
+-- _IS_PED_M*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function N_0x0D3B1568917EBDA0(ped, p1) end
+
+-- _0x0D497AA69059FE40  (0x0D497AA69059FE40)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0D497AA69059FE40(p0, p1) end
+
+-- _0x0EEF7A81C17679DB  (0x0EEF7A81C17679DB)
+-- _IS_PED_L* - _IS_PED_M*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x0EEF7A81C17679DB(ped) end
+
+-- _0x0F967019CC853BCC  (0x0F967019CC853BCC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0F967019CC853BCC(p0, p1) end
+
+-- _0x0FB1BA7FF73B41E1  (0x0FB1BA7FF73B41E1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x0FB1BA7FF73B41E1(p0, p1, p2) end
+
+-- _0x0FFDF937E5C11382  (0x0FFDF937E5C11382)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0x0FFDF937E5C11382(p0, p1, p2, p3, p4, p5) end
+
+-- _0x101B45C5F56D970F  (0x101B45C5F56D970F)
+-- min build: 1207
+---@param ped number
+---@param damageCleanliness number
+---@param p3 number
+---@return boolean
+---@return any
+function N_0x101B45C5F56D970F(ped, damageCleanliness, p3) end
+
+-- _0x10F96086123B939F  (0x10F96086123B939F)
+-- NB_CUSTOM_CLIENT_ON_CREATE_COMPLETE - set legendary to not avoid prey
+-- min build: 1207
+---@param legendaryPed number
+---@param preyPed number
+---@param p2 number
+function N_0x10F96086123B939F(legendaryPed, preyPed, p2) end
+
+-- _0x1148F706CF4EBDDA  (0x1148F706CF4EBDDA)
+-- _CAN_PED_SEE* - _CAN_PED_USE_(SCENARIO_HASH?)*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@return boolean
+function N_0x1148F706CF4EBDDA(ped, p1, p2) end
+
+-- _0x1298B3D8E4C2409F  (0x1298B3D8E4C2409F)
+-- min build: 1207
+---@param p0 any
+function N_0x1298B3D8E4C2409F(p0) end
+
+-- _0x12EB4E31F092C9B3  (0x12EB4E31F092C9B3)
+-- _GET_IS_PED_(BLEEDING_OUT?)*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x12EB4E31F092C9B3(ped) end
+
+-- _0x12F2D161BF4031FC  (0x12F2D161BF4031FC)
+-- _SET_A* - _SET_B*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x12F2D161BF4031FC(ped, p1) end
+
+-- _0x134775B093AD5C38  (0x134775B093AD5C38)
+-- _GET_PED_M*
+-- min build: 1207
+---@param ped number
+---@return number
+function N_0x134775B093AD5C38(ped) end
+
+-- _0x154B7E841AC7412F  (0x154B7E841AC7412F)
+-- _SET_SCENARIO_PED_* - _SET_SPAWNER_*
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0x154B7E841AC7412F(groupId, p1) end
+
+-- _0x15F4732C357B1D6D  (0x15F4732C357B1D6D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x15F4732C357B1D6D(p0, p1, p2) end
+
+-- _0x16802C32B2FCA06B  (0x16802C32B2FCA06B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x16802C32B2FCA06B(p0, p1, p2, p3) end
+
+-- _0x16F798A05BB9E3B5  (0x16F798A05BB9E3B5)
+-- _PED_COWER_M*
+-- min build: 1207
+---@param ped number
+function N_0x16F798A05BB9E3B5(ped) end
+
+-- _0x1D23D3F70606D788  (0x1D23D3F70606D788)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1D23D3F70606D788(p0, p1) end
+
+-- _0x1D4636C90BBEFACB  (0x1D4636C90BBEFACB)
+-- _SET_PED_CA* - _SET_PED_CO*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x1D4636C90BBEFACB(ped, p1) end
+
+-- _0x1F44B7E283C09EDE  (0x1F44B7E283C09EDE)
+-- Only used in SP R* Scripts
+-- Params: p2 = same as p2 of 0x3C529A827998F9B3
+-- _SET_PED_TA* - _SET_PED_TO_*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function N_0x1F44B7E283C09EDE(ped, p1, p2) end
+
+-- _0x1F8215D0E446F593  (0x1F8215D0E446F593)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x1F8215D0E446F593(p0, p1, p2) end
+
+-- _0x2371C39D4F91C288  (0x2371C39D4F91C288)
+-- min build: 1207
+---@param ped number
+function N_0x2371C39D4F91C288(ped) end
+
+-- _0x23BDE06596A22CEC  (0x23BDE06596A22CEC)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 any
+function N_0x23BDE06596A22CEC(ped, p1, p2, p3) end
+
+-- _0x242EDF85D4E87B65  (0x242EDF85D4E87B65)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x242EDF85D4E87B65(p0) end
+
+-- _0x256EDD55C6BE1482  (0x256EDD55C6BE1482)
+-- _IS_PED_FL* - _IS_PED_FU*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x256EDD55C6BE1482(ped) end
+
+-- _0x273915CE30780986  (0x273915CE30780986)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x273915CE30780986(p0, p1) end
+
+-- _0x27E8A84C12B0B7D1  (0x27E8A84C12B0B7D1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x27E8A84C12B0B7D1(p0, p1, p2) end
+
+-- _0x28508173C6A7CC18  (0x28508173C6A7CC18)
+-- min build: 1311
+---@param p0 any
+function N_0x28508173C6A7CC18(p0) end
+
+-- _0x290B2E6CCDE532E1  (0x290B2E6CCDE532E1)
+-- _IS_PED_L* - _IS_PED_M*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x290B2E6CCDE532E1(ped) end
+
+-- _0x29924EB8EE9DB926  (0x29924EB8EE9DB926)
+-- _SET_PED_K* or _SET_PED_L*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x29924EB8EE9DB926(ped, p1) end
+
+-- _0x29F3539189D3E277  (0x29F3539189D3E277)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x29F3539189D3E277(p0, p1) end
+
+-- _0x2D976DBDC731DF80  (0x2D976DBDC731DF80)
+-- min build: 1207
+---@param ped number
+function N_0x2D976DBDC731DF80(ped) end
+
+-- _0x2DC0E8DCBD3546E9  (0x2DC0E8DCBD3546E9)
+-- _IS_PED_D*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x2DC0E8DCBD3546E9(ped) end
+
+-- _0x2DD4E0E26DFAD97D  (0x2DD4E0E26DFAD97D)
+-- _IS_PED_M* - _IS_PED_O*
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+---@param p2 number
+---@return boolean
+function N_0x2DD4E0E26DFAD97D(ped1, ped2, p2) end
+
+-- _0x2E5B5D1F1453E08E  (0x2E5B5D1F1453E08E)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x2E5B5D1F1453E08E(ped, p1) end
+
+-- _0x2FA568BFA725F8D6  (0x2FA568BFA725F8D6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x2FA568BFA725F8D6(p0, p1, p2, p3) end
+
+-- _0x31B2E7F2E3C58B89  (0x31B2E7F2E3C58B89)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0x31B2E7F2E3C58B89(p0, p1, p2, p3) end
+
+-- _0x32417CB860A3BDC4  (0x32417CB860A3BDC4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x32417CB860A3BDC4(p0, p1) end
+
+-- _0x326F7951EF0D7F75  (0x326F7951EF0D7F75)
+-- Only used in R* SP Script short_update
+-- _GET_TARGET_* - _GET_TRACKED*
+-- min build: 1207
+---@param ped number
+---@param eventType number
+---@return any
+function N_0x326F7951EF0D7F75(ped, eventType) end
+
+-- _0x329772C47DBB2FBC  (0x329772C47DBB2FBC)
+-- _SET_PED_P* - _SET_PED_R*
+-- min build: 1207
+---@param ped number
+function N_0x329772C47DBB2FBC(ped) end
+
+-- _0x32CCAD8A981B53D3  (0x32CCAD8A981B53D3)
+-- _STOP_(?)*
+-- min build: 1207
+---@param ped number
+function N_0x32CCAD8A981B53D3(ped) end
+
+-- _0x32CEDA9A0AB4CEF7  (0x32CEDA9A0AB4CEF7)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0x32CEDA9A0AB4CEF7(ped, p1, p2) end
+
+-- _0x34B5CEAC180A5D6E  (0x34B5CEAC180A5D6E)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0x34B5CEAC180A5D6E(ped, p1, p2) end
+
+-- _0x34C11114887150FD  (0x34C11114887150FD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x34C11114887150FD(p0, p1) end
+
+-- _0x34EDDD59364AD74A  (0x34EDDD59364AD74A)
+-- min build: 1207
+---@param ped number
+---@return any
+function N_0x34EDDD59364AD74A(ped) end
+
+-- _0x354CA4DDDEEC397A  (0x354CA4DDDEEC397A)
+-- min build: 1207
+---@param ped number
+---@return number
+function N_0x354CA4DDDEEC397A(ped) end
+
+-- _0x370A973252741AC4  (0x370A973252741AC4)
+-- _RESET_PED_*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x370A973252741AC4(ped, p1) end
+
+-- _0x3A5697B80FED5EBE  (0x3A5697B80FED5EBE)
+-- _SET_PED_MO*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function N_0x3A5697B80FED5EBE(ped, p1, p2, p3, p4) end
+
+-- _0x3ACCE14DFA6BA8C2  (0x3ACCE14DFA6BA8C2)
+-- Used in R* Script net_fetch (NET_FETCH_UPDATE_RECIPIENT_PROP_ILO_IN_COMBAT) and various SP Scripts
+-- Params: p1 = 4/5/6, p5 = 40.f/100.f, coords = Player ped
+-- Perhaps returns some distance (Clearing that the local player is able to use ILO while in combat because they are near the recipient but also near hated peds)
+-- _GET_NUM_M* - _GET_PEDS_J*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param x number
+---@param y number
+---@param z number
+---@param p5 number
+---@param itemset number
+---@return number
+function N_0x3ACCE14DFA6BA8C2(ped, p1, x, y, z, p5, itemset) end
+
+-- _0x3AEC4A410ECAF30D  (0x3AEC4A410ECAF30D)
+-- _IS_PED_R*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x3AEC4A410ECAF30D(ped) end
+
+-- _0x3C529A827998F9B3  (0x3C529A827998F9B3)
+-- _SET_PED_TA* - _SET_PED_TO_*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function N_0x3C529A827998F9B3(ped, p1, p2) end
+
+-- _0x3EFED081B4834BA1  (0x3EFED081B4834BA1)
+-- min build: 1232
+---@param p0 any
+function N_0x3EFED081B4834BA1(p0) end
+
+-- _0x3FCBB5FCFD968698  (0x3FCBB5FCFD968698)
+-- Used for script function PROCESS_PLAYER_HAT_EVENT
+-- Returns requestId to be used with 0x13E7320C762F0477
+-- min build: 1207
+---@param drawable number
+---@param albedo number
+---@param normal number
+---@param material number
+---@param p4 any
+---@return number
+function N_0x3FCBB5FCFD968698(drawable, albedo, normal, material, p4) end
+
+-- _0x3FDBB99EFD8CE4AF  (0x3FDBB99EFD8CE4AF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x3FDBB99EFD8CE4AF(p0, p1, p2) end
+
+-- _0x3FDCC1F8C17E303E  (0x3FDCC1F8C17E303E)
+-- Changes health bar around heart core icon
+-- INITIALISE_NEW_ROLE - Applying Super Jump buffs: p1 = 10, p2 = 0.0f
+-- INITIALISE_NEW_ROLE - Clearing up Super Jump buffs: p1 = 10, p2 = 1.0f
+-- _SET_D*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function N_0x3FDCC1F8C17E303E(ped, p1, p2) end
+
+-- _0x405180B14DA5A935  (0x405180B14DA5A935)
+-- _SET_PED_A*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x405180B14DA5A935(ped, p1) end
+
+-- _0x40C3524D4ED83554  (0x40C3524D4ED83554)
+-- _SET_SCENARIO_PED_* - _SET_SPAWNER_*
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0x40C3524D4ED83554(groupId, p1) end
+
+-- _0x40C9155AF8BC13F3  (0x40C9155AF8BC13F3)
+-- _IS_PED_RE*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x40C9155AF8BC13F3(ped) end
+
+-- _0x413697EC260AABBF  (0x413697EC260AABBF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x413697EC260AABBF(p0, p1, p2) end
+
+-- _0x41C23A8E6B344867  (0x41C23A8E6B344867)
+-- _SET_PED_IN*
+-- min build: 1207
+---@param ped number
+---@param p1 string
+function N_0x41C23A8E6B344867(ped, p1) end
+
+-- _0x45FEA6D5539BD474  (0x45FEA6D5539BD474)
+-- _SET_PED_IN*
+-- min build: 1207
+---@param ped number
+---@param p1 string
+function N_0x45FEA6D5539BD474(ped, p1) end
+
+-- _0x49DADFC4CD808B0A  (0x49DADFC4CD808B0A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x49DADFC4CD808B0A(p0, p1, p2) end
+
+-- _0x4B19F171450E0D4F  (0x4B19F171450E0D4F)
+-- min build: 1207
+---@param ped number
+---@return number
+function N_0x4B19F171450E0D4F(ped) end
+
+-- _0x4E68C7EF706DF35D  (0x4E68C7EF706DF35D)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param relationshipGroup number
+function N_0x4E68C7EF706DF35D(ped, x, y, z, p4, relationshipGroup) end
+
+-- _0x4EC4EA2F72B36358  (0x4EC4EA2F72B36358)
+-- _SET_PED_A*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x4EC4EA2F72B36358(ped, p1) end
+
+-- _0x4F27603E44A8E4C0  (0x4F27603E44A8E4C0)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0x4F27603E44A8E4C0(ped, p1, p2) end
+
+-- _0x4F63433CE3C08230  (0x4F63433CE3C08230)
+-- Only used in R* Script shop_harriet
+-- _SET_PED_F*
+-- min build: 1311
+---@param ped number
+---@param p1 boolean
+function N_0x4F63433CE3C08230(ped, p1) end
+
+-- _0x5203038FF8BAE577  (0x5203038FF8BAE577)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@return boolean
+function N_0x5203038FF8BAE577(ped, p1, p2) end
+
+-- _0x52250B92EA70BE3D  (0x52250B92EA70BE3D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x52250B92EA70BE3D(p0) end
+
+-- _0x52A24D8A1DA89658  (0x52A24D8A1DA89658)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0x52A24D8A1DA89658(ped, p1, p2) end
+
+-- _0x53BA7D96B9A421D9  (0x53BA7D96B9A421D9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x53BA7D96B9A421D9(p0, p1) end
+
+-- _0x54D3CD482742C482  (0x54D3CD482742C482)
+-- min build: 1355
+---@param animal number
+---@param p2 number
+function N_0x54D3CD482742C482(animal, p2) end
+
+-- _0x550CB89DD7F4FA3D  (0x550CB89DD7F4FA3D)
+-- _HAS_PED_*
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+---@return boolean
+function N_0x550CB89DD7F4FA3D(ped1, ped2) end
+
+-- _0x55546004A244302A  (0x55546004A244302A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x55546004A244302A(p0, p1) end
+
+-- _0x56076667E7C2DCD6  (0x56076667E7C2DCD6)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+function N_0x56076667E7C2DCD6(p0, p1) end
+
+-- _0x56E4BAD93D33453C  (0x56E4BAD93D33453C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x56E4BAD93D33453C(p0, p1) end
+
+-- _0x577C60BA06D0EA64  (0x577C60BA06D0EA64)
+-- _IS_PED_C* - _IS_PED_D*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x577C60BA06D0EA64(ped) end
+
+-- _0x57F35552E771BE9D  (0x57F35552E771BE9D)
+-- _SET_PED_M*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x57F35552E771BE9D(ped, p1) end
+
+-- _0x5A1A929C8B729B4A  (0x5A1A929C8B729B4A)
+-- _C*
+-- min build: 1207
+---@param ped number
+function N_0x5A1A929C8B729B4A(ped) end
+
+-- _0x5AF24CA9C974E51A  (0x5AF24CA9C974E51A)
+-- _SET_C*
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+function N_0x5AF24CA9C974E51A(ped1, ped2) end
+
+-- _0x5B73975B4F12F7F3  (0x5B73975B4F12F7F3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x5B73975B4F12F7F3(p0, p1, p2, p3, p4) end
+
+-- _0x5BB04BC74A474B47  (0x5BB04BC74A474B47)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x5BB04BC74A474B47(p0, p1) end
+
+-- _0x5BF0B9D9A8E227A0  (0x5BF0B9D9A8E227A0)
+-- _IS_PED_B* - _IS_PED_C*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x5BF0B9D9A8E227A0(ped) end
+
+-- _0x5C6C7C70CA302801  (0x5C6C7C70CA302801)
+-- _IS_PED_IN*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x5C6C7C70CA302801(ped) end
+
+-- _0x5C90E20C25E6D83C  (0x5C90E20C25E6D83C)
+-- min build: 1207
+---@param p0 any
+function N_0x5C90E20C25E6D83C(p0) end
+
+-- _0x5CA20FBE49891BBD  (0x5CA20FBE49891BBD)
+-- Used in Script Function MP_MAIN_OFFLINE__INITIALIZE_FLOW & PROCESS_GENERIC_PLAYER_INITIALIZATION
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x5CA20FBE49891BBD(ped, p1) end
+
+-- _0x5CB2EBB467BE3ED6  (0x5CB2EBB467BE3ED6)
+-- min build: 1355
+---@param animal number
+---@param p2 number
+function N_0x5CB2EBB467BE3ED6(animal, p2) end
+
+-- _0x5D4CD22A8C82A81A  (0x5D4CD22A8C82A81A)
+-- Related to ped hat
+-- _SET_PED_LA* - _SET_PED_LE*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x5D4CD22A8C82A81A(ped, p1) end
+
+-- _0x5DA36CCCB63C0895  (0x5DA36CCCB63C0895)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x5DA36CCCB63C0895(p0, p1, p2) end
+
+-- _0x5E9FAF6C513347B4  (0x5E9FAF6C513347B4)
+-- Only used in R* SP Scripts
+-- _GET_PED_IN*
+-- min build: 1207
+---@param ped number
+---@param eventType number
+---@return number
+function N_0x5E9FAF6C513347B4(ped, eventType) end
+
+-- _0x5EFA8A3D8A60D662  (0x5EFA8A3D8A60D662)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x5EFA8A3D8A60D662(p0, p1) end
+
+-- _0x5FCF25D584065BFD  (0x5FCF25D584065BFD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x5FCF25D584065BFD(p0, p1, p2, p3) end
+
+-- _0x600BBDD29820370C  (0x600BBDD29820370C)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+function N_0x600BBDD29820370C(ped) end
+
+-- _0x604E1010E3162E86  (0x604E1010E3162E86)
+-- min build: 1207
+---@param ped number
+---@param propItemId string
+---@param p2 string
+function N_0x604E1010E3162E86(ped, propItemId, p2) end
+
+-- _0x606D529DADA3C940  (0x606D529DADA3C940)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function N_0x606D529DADA3C940(ped, p1) end
+
+-- _0x62FDF4E678E40CC6  (0x62FDF4E678E40CC6)
+-- Returns p1 value for 0x8E84119A23C16623
+-- min build: 1207
+---@param entity number
+---@param p1 any
+---@return any
+function N_0x62FDF4E678E40CC6(entity, p1) end
+
+-- _0x633F83B301C87994  (0x633F83B301C87994)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x633F83B301C87994(p0, p1) end
+
+-- _0x642720D8D69328B6  (0x642720D8D69328B6)
+-- _SET_PED_M*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x642720D8D69328B6(ped, p1) end
+
+-- _0x6507AC3BD7C99009  (0x6507AC3BD7C99009)
+-- _IS_N* - _IS_P*
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@return boolean
+function N_0x6507AC3BD7C99009(x, y, z, p3) end
+
+-- _0x6734F0A6A52C371C  (0x6734F0A6A52C371C)
+-- min build: 1207
+---@param player number
+---@param horseSlot number
+function N_0x6734F0A6A52C371C(player, horseSlot) end
+
+-- _0x6A190B94C2541A99  (0x6A190B94C2541A99)
+-- min build: 1207
+---@param p0 any
+function N_0x6A190B94C2541A99(p0) end
+
+-- _0x6A489892E813951A  (0x6A489892E813951A)
+-- min build: 1207
+---@param p0 any
+function N_0x6A489892E813951A(p0) end
+
+-- _0x6E8B87139854022D  (0x6E8B87139854022D)
+-- Only used in SP R* Script train_robbery3: p1 = CLIPSET@VEH_TRAIN@HANDCART@BASE_PANIC & CLIPSET@VEH_TRAIN@HANDCART@BASE_PANIC_JOHN
+-- min build: 1207
+---@param ped number
+---@param clipset string
+function N_0x6E8B87139854022D(ped, clipset) end
+
+-- _0x6F46F8ACB44C4FC1  (0x6F46F8ACB44C4FC1)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x6F46F8ACB44C4FC1(p0) end
+
+-- _0x7020839C7302D8AC  (0x7020839C7302D8AC)
+-- _HAS_*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x7020839C7302D8AC(ped) end
+
+-- _0x704C908E9C405136  (0x704C908E9C405136)
+-- _CLEAR*
+-- min build: 1207
+---@param ped number
+function N_0x704C908E9C405136(ped) end
+
+-- _0x712B2C2B2471B493  (0x712B2C2B2471B493)
+-- _SET_PED_MO*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x712B2C2B2471B493(ped, p1) end
+
+-- _0x735662994E60A710  (0x735662994E60A710)
+-- _SET_PED_F*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x735662994E60A710(ped, p1) end
+
+-- _0x7406C71F4AC2FFCC  (0x7406C71F4AC2FFCC)
+-- min build: 1207
+---@param p0 any
+function N_0x7406C71F4AC2FFCC(p0) end
+
+-- _0x758F081DB204DDDE  (0x758F081DB204DDDE)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x758F081DB204DDDE(ped) end
+
+-- _0x75A082563B4452E5  (0x75A082563B4452E5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x75A082563B4452E5(p0, p1, p2, p3) end
+
+-- _0x75D3333409CD33CE  (0x75D3333409CD33CE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x75D3333409CD33CE(p0, p1, p2) end
+
+-- _0x763FA8A9D76EE3A7  (0x763FA8A9D76EE3A7)
+-- Used in Script Function NB_EVENT_OVERRIDE__HANDLE__EVENT_DAMAGE_ENTITY
+-- min build: 1311
+---@param ped number
+---@return number
+function N_0x763FA8A9D76EE3A7(ped) end
+
+-- _0x77243ED4F7CAAA55  (0x77243ED4F7CAAA55)
+-- _IS_I* - _IS_L*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x77243ED4F7CAAA55(ped) end
+
+-- _0x7ABBD9E449E0DB00  (0x7ABBD9E449E0DB00)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x7ABBD9E449E0DB00(ped, p1) end
+
+-- _0x7B5C293238EE4F20  (0x7B5C293238EE4F20)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x7B5C293238EE4F20(p0) end
+
+-- _0x7BB810E8B343AC7B  (0x7BB810E8B343AC7B)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x7BB810E8B343AC7B(p0) end
+
+-- _0x7C08E7CB8D951B70  (0x7C08E7CB8D951B70)
+-- Only used in SP
+-- _SET_REMOVE_PED*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x7C08E7CB8D951B70(ped, p1) end
+
+-- _0x7C10221CE718AA72  (0x7C10221CE718AA72)
+-- _CLEAR_PED_M*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x7C10221CE718AA72(ped, p1) end
+
+-- _0x7E5185B979706210  (0x7E5185B979706210)
+-- _SET_FORMATION_P*
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+function N_0x7E5185B979706210(groupId, p1) end
+
+-- _0x7E8F9949B7AABBF0  (0x7E8F9949B7AABBF0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x7E8F9949B7AABBF0(p0, p1, p2) end
+
+-- _0x7EDB3C766B0D073F  (0x7EDB3C766B0D073F)
+-- Only used in R* Script net_moonshine_property
+-- _A* - _B*
+-- min build: 1232
+---@param ped number
+function N_0x7EDB3C766B0D073F(ped) end
+
+-- _0x7EE3A8660F38797E  (0x7EE3A8660F38797E)
+-- Seems to return true if the ped is in the intimidated on ass state. Checks if task index 478 (TASK_INTIMIDATED) is active.
+-- _IS_PED_H* - _IS_PED_I*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x7EE3A8660F38797E(ped) end
+
+-- _0x7F090958AE95B61B  (0x7F090958AE95B61B)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function N_0x7F090958AE95B61B(ped, p1) end
+
+-- _0x8101BA1C0B462412  (0x8101BA1C0B462412)
+-- _ATTACH_*
+-- min build: 1207
+---@param ped number
+---@param ropeId number
+function N_0x8101BA1C0B462412(ped, ropeId) end
+
+-- _0x82CB0F3F0C7785E5  (0x82CB0F3F0C7785E5)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x82CB0F3F0C7785E5(p0) end
+
+-- _0x851966E1E35AF491  (0x851966E1E35AF491)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x851966E1E35AF491(p0, p1) end
+
+-- _0x85F500F4E24CA43E  (0x85F500F4E24CA43E)
+-- Used in Script Function SKCS_PLAYER_ROBBING
+-- _SET_PED_A*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x85F500F4E24CA43E(ped, p1) end
+
+-- _0x86F0B6730C32AC14  (0x86F0B6730C32AC14)
+-- _SET_PED_*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x86F0B6730C32AC14(ped, p1) end
+
+-- _0x86FAFC18E3D4380C  (0x86FAFC18E3D4380C)
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0x86FAFC18E3D4380C(groupId, p1) end
+
+-- _0x878E8104FA27CDAE  (0x878E8104FA27CDAE)
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+function N_0x878E8104FA27CDAE(vehicle, p1) end
+
+-- _0x87C2724A56F66020  (0x87C2724A56F66020)
+-- _CLEAR_PED_E* - _CLEAR_PED_L*
+-- min build: 1207
+---@param ped number
+function N_0x87C2724A56F66020(ped) end
+
+-- _0x8822F124788B8D0A  (0x8822F124788B8D0A)
+-- Only used in R* Script train_robbery4
+-- _SET_PED_D*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x8822F124788B8D0A(ped, p1) end
+
+-- _0x8822F139408B8D0A  (0x8822F139408B8D0A)
+-- If returned true, SET_ENABLE_BOUND_ANKLES is called in R* Script guama2
+-- _GET_D* - _GET_E*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x8822F139408B8D0A(ped) end
+
+-- _0x88A95BB640FC186F  (0x88A95BB640FC186F)
+-- Used in R* Script generic_weight_control_item
+-- _CLEAR_PED_E* - CLEAR_PED_(G?)L*
+-- min build: 1207
+---@param ped number
+function N_0x88A95BB640FC186F(ped) end
+
+-- _0x88B2026A3B0BE33D  (0x88B2026A3B0BE33D)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x88B2026A3B0BE33D(ped, p1) end
+
+-- _0x897934E868EDDD6C  (0x897934E868EDDD6C)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function N_0x897934E868EDDD6C(ped, p1, p2, p3, p4) end
+
+-- _0x89816B58C3466262  (0x89816B58C3466262)
+-- _GET_PED_B* - _GET_PED_C*
+-- min build: 1207
+---@param ped number
+---@return any
+function N_0x89816B58C3466262(ped) end
+
+-- _0x899DFA0009AC93DE  (0x899DFA0009AC93DE)
+-- _SET_PED_O*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x899DFA0009AC93DE(ped, p1) end
+
+-- _0x89E59DBD15E21177  (0x89E59DBD15E21177)
+-- _SET_C*
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+function N_0x89E59DBD15E21177(groupId, p1) end
+
+-- _0x8AF46E5159A5B620  (0x8AF46E5159A5B620)
+-- _SET_PED_IN*
+-- min build: 1207
+---@param ped number
+---@param speechParams number
+function N_0x8AF46E5159A5B620(ped, speechParams) end
+
+-- _0x8AF8E647D6B2A649  (0x8AF8E647D6B2A649)
+-- Returns offset (0 < 32) to be used with MISC::SET_BIT
+-- _GET_PED_CR*
+-- min build: 1207
+---@param groupId number
+---@param ped number
+---@return number
+function N_0x8AF8E647D6B2A649(groupId, ped) end
+
+-- _0x8AFCCC0F18D70018  (0x8AFCCC0F18D70018)
+-- _SET_FORMATION_*
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0x8AFCCC0F18D70018(groupId, p1) end
+
+-- _0x8BA0C65AC15A7D33  (0x8BA0C65AC15A7D33)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x8BA0C65AC15A7D33(p0, p1, p2, p3) end
+
+-- _0x8BE24D74D74C6E9B  (0x8BE24D74D74C6E9B)
+-- Used in Script Function NET_CAMP_DOG_CLIENT_HANDLE_ANIMAL_INTERACTION
+-- min build: 1207
+---@param ped number
+---@return number
+function N_0x8BE24D74D74C6E9B(ped) end
+
+-- _0x8CB2553C559102C1  (0x8CB2553C559102C1)
+-- _SET_PED_T* - SET_PED_U*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0x8CB2553C559102C1(ped, p1, p2) end
+
+-- _0x8D9DB115FBA8E23D  (0x8D9DB115FBA8E23D)
+-- min build: 1207
+---@param p0 any
+function N_0x8D9DB115FBA8E23D(p0) end
+
+-- _0x9078FB0557364099  (0x9078FB0557364099)
+-- min build: 1207
+---@param p0 any
+function N_0x9078FB0557364099(p0) end
+
+-- _0x913D04A5176F84C9  (0x913D04A5176F84C9)
+-- _IS_PED_S* - _IS_PED_U*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x913D04A5176F84C9(ped) end
+
+-- _0x9184788BFF1EDAD7  (0x9184788BFF1EDAD7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9184788BFF1EDAD7(p0, p1) end
+
+-- _0x91BAB9E064F036CD  (0x91BAB9E064F036CD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x91BAB9E064F036CD(p0, p1) end
+
+-- _0x92A1B55A59720395  (0x92A1B55A59720395)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x92A1B55A59720395(p0, p1) end
+
+-- _0x94132D7C8D3575C4  (0x94132D7C8D3575C4)
+-- _GET_IS_PED_*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0x94132D7C8D3575C4(ped) end
+
+-- _0x9629FAF6460D35CB  (0x9629FAF6460D35CB)
+-- min build: 1207
+---@param group number
+---@param p1 boolean
+function N_0x9629FAF6460D35CB(group, p1) end
+
+-- _0x96595B36D6A2279B  (0x96595B36D6A2279B)
+-- Only used in R* Script mob4 combined with SET_ANIMAL_TUNING_BOOL_PARAM
+-- _SET_PED_S* - _SET_PED_TARGET_*
+-- min build: 1207
+---@param animal number
+---@param toggle boolean
+function N_0x96595B36D6A2279B(animal, toggle) end
+
+-- _0x966DE09688A1DE39  (0x966DE09688A1DE39)
+-- _SET_FORMATION_P*
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function N_0x966DE09688A1DE39(groupId, p1, p2, p3, p4) end
+
+-- _0x96C7B659854DE629  (0x96C7B659854DE629)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x96C7B659854DE629(p0, p1) end
+
+-- _0x97A38B65EBDA3D50  (0x97A38B65EBDA3D50)
+-- _SET_PED_D*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x97A38B65EBDA3D50(ped, p1) end
+
+-- _0x97B06669AC569003  (0x97B06669AC569003)
+-- _CLEAR*
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+function N_0x97B06669AC569003(ped1, ped2) end
+
+-- _0x97C475212B327666  (0x97C475212B327666)
+-- _SET_SCENARIO_PED_* - _SET_SPAWNER_*
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0x97C475212B327666(groupId, p1) end
+
+-- _0x9851DE7AEC10B4E1  (0x9851DE7AEC10B4E1)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param p3 number
+---@param p4 number
+---@param p5 any
+function N_0x9851DE7AEC10B4E1(x, y, z, p3, p4, p5) end
+
+-- _0x992187D975635DF5  (0x992187D975635DF5)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+function N_0x992187D975635DF5(p0, p1) end
+
+-- _0x99DF2639DA76C1DC  (0x99DF2639DA76C1DC)
+-- _CAN_PED_*
+-- min build: 1232
+---@param ped1 number
+---@param ped2 number
+---@param p2 number
+---@return boolean
+function N_0x99DF2639DA76C1DC(ped1, ped2, p2) end
+
+-- _0x9A4AC116CC1EEE14  (0x9A4AC116CC1EEE14)
+-- min build: 1207
+---@param p0 any
+function N_0x9A4AC116CC1EEE14(p0) end
+
+-- _0x9AB33CB5834885B3  (0x9AB33CB5834885B3)
+-- _SET_PED_M*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function N_0x9AB33CB5834885B3(ped, p1, p2, p3, p4) end
+
+-- _0x9B65444C07B782BF  (0x9B65444C07B782BF)
+-- Only used in SP R* Script winter1: p1 = Winter1Mount
+-- min build: 1207
+---@param ped number
+---@param p1 string
+function N_0x9B65444C07B782BF(ped, p1) end
+
+-- _0x9B9B9FA0EA283E3D  (0x9B9B9FA0EA283E3D)
+-- Used in Script Function SKCS_PLAYER_ROBBING
+-- _SET_PED_SHOULD_PLAY_* - _SET_PED_SW*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x9B9B9FA0EA283E3D(ped, p1) end
+
+-- _0x9BBEAF8B0C007F1E  (0x9BBEAF8B0C007F1E)
+-- _SET_PLAYER_CAN_B* - _SET_PLAYER_CAN_U*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x9BBEAF8B0C007F1E(ped, p1) end
+
+-- _0x9D8DFE2DE9CB4DFC  (0x9D8DFE2DE9CB4DFC)
+-- _RESET_PED_*
+-- min build: 1207
+---@param ped number
+function N_0x9D8DFE2DE9CB4DFC(ped) end
+
+-- _0x9E66708B2B41F14A  (0x9E66708B2B41F14A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9E66708B2B41F14A(p0, p1) end
+
+-- _0x9F0F28B42C4EE80A  (0x9F0F28B42C4EE80A)
+-- min build: 1355
+---@param animal number
+---@param p2 number
+function N_0x9F0F28B42C4EE80A(animal, p2) end
+
+-- _0x9F933E0985E12C51  (0x9F933E0985E12C51)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+function N_0x9F933E0985E12C51(ped, p1, p2, p3) end
+
+-- _0xA064BBABB064446F  (0xA064BBABB064446F)
+-- min build: 1207
+---@param p0 any
+function N_0xA064BBABB064446F(p0) end
+
+-- _0xA180FBD502A03125  (0xA180FBD502A03125)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xA180FBD502A03125(p0, p1, p2) end
+
+-- _0xA1FBAC56D38563E2  (0xA1FBAC56D38563E2)
+-- min build: 1207
+---@param volume number
+---@return boolean
+function N_0xA1FBAC56D38563E2(volume) end
+
+-- _0xA2116C1E4ED85C24  (0xA2116C1E4ED85C24)
+-- _SET_PED_*
+-- min build: 1207
+---@param ped number
+---@param inverted boolean
+function N_0xA2116C1E4ED85C24(ped, inverted) end
+
+-- _0xA218D2BBCAA7388C  (0xA218D2BBCAA7388C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xA218D2BBCAA7388C(p0, p1) end
+
+-- _0xA274F51EF7E34B95  (0xA274F51EF7E34B95)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xA274F51EF7E34B95(p0, p1) end
+
+-- _0xA2B8E47442C76CEC  (0xA2B8E47442C76CEC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA2B8E47442C76CEC(p0, p1) end
+
+-- _0xA2F8B3B5FEDFC100  (0xA2F8B3B5FEDFC100)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA2F8B3B5FEDFC100(p0, p1) end
+
+-- _0xA31D350D66FA1855  (0xA31D350D66FA1855)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xA31D350D66FA1855(p0) end
+
+-- _0xA405BF9F01960C16  (0xA405BF9F01960C16)
+-- min build: 1207
+---@param p0 any
+function N_0xA405BF9F01960C16(p0) end
+
+-- _0xA4AC05B1A364EBC5  (0xA4AC05B1A364EBC5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xA4AC05B1A364EBC5(p0, p1, p2) end
+
+-- _0xA4B6432E3880F2F9  (0xA4B6432E3880F2F9)
+-- min build: 1311
+---@param ped number
+---@return boolean
+function N_0xA4B6432E3880F2F9(ped) end
+
+-- _0xA6D6F03095C88F59  (0xA6D6F03095C88F59)
+-- _DELETE_*
+-- min build: 1207
+---@param ped number
+function N_0xA6D6F03095C88F59(ped) end
+
+-- _0xA7A806677F8DE138  (0xA7A806677F8DE138)
+-- Washing player's face/hands now
+-- _CLEAR_PED_E* - _CLEAR_PED_L*
+-- min build: 1207
+---@param ped number
+function N_0xA7A806677F8DE138(ped) end
+
+-- _0xA7DC9266ED6A4E51  (0xA7DC9266ED6A4E51)
+-- _CLEAR_PED_B* - _CLEAR_PED_C*
+-- min build: 1207
+---@param ped number
+function N_0xA7DC9266ED6A4E51(ped) end
+
+-- _0xA8A95CECB1906EA2  (0xA8A95CECB1906EA2)
+-- _SET_ENABLE_B* - _SET_ENABLE_H*
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0xA8A95CECB1906EA2(groupId, p1) end
+
+-- _0xA90684ED185CCB4B  (0xA90684ED185CCB4B)
+-- Only used in R* Script mob4 and rcm_mason4
+-- _SET_PED_DEFENSIVE_* - _SET_PED_DESIRED_*
+-- min build: 1207
+---@param animal number
+---@param p1 boolean
+---@param p2 number
+---@param p3 number
+function N_0xA90684ED185CCB4B(animal, p1, p2, p3) end
+
+-- _0xA967D6A8ED2D713B  (0xA967D6A8ED2D713B)
+-- _SET_PED_P* - _SET_PED_R*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0xA967D6A8ED2D713B(ped, p1) end
+
+-- _0xAA6C49AE90A32299  (0xAA6C49AE90A32299)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0xAA6C49AE90A32299(ped, p1) end
+
+-- _0xAAC0EE3B4999ABB5  (0xAAC0EE3B4999ABB5)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+function N_0xAAC0EE3B4999ABB5(ped, targetPed) end
+
+-- _0xAD3330E3C3E98007  (0xAD3330E3C3E98007)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xAD3330E3C3E98007(p0, p1) end
+
+-- _0xAE6B68A83ABBE7C0  (0xAE6B68A83ABBE7C0)
+-- min build: 1207
+---@param p0 any
+function N_0xAE6B68A83ABBE7C0(p0) end
+
+-- _0xAF041C10756C30FB  (0xAF041C10756C30FB)
+-- _CLEAR_PED_D*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+function N_0xAF041C10756C30FB(ped, p1, p2, p3) end
+
+-- _0xB05CC690CDE8A4A9  (0xB05CC690CDE8A4A9)
+-- Used to set up bad guy groups in nb_kidnapped R* Script (MP_RE_KIDNAPPED): p1 = 4.f
+-- _SET_FORMATION_*
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+---@return boolean
+function N_0xB05CC690CDE8A4A9(groupId, p1) end
+
+-- _0xB06F5F1DEF417216  (0xB06F5F1DEF417216)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xB06F5F1DEF417216(p0, p1, p2, p3) end
+
+-- _0xB4B7C92FCE7347B7  (0xB4B7C92FCE7347B7)
+-- _RESET_PED_C*
+-- min build: 1207
+---@param ped number
+function N_0xB4B7C92FCE7347B7(ped) end
+
+-- _0xB65927F861E7AE39  (0xB65927F861E7AE39)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function N_0xB65927F861E7AE39(ped, p1) end
+
+-- _0xB8E2D655E1D5BD39  (0xB8E2D655E1D5BD39)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xB8E2D655E1D5BD39(p0) end
+
+-- _0xB91AB3BE7F655D49  (0xB91AB3BE7F655D49)
+-- _IS_PED_J* - _IS_PED_L*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xB91AB3BE7F655D49(ped) end
+
+-- _0xB9BDFAE609DFB7C5  (0xB9BDFAE609DFB7C5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xB9BDFAE609DFB7C5(p0, p1, p2) end
+
+-- _0xBB3E5370EBB6BE28  (0xBB3E5370EBB6BE28)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xBB3E5370EBB6BE28(p0, p1) end
+
+-- _0xBC1DC48270468444  (0xBC1DC48270468444)
+-- min build: 1207
+---@param p0 any
+function N_0xBC1DC48270468444(p0) end
+
+-- _0xBD0E4F52F6D95242  (0xBD0E4F52F6D95242)
+-- _IS_PED_M* - _IS_PED_O*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xBD0E4F52F6D95242(ped) end
+
+-- _0xBF567DF2BEF211A6  (0xBF567DF2BEF211A6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBF567DF2BEF211A6(p0, p1) end
+
+-- _0xBFA6B7731C3BAF02  (0xBFA6B7731C3BAF02)
+-- Only used in R* Script tg_p (CLIENT__AMBIENT_POPULATION - Player starts the populate in region)
+-- Does nearly the same thing as INSTANTLY_FILL_PED_POPULATION?
+-- min build: 1207
+function N_0xBFA6B7731C3BAF02() end
+
+-- _0xC2722B252C79E641  (0xC2722B252C79E641)
+-- _FORCE_PED_*
+-- min build: 1232
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 boolean
+function N_0xC2722B252C79E641(ped, p1, p2, p3) end
+
+-- _0xC2EF407645BEECDC  (0xC2EF407645BEECDC)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC2EF407645BEECDC(p0) end
+
+-- _0xC5B78E41DCF8227C  (0xC5B78E41DCF8227C)
+-- _SET_H* - _SET_I*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0xC5B78E41DCF8227C(ped, p1) end
+
+-- _0xC6136B40FFFB778B  (0xC6136B40FFFB778B)
+-- min build: 1207
+---@param p0 boolean
+function N_0xC6136B40FFFB778B(p0) end
+
+-- _0xC6981AFF6D2A71C2  (0xC6981AFF6D2A71C2)
+-- min build: 1207
+---@param p0 any
+function N_0xC6981AFF6D2A71C2(p0) end
+
+-- _0xC6C4E15CF7D52FEA  (0xC6C4E15CF7D52FEA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xC6C4E15CF7D52FEA(p0, p1) end
+
+-- _0xC9151483CC06A414  (0xC9151483CC06A414)
+-- min build: 1207
+---@param ped number
+function N_0xC9151483CC06A414(ped) end
+
+-- _0xC991EF46FE323867  (0xC991EF46FE323867)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function N_0xC991EF46FE323867(ped, p1) end
+
+-- _0xC99F104BDF8C7F5A  (0xC99F104BDF8C7F5A)
+-- _SET_PLAYER_N* - _SET_PLAYER_S*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0xC99F104BDF8C7F5A(ped, p1) end
+
+-- _0xCA95C156C14B2054  (0xCA95C156C14B2054)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCA95C156C14B2054(p0, p1) end
+
+-- _0xCB1A3864C524F784  (0xCB1A3864C524F784)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCB1A3864C524F784(p0, p1) end
+
+-- _0xCB86D3E3E3708901  (0xCB86D3E3E3708901)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0xCB86D3E3E3708901(p0, p1, p2, p3, p4) end
+
+-- _0xCB8F4C9343EBE240  (0xCB8F4C9343EBE240)
+-- Only used in R* SP Scripts
+-- _GET_PLAYER_W* - _GET_RANDOM_*
+-- min build: 1207
+---@param ped number
+---@param eventType number
+---@return boolean
+---@return vector3
+function N_0xCB8F4C9343EBE240(ped, eventType) end
+
+-- _0xCBDE59C48F2B06F5  (0xCBDE59C48F2B06F5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xCBDE59C48F2B06F5(p0, p1, p2) end
+
+-- _0xCD9E5F94A2F38683  (0xCD9E5F94A2F38683)
+-- _SET_PED_R* - _SET_PED_S*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0xCD9E5F94A2F38683(ped, p1) end
+
+-- _0xCDFB8C04D4C95D9B  (0xCDFB8C04D4C95D9B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xCDFB8C04D4C95D9B(p0, p1, p2, p3) end
+
+-- _0xCF0B19806473D324  (0xCF0B19806473D324)
+-- _SET_PED_COMBAT_*
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+function N_0xCF0B19806473D324(ped, x, y, z) end
+
+-- _0xD049920CD29F6CC8  (0xD049920CD29F6CC8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xD049920CD29F6CC8(p0, p1, p2, p3, p4) end
+
+-- _0xD049FDAF089FDDB0  (0xD049FDAF089FDDB0)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function N_0xD049FDAF089FDDB0(ped, p1, p2) end
+
+-- _0xD103F6DBB5442BE8  (0xD103F6DBB5442BE8)
+-- Params: p1 either a 1 or 0, so perhaps BOOL
+-- _SET_PED_A*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0xD103F6DBB5442BE8(ped, p1) end
+
+-- _0xD2F0FE8805D91647  (0xD2F0FE8805D91647)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xD2F0FE8805D91647(p0, p1) end
+
+-- _0xD355E2F1BB41087E  (0xD355E2F1BB41087E)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function N_0xD355E2F1BB41087E(ped, p1) end
+
+-- _0xD4D403EA031F351C  (0xD4D403EA031F351C)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xD4D403EA031F351C(ped) end
+
+-- _0xD55DB4466D00A258  (0xD55DB4466D00A258)
+-- Used in Script Function LA_CHECK_ALERTED
+-- _GET_IS_PED_*
+-- min build: 1207
+---@param legendaryAnimal number
+---@return boolean
+function N_0xD55DB4466D00A258(legendaryAnimal) end
+
+-- _0xD5BD1B5318A81994  (0xD5BD1B5318A81994)
+-- _SET_FORMATION_*
+-- min build: 1207
+---@param groupId number
+---@param p1 boolean
+function N_0xD5BD1B5318A81994(groupId, p1) end
+
+-- _0xD61FCF9FCFD515B7  (0xD61FCF9FCFD515B7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD61FCF9FCFD515B7(p0, p1, p2) end
+
+-- _0xD7D2F45C56A4F4DF  (0xD7D2F45C56A4F4DF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD7D2F45C56A4F4DF(p0, p1, p2) end
+
+-- _0xD8544F6260F5F01E  (0xD8544F6260F5F01E)
+-- METAPED_PLAYER_COMPONENTS_SET_META_TYPE_TO_BE_BYPASSED: Setting visibility
+-- p1 is mostly 10
+-- _CLEAR_PED_N* - _CLEAR_PED_W*
+-- min build: 1232
+---@param ped number
+---@param p1 number
+function N_0xD8544F6260F5F01E(ped, p1) end
+
+-- _0xD8CEEED54C672B5D  (0xD8CEEED54C672B5D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0xD8CEEED54C672B5D(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xD97BC27AC039F681  (0xD97BC27AC039F681)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xD97BC27AC039F681(p0, p1, p2, p3) end
+
+-- _0xDDFAD4DEAA7FA362  (0xDDFAD4DEAA7FA362)
+-- _SET_FORMATION_P*
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function N_0xDDFAD4DEAA7FA362(groupId, p1, p2, p3, p4) end
+
+-- _0xDEDBED3020DA49DC  (0xDEDBED3020DA49DC)
+-- min build: 1207
+---@param p0 any
+function N_0xDEDBED3020DA49DC(p0) end
+
+-- _0xDEE8D30AA5C2E28D  (0xDEE8D30AA5C2E28D)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0xDEE8D30AA5C2E28D(ped, p1, p2) end
+
+-- _0xE0FE107AB174D64A  (0xE0FE107AB174D64A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE0FE107AB174D64A(p0, p1) end
+
+-- _0xE1103300F3456DE7  (0xE1103300F3456DE7)
+-- _SET_FORMATION_P*
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+---@param p2 number
+function N_0xE1103300F3456DE7(groupId, p1, p2) end
+
+-- _0xE1AADD0055D76603  (0xE1AADD0055D76603)
+-- _C*
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param boneIndex1 number
+---@param boneIndex2 number
+---@param x number
+---@param y number
+---@param z number
+---@param p7 number
+---@param p8 boolean
+---@param p9 boolean
+---@param p10 number
+function N_0xE1AADD0055D76603(ped, entity, boneIndex1, boneIndex2, x, y, z, p7, p8, p9, p10) end
+
+-- _0xE1B3BE07D3AADDED  (0xE1B3BE07D3AADDED)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function N_0xE1B3BE07D3AADDED(ped, p1, p2) end
+
+-- _0xE20027B414BFE6C7  (0xE20027B414BFE6C7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE20027B414BFE6C7(p0, p1) end
+
+-- _0xE29D8CD66553DBAA  (0xE29D8CD66553DBAA)
+-- _SET_PED_R* -_SET_PED_S*
+-- min build: 1207
+---@param horse number
+function N_0xE29D8CD66553DBAA(horse) end
+
+-- _0xE37ACEE15AC50C7E  (0xE37ACEE15AC50C7E)
+-- _SET_PED_IN*
+-- min build: 1207
+---@param ped number
+---@param p1 string
+function N_0xE37ACEE15AC50C7E(ped, p1) end
+
+-- _0xE4C95E0AE31C6512  (0xE4C95E0AE31C6512)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function N_0xE4C95E0AE31C6512(ped, p1) end
+
+-- _0xE4EF4382E22C780C  (0xE4EF4382E22C780C)
+-- min build: 1207
+---@param p0 any
+function N_0xE4EF4382E22C780C(p0) end
+
+-- _0xE50C9816B3F22D8B  (0xE50C9816B3F22D8B)
+-- _SET_D*
+-- min build: 1311
+---@param ped number
+---@param p1 number
+---@param p2 number
+function N_0xE50C9816B3F22D8B(ped, p1, p2) end
+
+-- _0xE6CB36F43A95D75F  (0xE6CB36F43A95D75F)
+-- min build: 1207
+---@param p0 any
+function N_0xE6CB36F43A95D75F(p0) end
+
+-- _0xE735A7DA22E88359  (0xE735A7DA22E88359)
+-- min build: 1207
+---@param p0 any
+function N_0xE735A7DA22E88359(p0) end
+
+-- _0xE737D5F14304A2EC  (0xE737D5F14304A2EC)
+-- Only used in R* Script nb_animal_attack: p2 = 120000
+-- _SET_PED_SH* - _SET_PED_SP*
+-- min build: 1207
+---@param ped number
+---@param player number
+---@param p2 number
+function N_0xE737D5F14304A2EC(ped, player, p2) end
+
+-- _0xE8ABE3B73FC7FE17  (0xE8ABE3B73FC7FE17)
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param propItemId string
+---@param conditionalAnimName string
+function N_0xE8ABE3B73FC7FE17(ped, targetEntity, propItemId, conditionalAnimName) end
+
+-- _0xE9E06EA514A69061  (0xE9E06EA514A69061)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE9E06EA514A69061(p0, p1) end
+
+-- _0xEA8763E505AFD49A  (0xEA8763E505AFD49A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xEA8763E505AFD49A(p0, p1, p2) end
+
+-- _0xEB8886E1065654CD  (0xEB8886E1065654CD)
+-- Washing player's face/hands now
+-- _FA* - _FI*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 string
+---@param p3 number
+function N_0xEB8886E1065654CD(ped, p1, p2, p3) end
+
+-- _0xEBAAC9A750E7563B  (0xEBAAC9A750E7563B)
+-- If returned true: PROCESS_RESIZING_TRACKING_BOUNDS_VOLUME - Scaling UP the bounds due to tracking
+-- If returned false: PROCESS_RESIZING_TRACKING_BOUNDS_VOLUME - Scaling DOWN the bounds due to tracking
+-- _IS_PED_T* - _IS_PED_U*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xEBAAC9A750E7563B(ped) end
+
+-- _0xEBD49472BCCF7642  (0xEBD49472BCCF7642)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xEBD49472BCCF7642(p0, p1) end
+
+-- _0xEC60D1D225BC50AA  (0xEC60D1D225BC50AA)
+-- _SET_C*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0xEC60D1D225BC50AA(ped, p1) end
+
+-- _0xED1C764997A86D5A  (0xED1C764997A86D5A)
+-- Only used in R* Script nb_stalking_hunter
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+function N_0xED1C764997A86D5A(ped1, ped2) end
+
+-- _0xEEDC9B29314B2733  (0xEEDC9B29314B2733)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function N_0xEEDC9B29314B2733(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _0xEF371232BC6053E1  (0xEF371232BC6053E1)
+-- _ADD_*
+-- min build: 1207
+---@param ped number
+function N_0xEF371232BC6053E1(ped) end
+
+-- _0xF47D54B986F0A346  (0xF47D54B986F0A346)
+-- Used in Script Function MOONSHINE_BAND_CLIENT_PATRON_UPDATE
+-- min build: 1232
+---@param ped number
+---@param danceIntensity number
+function N_0xF47D54B986F0A346(ped, danceIntensity) end
+
+-- _0xF634E2892220EF34  (0xF634E2892220EF34)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function N_0xF634E2892220EF34(ped, p1) end
+
+-- _0xF6A8C4B4A11AE89C  (0xF6A8C4B4A11AE89C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return any
+function N_0xF6A8C4B4A11AE89C(p0, p1, p2, p3, p4, p5) end
+
+-- _0xF7327ACC7A89AEF1  (0xF7327ACC7A89AEF1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xF7327ACC7A89AEF1(p0, p1, p2) end
+
+-- _0xF917F92BF22ECBAB  (0xF917F92BF22ECBAB)
+-- min build: 1207
+---@param p0 any
+function N_0xF917F92BF22ECBAB(p0) end
+
+-- _0xF9331B3A314EB49D  (0xF9331B3A314EB49D)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xF9331B3A314EB49D(ped) end
+
+-- _0xF9CBD46433E36713  (0xF9CBD46433E36713)
+-- Used in Script Function PLAYER_HEAD_TRACKING_MAINTAIN
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 string
+function N_0xF9CBD46433E36713(ped, targetEntity, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _0xFA0D206B489A6846  (0xFA0D206B489A6846)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xFA0D206B489A6846(p0, p1, p2, p3, p4) end
+
+-- _0xFA742B82D093D848  (0xFA742B82D093D848)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xFA742B82D093D848(p0, p1, p2) end
+
+-- _0xFC23348F0F4E245F  (0xFC23348F0F4E245F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xFC23348F0F4E245F(p0, p1, p2, p3) end
+
+-- _0xFD3C31A2E45671E7  (0xFD3C31A2E45671E7)
+-- _DISABLE_A* - _DISABLE_C*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0xFD3C31A2E45671E7(ped, p1) end
+
+-- _0xFD8E853F0BC2E942  (0xFD8E853F0BC2E942)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFD8E853F0BC2E942(p0, p1) end
+
+-- _0xFEA6126C34DF2532  (0xFEA6126C34DF2532)
+-- METAPED_PLAYER_COMPONENTS_SET_META_TYPE_TO_BE_BYPASSED: Setting visibility
+-- _SET_M* - _SET_P*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0xFEA6126C34DF2532(ped, p1) end
+
+-- _ADD_PED_STAY_OUT_VOLUME  (0xE9B168527B337BF0)
+-- min build: 1207
+---@param ped number
+---@param volume number
+---@return boolean
+function _AddPedStayOutVolume(ped, volume) end
+
+-- _ADD_PED_SUBSCRIBE_TO_LEGENDARY_BLIPS  (0xE37287EE358939C3)
+-- min build: 1311
+---@param ped number
+---@return boolean
+function _AddPedSubscribeToLegendaryBlips(ped) end
+
+-- _ADD_SCENARIO_BLOCKING_VOLUME  (0x4C39C95AE5DB1329)
+-- flag: see ADD_SCENARIO_BLOCKING_AREA
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+---@param flag number
+---@return any
+function _AddScenarioBlockingVolume(volume, p1, flag) end
+
+-- _ADD_SCENARIO_TRANSITION  (0x6D07B371E9439019)
+-- Forces transition now, called together with 0xD65FDC686A031C83
+-- min build: 1207
+---@param ped number
+function _AddScenarioTransition(ped) end
+
+-- _ADD_TEXTURE_LAYER  (0x86BB5FF45F193A02)
+-- Creates ped overlay in texture override data and returns it's index.
+-- This index are used for further overlay editing.
+-- 
+-- albedoHash: a hash of overlay's albedo texture
+-- colorType: a color type(from 0 to 2). 0 is used for overlays with RGB colors usually.
+-- min build: 1207
+---@param textureId number
+---@param albedoHash number
+---@param normalHash number
+---@param materialHash number
+---@param blendType number
+---@param texAlpha number
+---@param sheetGridIndex number
+---@return number
+function _AddTextureLayer(textureId, albedoHash, normalHash, materialHash, blendType, texAlpha, sheetGridIndex) end
+
+-- _APPLY_PED_DAMAGE_PACK_TO_BONE  (0x58D32261AE0F0843)
+-- Applies damage pack to a ped bone with offset and rotation.
+-- Note: for boneId only PD_Vomit seems to work.
+-- 
+-- Preview: https://imgur.com/a/qwEGXEu
+-- min build: 1207
+---@param ped number
+---@param boneId number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param damagePack string
+function _ApplyPedDamagePackToBone(ped, boneId, xOffset, yOffset, zOffset, xRot, yRot, zRot, damagePack) end
+
+-- _APPLY_PED_META_PED_OUTFIT  (0x74F512E29CB717E2)
+-- https://github.com/femga/rdr3_discoveries/blob/master/clothes/metaped_outfits.lua
+-- min build: 1207
+---@param requestId number
+---@param ped number
+---@param p2 boolean
+---@param p3 boolean
+---@return boolean
+function _ApplyPedMetaPedOutfit(requestId, ped, p2, p3) end
+
+-- _APPLY_SHOP_ITEM_TO_PED  (0xD3A7B003ED343FD9)
+-- min build: 1207
+---@param ped number
+---@param componentHash number
+---@param immediately boolean
+---@param isMp boolean
+---@param p4 boolean
+function _ApplyShopItemToPed(ped, componentHash, immediately, isMp, p4) end
+
+-- _APPLY_TEXTURE_ON_PED  (0x0B46E25761519058)
+-- min build: 1207
+---@param ped number
+---@param componentHash number
+---@param textureId number
+function _ApplyTextureOnPed(ped, componentHash, textureId) end
+
+-- _ARE_ALL_AMBIENT_PED_RESERVATIONS_READY  (0x5E420FF293EE5472)
+-- min build: 1207
+---@return boolean
+function _AreAllAmbientPedReservationsReady() end
+
+-- _ATTACH_VOLUME_TO_ENTITY  (0x7C00CFC48A782DC0)
+-- min build: 1207
+---@param volume number
+---@param entity number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param p8 number
+---@param p9 boolean
+function _AttachVolumeToEntity(volume, entity, offsetX, offsetY, offsetZ, rotX, rotY, rotZ, p8, p9) end
+
+-- _CAN_PED_HEAR_TARGET_PED  (0x0EA9EACBA3B01601)
+-- Returns true if `listener` can hear `source`.
+-- If `includeNoiseBoost` is true, the source's noise radius is applied (easier to hear).
+-- It treats the source as louder. Its current noise expands the effective hearing range (by subtracting noiseRadius² from dist²), while false uses the baseline distance-only check (stealth).
+-- min build: 1207
+---@param source number
+---@param listener number
+---@param includeNoiseBoost boolean
+---@return boolean
+function _CanPedHearTargetPed(source, listener, includeNoiseBoost) end
+
+-- _CAN_PED_USE_SCENARIO_POINT  (0xAB643407D0B26F07)
+-- p2 is always 0, p3 is always 0, p4 is always 1
+-- min build: 1207
+---@param ped number
+---@param scenario number
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return boolean
+function _CanPedUseScenarioPoint(ped, scenario, p2, p3, p4) end
+
+-- _CHANGE_PED_STAMINA  (0xC3D4B754C0E86B9E)
+-- Alters entity's stamina by 'amount'. Can be negative (to drain stamina). float amount: -1000.0 - 1000.0
+-- min build: 1207
+---@param ped number
+---@param amount number
+---@return boolean
+function _ChangePedStamina(ped, amount) end
+
+-- _CLEAR_ACTIVE_ANIMAL_OWNER  (0xBCC76708E5677E1D)
+-- Used in Script Functions PLAYER_HORSE_RELEASE_HORSE_TO_AMBIENT_WORLD (p1 = true), HORSE_SETUP_PLAYER_HORSE_ATTRIBUTES (p1 = false)
+-- Set to false for player horse in scripts and seems it's only true when releasing/changing a player horse? Cannot determine what effect it has, but it doesn't seem to affect _GET_HORSE_TAMING_STATE
+-- min build: 1207
+---@param horse number
+---@param clear boolean
+function _ClearActiveAnimalOwner(horse, clear) end
+
+-- _CLEAR_PED_ACTION_DISABLE_FLAG  (0x949B2F9ED2917F5D)
+-- min build: 1207
+---@param ped number
+---@param actionDisableFlag number
+function _ClearPedActionDisableFlag(ped, actionDisableFlag) end
+
+-- _CLEAR_PED_BLOOD_DAMAGE_FACIAL  (0x7F5D88333EE8A86F)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _ClearPedBloodDamageFacial(ped, p1) end
+
+-- _CLEAR_PED_COMBAT_STYLE  (0x78815FC52832B690)
+-- Params: p1 = 1 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _ClearPedCombatStyle(ped, p1) end
+
+-- _CLEAR_PED_COMBAT_STYLE_MOD  (0x1FA132CBCD7CB239)
+-- _CLEAR_PED_COMBAT_*
+-- min build: 1207
+---@param ped number
+---@param combatStyleModHash number
+function _ClearPedCombatStyleMod(ped, combatStyleModHash) end
+
+-- _CLEAR_PED_DESIRED_LOCO_FOR_MODEL  (0x4FD80C3DD84B817B)
+-- Clears locomotion archetype
+-- min build: 1207
+---@param ped number
+function _ClearPedDesiredLocoForModel(ped) end
+
+-- _CLEAR_PED_DESIRED_LOCO_MOTION_TYPE  (0x58F7DB5BD8FA2288)
+-- min build: 1207
+---@param ped number
+function _ClearPedDesiredLocoMotionType(ped) end
+
+-- _CLEAR_PED_GRAPPLE_FLAG  (0xEAE3B5B019C8D23F)
+-- min build: 1207
+---@param ped number
+---@param flag number
+function _ClearPedGrappleFlag(ped, flag) end
+
+-- _CLEAR_PED_TARGET_ACTION_DISABLE_FLAG  (0xBBF6D1D07C02D00A)
+-- min build: 1207
+---@param ped number
+---@param actionDisableFlag number
+function _ClearPedTargetActionDisableFlag(ped, actionDisableFlag) end
+
+-- _CLEAR_PED_TEXTURE  (0xB63B9178D0F58D82)
+-- Removes every texture layer
+-- Old Name: _RESET_PED_TEXTURE_2
+-- min build: 1207
+---@param textureId number
+function _ClearPedTexture(textureId) end
+
+-- _CLEAR_PELT_FROM_HORSE  (0x627F7F3A0C4C51FF)
+-- min build: 1207
+---@param horse number
+---@param peltId number
+function _ClearPeltFromHorse(horse, peltId) end
+
+-- _COMPUTE_LOOT_FOR_PED_CARCASS  (0xB29C553BA582D09E)
+-- Computes the loot table for an animal/human carcass given its model and processing quality.
+-- Returns the number of loot entries written. Results are written into outLoot starting at index 1.
+-- Usage/Example: https://pastebin.com/LffcaAXy
+-- min build: 1207
+---@param model number
+---@param damageCleanliness number
+---@param skinningQuality number
+---@return number
+---@return any
+function _ComputeLootForPedCarcass(model, damageCleanliness, skinningQuality) end
+
+-- _COMPUTE_PED_MOVE_BLEND_RATIO_FOR_MAX_SPEED  (0x46BF2A810679D6E6)
+-- Returns estimated max speed (m/s) for the ped move blend ratio. Move blend ratio is in a range of 0.0 - 3.0.
+-- _COMPUTE_S*
+-- min build: 1207
+---@param ped number
+---@param maxMoveBlendRatio number
+---@return number
+function _ComputePedMoveBlendRatioForMaxSpeed(ped, maxMoveBlendRatio) end
+
+-- _COMPUTE_SATCHEL_ITEM_FOR_PED_CARCASS  (0x6B89FAA36FC909A3)
+-- Related to dead animals items/loots
+-- Notice: skinningQuality is partially calculated using pedQuality
+-- min build: 1207
+---@param ped number
+---@param damageCleanliness number
+---@param skinningQuality number
+---@return number
+---@return any
+function _ComputeSatchelItemForPedCarcass(ped, damageCleanliness, skinningQuality) end
+
+-- _COMPUTE_SPEED_FOR_PED_MOVE_BLEND_RATIO  (0xCA95924C893A0C91)
+-- Returns ped move blend ratio corresponding to the specified speed.
+-- min build: 1207
+---@param ped number
+---@param speed number
+---@return number
+function _ComputeSpeedForPedMoveBlendRatio(ped, speed) end
+
+-- _COUNT_PEDS_AWARE_OF_EVENT  (0xF4860514AD354226)
+-- Counts how many peds are aware of a shocking event within a radius.
+-- The eventHandle is from ADD_SHOCKING_EVENT_FOR_ENTITY. The entities output collection is capped at 15 in observed code and is used to drive reactions/tasks for the affected peds.
+-- min build: 1207
+---@param shockingEvent number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return number
+---@return any
+function _CountPedsAwareOfEvent(shockingEvent, x, y, z, radius) end
+
+-- _CREATE_GRAVITY_WELL  (0x4F5EBE70081E5A20)
+-- Creates a handle to an instance of "CScriptResource_GravityWell", this system forces local ped to target specified position when moving, however player still can interrupt this.
+-- Can be useful to "point" player at some specific position.
+-- Only works while on-foot.
+-- 
+-- _CREATE_[P-Z]
+-- min build: 1207
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param heading number
+---@param radius number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param stopAtDestination boolean
+---@return number
+function _CreateGravityWell(xPos, yPos, zPos, heading, radius, p5, p6, p7, stopAtDestination) end
+
+-- _CREATE_META_PED  (0x0BCD4091C8EABA42)
+-- Only used in SP scripts, for example odriscolls1: BOOLS: true, true, true, false, false
+-- min build: 1207
+---@param requestId number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 boolean
+---@return number
+function _CreateMetaPed(requestId, x, y, z, heading, p5, p6, p7, p8, p9) end
+
+-- _CREATE_META_PED_ASSET  (0x9641A9A20310F6B8)
+-- Creates prop from metaped asset bundle
+-- https://github.com/femga/rdr3_discoveries/blob/master/objects/metaped_asset_bundles_list.lua
+-- Creates a pickup-able metaped component. asset doesn't seems to be related to component hashes. Hash example : 0xD20354AB (https ://i.imgur.com/dzHkcDb.png)
+-- min build: 1207
+---@param asset number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 boolean
+---@return number
+function _CreateMetaPedAsset(asset, posX, posY, posZ, rotX, rotY, rotZ, p7, p8, p9) end
+
+-- _CREATE_META_PED_OUTFIT_PED  (0xEAF682A14F8E5F53)
+-- Creates metaped from ped outfit requestId. See _REQUEST_METAPED_OUTFIT
+-- min build: 1207
+---@param requestId number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@return number
+function _CreateMetaPedOutfitPed(requestId, x, y, z, heading, p5, p6, p7, p8) end
+
+-- _DETACH_VOLUME_FROM_ENTITY  (0x19C975B81BE53C28)
+-- min build: 1207
+---@param volume number
+---@param entity number
+function _DetachVolumeFromEntity(volume, entity) end
+
+-- _DETECT_PLAYER_SHOT_NEAR_PED  (0x9C81338B2E62CE0A)
+-- The time of the shot must've occured <= shotNearTimeMs for this native to return true
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param shotNearTimeMs number
+---@return boolean
+function _DetectPlayerShotNearPed(player, ped, shotNearTimeMs) end
+
+-- _DISABLE_ALL_LOOK_AT_REQUESTS  (0xE1965A380342BE1F)
+-- min build: 1355
+---@param ped number
+---@param p1 number
+function _DisableAllLookAtRequests(ped, p1) end
+
+-- _DISABLE_AMBIENT_LOOK_AT_REQUESTS  (0x80038740C96AD17F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function _DisableAmbientLookAtRequests(p0, p1) end
+
+-- _DOES_META_PED_OUTFIT_EXIST_FOR_PED_MODEL  (0xC0E880B7A441164D)
+-- min build: 1207
+---@param outfit number
+---@param model number
+---@return boolean
+function _DoesMetaPedOutfitExistForPedModel(outfit, model) end
+
+-- _DOES_META_PED_SUBOUTFIT_EXIST_FOR_PED_MODEL  (0x4FF3C2B4E6A196C1)
+-- min build: 1207
+---@param outfit number
+---@param suboutfit number
+---@param model number
+---@return boolean
+function _DoesMetaPedSuboutfitExistForPedModel(outfit, suboutfit, model) end
+
+-- _EQUIP_META_PED_OUTFIT  (0x1902C4CFCC5BE57C)
+-- Note: you have to update your ped's variation after calling (using 0xCC8CA3E88256E58F)
+-- 
+-- Body Types:
+-- MPCREATOR_NEUTRAL
+-- MPCREATOR_SKINNY
+-- MPCREATOR_SKINNY_MUSCULAR
+-- MPCREATOR_HEAVY
+-- MPCREATOR_HEAVY_MUSCULAR
+-- 
+-- eBodyWeightOutfit (pedattributes.ymt):
+-- -2045421226 (smallest)
+-- -1745814259
+-- -325933489
+-- -1065791927
+-- -844699484
+-- -1273449080
+-- 927185840
+-- 149872391
+-- 399015098
+-- -644349862
+-- 1745919061 (default)
+-- 1004225511
+-- 1278600348
+-- 502499352
+-- -2093198664
+-- -1837436619
+-- 1736416063
+-- 2040610690
+-- -1173634986
+-- -867801909
+-- 1960266524 (biggest)
+-- 
+-- https://github.com/femga/rdr3_discoveries/blob/master/peds_customization/ped_outfits.lua
+-- 
+-- Alt name: _EQUIP_META_PED_OUTFIT_COMPONENT
+-- min build: 1207
+---@param ped number
+---@param hash number
+function _EquipMetaPedOutfit(ped, hash) end
+
+-- _EQUIP_META_PED_OUTFIT_EXTRA  (0xA5BAE410B03E7371)
+-- Changes Multiplayer ped face and body type components, they can be stacked
+-- Params: p3 = 1
+-- Body shape for mp_male from 124 - 128, 110 - 115 for mp_female
+-- Face shape for mp_male from 110 - 123, 96 - 109 for mp_female
+-- Cloth type for mp_male from 0 - 109, 0 - 95 for mp_female
+-- min build: 1207
+---@param ped number
+---@param component number
+---@param p2 any
+---@param p3 any
+function _EquipMetaPedOutfitExtra(ped, component, p2, p3) end
+
+-- _EQUIP_META_PED_OUTFIT_PRESET  (0x77FF8D35EEC6BBC4)
+-- Sets the outfit preset for the ped. The presetId is an index which determines its preset outfit. p2 is always false in the scripts.
+-- If p2 is true as player, then certain components like facial hair and hair will not be removed.
+-- Old name: _SET_PED_OUTFIT_PRESET
+-- min build: 1207
+---@param ped number
+---@param presetId number
+---@param p2 boolean
+function _EquipMetaPedOutfitPreset(ped, presetId, p2) end
+
+-- _EQUIP_META_PED_SUBOUTFIT  (0x66FF395445A88A6E)
+-- min build: 1207
+---@param ped number
+---@param suboutfit number
+---@param p2 number
+function _EquipMetaPedSuboutfit(ped, suboutfit, p2) end
+
+-- _FAKE_SET_PED_LOCO_INJURED  (0x8B3CB08158E98481)
+-- min build: 1207
+---@param ped number
+---@param enabled boolean
+function _FakeSetPedLocoInjured(ped, enabled) end
+
+-- _FORCE_PED_DEATH  (0x1CE875505D45338A)
+-- min build: 1207
+---@param ped number
+---@param pedKiller number
+---@param weapon number
+function _ForcePedDeath(ped, pedKiller, weapon) end
+
+-- _GET_ACCURACY_AGAINST_LOCAL_PLAYER_MODIFIER  (0xDC9273D95976BA22)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetAccuracyAgainstLocalPlayerModifier(ped) end
+
+-- _GET_ACTIVE_ANIMAL_OWNER  (0xF103823FFE72BB49)
+-- min build: 1207
+---@param animal number
+---@return number
+function _GetActiveAnimalOwner(animal) end
+
+-- _GET_ACTIVE_DYNAMIC_SCENARIO  (0x569F1E1237508DEB)
+-- Returns kneeling, sitting, squating, and sleeping scenario hashes
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetActiveDynamicScenario(ped) end
+
+-- _GET_ACTIVE_DYNAMIC_SCENARIO_2  (0xC22AA08A8ADB87D4)
+-- Returns kneeling, sitting, squating, and sleeping scenario hashes
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetActiveDynamicScenario2(ped) end
+
+-- _GET_BLOCKING_OF_NON_TEMPORARY_EVENTS  (0x268B3AEBF032A88D)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _GetBlockingOfNonTemporaryEvents(ped) end
+
+-- _GET_CARRIED_PELT_SKINS  (0x6F43C351A5D51E2F)
+-- https://github.com/nativewrappers/nativewrappers/blob/main/src/redm/entities/HorsePeltEntries.ts
+-- https://pastebin.com/D58XgYBm
+-- min build: 1207
+---@param mount number
+---@return number
+---@return any
+function _GetCarriedPeltSkins(mount) end
+
+-- _GET_CARRIER_AS_HUMAN  (0x79443D56C8DF45EE)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetCarrierAsHuman(entity) end
+
+-- _GET_CARRIER_AS_MOUNT  (0xA033D7E4BBF9844D)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetCarrierAsMount(entity) end
+
+-- _GET_CARRIER_AS_PED  (0x09B83E68DE004CD4)
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetCarrierAsPed(entity) end
+
+-- _GET_CATEGORY_OF_COMPONENT_AT_INDEX  (0x9B90842304C938A7)
+-- min build: 1207
+---@param ped number
+---@param componentIndex number
+---@param p2 any
+---@return number
+function _GetCategoryOfComponentAtIndex(ped, componentIndex, p2) end
+
+-- _GET_CHAR_EXPRESSION  (0xFD1BA1EEF7985BB8)
+-- Gets MetaPedExpression at index specified
+-- 
+-- For index, see: _SET_CHAR_EXPRESSION
+-- 
+-- Old name: _GET_PED_FACE_FEATURE
+-- min build: 1207
+---@param ped number
+---@param index number
+---@return number
+function _GetCharExpression(ped, index) end
+
+-- _GET_DEFAULT_RELATIONSHIP_GROUP_HASH  (0x3CC4A718C258BDD0)
+-- min build: 1207
+---@param modelHash number
+---@return number
+function _GetDefaultRelationshipGroupHash(modelHash) end
+
+-- _GET_FIRST_ENTITY_PED_IS_CARRYING  (0xD806CD2A4F2C2996)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetFirstEntityPedIsCarrying(ped) end
+
+-- _GET_GROUP_FORMATION  (0x13A1B061007C906B)
+-- min build: 1207
+---@param groupId number
+---@return number
+function _GetGroupFormation(groupId) end
+
+-- _GET_HEALTH_RECHARGE_MULTIPLIER  (0x95B8E397B8F4360F)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetHealthRechargeMultiplier(ped) end
+
+-- _GET_HORSE_TAMING_STATE  (0x454AD4DA6C41B5BD)
+-- Returns an int based on enum eTamingState
+-- 
+-- enum eTamingState
+-- {
+-- 	ATS_INVALID = 0,
+-- 	ATS_INACTIVE,
+-- 	ATS_TARGET_DETECTED,
+-- 	ATS_CALLED_OUT,
+-- 	ATS_MOUNTABLE,
+-- 	ATS_BEING_PATTED,
+-- 	ATS_BREAKING_ACTIVE,
+-- 	ATS_SPOOKED,
+-- 	ATS_RETREATING,
+-- 	ATS_FLEEING
+-- };
+-- min build: 1207
+---@param horse number
+---@return number
+function _GetHorseTamingState(horse) end
+
+-- _GET_INCAPACITATION_TIME_REMAINING  (0x88D9D76D78065487)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetIncapacitationTimeRemaining(ped) end
+
+-- _GET_IS_PED_BEING_ROBBED  (0xE33F98BD76490ABC)
+-- If p2 is false, then this native will return true until the interaction is complete. If true, the native will return true until player pockets robbery item.
+-- _GET_IS_PED_[M-R]*
+-- min build: 1207
+---@param ped number
+---@param player number
+---@param trueUntilPlayerPocketsItem boolean
+---@return boolean
+function _GetIsPedBeingRobbed(ped, player, trueUntilPlayerPocketsItem) end
+
+-- _GET_IS_PED_COMMAND_HASH_PRESENT  (0x68821369A2CEADD5)
+-- min build: 1207
+---@param ped number
+---@param commandHash number
+---@return boolean
+function _GetIsPedCommandHashPresent(ped, commandHash) end
+
+-- _GET_IS_PED_IN_DISPUTE_WITH_PED  (0x331550B212014B92)
+-- Returns true if ped is in a dispute another ped (pedInDisputeWith can also be 0)
+-- min build: 1207
+---@param ped number
+---@param pedInDisputeWith number
+---@return boolean
+function _GetIsPedInDisputeWithPed(ped, pedInDisputeWith) end
+
+-- _GET_IS_PED_MOTIVATION_STATE_ENABLED  (0x33FA048675821DA7)
+-- motivationState: see _SET_PED_MOTIVATION
+-- min build: 1207
+---@param ped number
+---@param motivationState number
+---@return boolean
+function _GetIsPedMotivationStateEnabled(ped, motivationState) end
+
+-- _GET_LASSO_TARGET  (0xB65A4DAB460A19BD)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLassoTarget(ped) end
+
+-- _GET_LASSOED_LASSOER  (0x0C31C51168E80365)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLassoedLassoer(ped) end
+
+-- _GET_LASSOER_OF_PED  (0x833F0053340EF413)
+-- _IS_PED_S* - _IS_PED_U*
+-- This native name may or may not be misleading.
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLassoerOfPed(ped) end
+
+-- _GET_LAST_LED_MOUNT  (0x693126B5D0457D0D)
+-- Returns last horse the ped was leading
+-- min build: 1232
+---@param ped number
+---@return number
+function _GetLastLedMount(ped) end
+
+-- _GET_LAST_MOUNT  (0x4C8B59171957BCF7)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLastMount(ped) end
+
+-- _GET_LAST_VEHICLE_DRAFT_HORSE_WAS_ATTACHED_TO  (0x5064DB5083C29921)
+-- min build: 1207
+---@param horse number
+---@return number
+function _GetLastVehicleDraftHorseWasAttachedTo(horse) end
+
+-- _GET_LOOTING_FLAG  (0xE4C11F104620DDCE)
+-- lootFlag: see SET_LOOTING_FLAG
+-- min build: 1207
+---@param ped number
+---@param lootFlag number
+---@return boolean
+function _GetLootingFlag(ped, lootFlag) end
+
+-- _GET_META_PED_RACE  (0xB292203008EBBAAC)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetMetaPedRace(ped) end
+
+-- _GET_META_PED_TYPE  (0xEC9A1261BF0CE510)
+-- enum eMetaPedType
+-- {
+-- 	MPT_MALE,
+-- 	MPT_FEMALE,
+-- 	MPT_TEEN,
+-- 	MPT_ANIMAL,
+-- 	MPT_NONE
+-- };
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetMetaPedType(ped) end
+
+-- _GET_NUM_COMPONENT_CATEGORIES_IN_PED  (0xA622E66EEE92A08D)
+-- Works similar to 0x90403E8107B60E81 (_GET_NUM_COMPONENTS_IN_PED) but is used to get category hashes instead
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetNumComponentCategoriesInPed(ped) end
+
+-- _GET_NUM_COMPONENTS_IN_PED  (0x90403E8107B60E81)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetNumComponentsInPed(ped) end
+
+-- _GET_NUM_FREE_SLOTS_IN_PED_POOL  (0x313778EDCA9158E2)
+-- min build: 1207
+---@return number
+function _GetNumFreeSlotsInPedPool() end
+
+-- _GET_NUM_RESERVED_AMBIENT_PEDS_DESIRED  (0x62DE46F061CAA468)
+-- min build: 1207
+---@return number
+function _GetNumReservedAmbientPedsDesired() end
+
+-- _GET_NUM_RESERVED_AMBIENT_PEDS_READY  (0x5C16855277819BBF)
+-- min build: 1207
+---@return number
+function _GetNumReservedAmbientPedsReady() end
+
+-- _GET_NUM_RESERVED_HEALTH  (0x16F2C8C084AB2092)
+-- min build: 1207
+---@param ped number
+---@return any
+function _GetNumReservedHealth(ped) end
+
+-- _GET_NUM_RESERVED_STAMINA  (0xFC3B580C4380B5B7)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetNumReservedStamina(ped) end
+
+-- _GET_PED_ATTITUDE  (0x7CC2186C32D3540A)
+-- AI_ATTITUDE_NEUTRAL = 0,
+-- AI_ATTITUDE_FRIENDLY,
+-- AI_ATTITUDE_WARY,
+-- AI_ATTITUDE_COMBATIVE,
+-- AI_ATTITUDE_NEVER_MET
+-- min build: 1207
+---@param ped number
+---@param player number
+---@return number
+function _GetPedAttitude(ped, player) end
+
+-- _GET_PED_BLACKBOARD_BOOL  (0x498F2E77982D6945)
+-- Can be used to get a peds foliage active status: variableName = FoliageActive
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@return boolean
+function _GetPedBlackboardBool(ped, variableName) end
+
+-- _GET_PED_BLACKBOARD_FLOAT  (0x56E58D4D118FB45E)
+-- Can be used to get a peds foliage raw height: variableName = FoliageHeight
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@return number
+function _GetPedBlackboardFloat(ped, variableName) end
+
+-- _GET_PED_BLACKBOARD_HASH  (0xBF5E791BBBF90A3C)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@return number
+function _GetPedBlackboardHash(ped, variableName) end
+
+-- _GET_PED_BRAWLING_STYLE  (0xEC6B59BE445FEC51)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedBrawlingStyle(ped) end
+
+-- _GET_PED_CAN_BE_INCAPACITATED_THIS_FRAME  (0x7A4E00364B5D727B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _GetPedCanBeIncapacitatedThisFrame(ped) end
+
+-- _GET_PED_COMBAT_ATTRIBUTE  (0xCC2B20596E29E4E3)
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@return boolean
+function _GetPedCombatAttribute(ped, attributeIndex) end
+
+-- _GET_PED_COMBAT_SPEED  (0xFFDE295662405B25)
+-- Gets the ped combat speed enum. See _SET_PED_COMBAT_SPEED for CCombatData__Speed values.
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedCombatSpeed(ped) end
+
+-- _GET_PED_COMPONENT_CATEGORY_BY_INDEX  (0xCCB97B51893C662F)
+-- Returns category hash that each ped component has. Hash examples: MASKS, HATS, HEADS, HORSE_MANES
+-- min build: 1207
+---@param ped number
+---@param index number
+---@return number
+function _GetPedComponentCategoryByIndex(ped, index) end
+
+-- _GET_PED_DAMAGE_CLEANLINESS  (0x88EFFED5FE8B0B4A)
+-- enum ePedDamageCleanliness
+-- {
+-- 	PED_DAMAGE_CLEANLINESS_POOR,
+-- 	PED_DAMAGE_CLEANLINESS_GOOD,
+-- 	PED_DAMAGE_CLEANLINESS_PERFECT
+-- };
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedDamageCleanliness(ped) end
+
+-- _GET_PED_DAMAGED  (0x6CFC373008A1EDAF)
+-- Returns true if _GET_PED_DAMAGE_CLEANLINESS was ever lower than 2
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _GetPedDamaged(ped) end
+
+-- _GET_PED_DEFENSIVE_VOLUME  (0xEF2E6F870783369B)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@return number
+function _GetPedDefensiveVolume(ped, p1) end
+
+-- _GET_PED_DIRT_LEVEL  (0x0105FEE8F9091255)
+-- Returns the ped's dirt amount as a scalar in [0.0, 1.0].
+-- Notes:
+-- - The second parameter is treated as a boolean selector (0 or 1). Internally it indexes a 2-slot graphics/appearance bank (base + 0xB8 * index + 0xE4); Rockstar scripts pass 1.
+-- - Use 1 for the "active/composite" layer to match in-game usage.
+-- - SP scripts often read, adjust, clamp, then feed back into _SET_PED_DIRT_CLEANED.
+-- Example (C++):
+-- 	float lvl = PED::_GET_PED_DIRT_LEVEL(ped, true);
+-- 	lvl = std::clamp(lvl + 0.1f, 0.0f, 1.0f);
+-- 	PED::_SET_PED_DIRT_CLEANED(ped, lvl, -1, true, true);
+-- min build: 1207
+---@param ped number
+---@param useCompositeLayer boolean
+---@return number
+function _GetPedDirtLevel(ped, useCompositeLayer) end
+
+-- _GET_PED_DRUNKNESS  (0x6FB76442469ABD68)
+-- Returns ped drunk level
+-- _H* or _I*
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedDrunkness(ped) end
+
+-- _GET_PED_GRAPPLE_FLAG  (0xF3C873ED0C595109)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedGrappleFlag(ped) end
+
+-- _GET_PED_GRAPPLE_STYLE  (0x753B15AD0FD6F3E3)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedGrappleStyle(ped) end
+
+-- _GET_PED_GRAPPLER  (0xD0B7AEB56229D317)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedGrappler(ped) end
+
+-- _GET_PED_HAS_INTERACTED_WITH_PLAYER  (0x947E43F544B6AB34)
+-- Returns whether given ped has recently interacted with a player in a specific way or not (determined by the given flag)
+-- flags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/0x947E43F544B6AB34
+-- min build: 1207
+---@param targetPed number
+---@param player number
+---@param flag number
+---@param durationMs number
+---@return boolean
+function _GetPedHasInteractedWithPlayer(targetPed, player, flag, durationMs) end
+
+-- _GET_PED_HAS_SIMPLE_PLAYER_MEMORY_CHANGED  (0xC3995D396F1D97B6)
+-- min build: 1207
+---@param ped number
+---@param memoryType number
+---@param ms number
+---@return boolean
+function _GetPedHasSimplePlayerMemoryChanged(ped, memoryType, ms) end
+
+-- _GET_PED_HEARING_RANGE  (0x900CA00CE703E1E2)
+-- Returns the hearing range of a ped. Counterpart to SET_PED_HEARING_RANGE.
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedHearingRange(ped) end
+
+-- _GET_PED_HEIGHT  (0x1D491CCF7211FB74)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedHeight(ped) end
+
+-- _GET_PED_ID_RANGE  (0x31167ED4324B758D)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedIdRange(ped) end
+
+-- _GET_PED_INCAPACITATION_HEALTH  (0x89BFDF6D53145545)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedIncapacitationHealth(ped) end
+
+-- _GET_PED_INDEX_FROM_PERSCHAR_HASH  (0xE76687023D8C8505)
+-- Used for AUDIO / ANIMSCENE (REFERENCE_REGIONAL_CHARACTER)
+-- Params: p1 = 0
+-- min build: 1207
+---@param persCharHash number
+---@param p1 number
+---@return number
+function _GetPedIndexFromPerscharHash(persCharHash, p1) end
+
+-- _GET_PED_INTERACTION_PERSONALITY  (0xD7AD3C7EBAF88C92)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedInteractionPersonality(ped) end
+
+-- _GET_PED_LASSO_HOGTIE_FLAG  (0x2C76FA0E01681F8D)
+-- https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CLassoHogtieFlags__Flags
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/LASSO_HOGTIE_FLAG
+-- min build: 1207
+---@param ped number
+---@param flagId number
+---@return boolean
+function _GetPedLassoHogtieFlag(ped, flagId) end
+
+-- _GET_PED_LAST_DROPPED_HAT  (0x1F714E7A9DADFC42)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedLastDroppedHat(ped) end
+
+-- _GET_PED_LOD_MULTIPLIER  (0x1B710E6F4AB69341)
+-- min build: 1355
+---@param ped number
+---@return number
+function _GetPedLodMultiplier(ped) end
+
+-- _GET_PED_MAX_STAMINA  (0xCB42AFE2B613EE55)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedMaxStamina(ped) end
+
+-- _GET_PED_MELEE_ACTION_PHASE  (0x6127F25ED21C533C)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedMeleeActionPhase(ped) end
+
+-- _GET_PED_META_OUTFIT_HASH  (0x30569F348D126A5A)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedMetaOutfitHash(ped) end
+
+-- _GET_PED_MODEL_SIZE_FROM_HASH  (0xA65AA1ACE81E5A77)
+-- PS_SMALL = 0,
+-- PS_MEDIUM,
+-- PS_MEDIUM_LARGE,
+-- PS_LARGE,
+-- PS_EXTRA_LARGE
+-- min build: 1311
+---@param modelHash number
+---@return number
+function _GetPedModelSizeFromHash(modelHash) end
+
+-- _GET_PED_MOTIVATION  (0x42688E94E96FD9B4)
+-- If targetPed is set to 0 the ped motivationState affects everyone
+-- min build: 1207
+---@param ped number
+---@param motivationState number
+---@param targetPed number
+---@return number
+function _GetPedMotivation(ped, motivationState, targetPed) end
+
+-- _GET_PED_QUALITY  (0x7BCC6087D130312A)
+-- Returns Ped Quality to be used to calculate Skinning Quality
+-- 
+-- enum ePedQuality
+-- {
+-- 	PQ_INVALID = -1,
+-- 	PQ_LOW,
+-- 	PQ_MEDIUM,
+-- 	PQ_HIGH,
+-- 	PQ_MAX
+-- };
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedQuality(ped) end
+
+-- _GET_PED_RAGDOLL_BONE_INDEX  (0xC5303F460A40D21D)
+-- Returns boneIndex
+-- min build: 1207
+---@param ped number
+---@param boneId number
+---@return number
+function _GetPedRagdollBoneIndex(ped, boneId) end
+
+-- _GET_PED_REGISTER_PROP  (0x4D0D2E3D8BC000EB)
+-- Gets a registered/attached prop entity for a particular ped. Second parameter will detach the prop entity from the ped if true. Props primarily appear to come from scenarios, such as a broom or hay bale.
+-- 
+-- Known props: https://pastebin.com/ap2NEJqB
+-- min build: 1207
+---@param ped number
+---@param propName string
+---@param detachProp boolean
+---@return number
+function _GetPedRegisterProp(ped, propName, detachProp) end
+
+-- _GET_PED_REMAINING_REVIVAL_TIME  (0xEBE89623EB861271)
+-- normalized / non normalized
+-- 0.0        / 1000.0         STARTED IN WRITHE STAGE
+-- 1.0        / 0.0            END OF WRITHE, DEAD
+-- -1.0                        DEAD
+-- 
+-- Returns some value from AI task 562 (unknown).
+-- min build: 1207
+---@param ped number
+---@param normalized boolean
+---@return number
+function _GetPedRemainingRevivalTime(ped, normalized) end
+
+-- _GET_PED_SEEING_RANGE  (0x2BA9D7BF629F920C)
+-- Returns the seeing range of a ped. Counterpart to SET_PED_SEEING_RANGE.
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedSeeingRange(ped) end
+
+-- _GET_PED_SPEECH_RELATIONSHIP  (0x7C8AA850617651D9)
+-- Checks weather a speech relationship hash was applied on given ped or not.
+-- _GET_PED_G* - _GET_PED_I* (INTERACTION?)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function _GetPedSpeechRelationship(ped, p1) end
+
+-- _GET_PED_STAMINA  (0x775A1CA7893AA8B5)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedStamina(ped) end
+
+-- _GET_PED_STAMINA_NORMALIZED  (0x22F2A386D43048A9)
+-- Returns stamina normalizedValue / normalizedUnlockedMax
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedStaminaNormalized(ped) end
+
+-- _GET_PED_TRANQUILIZER  (0x65C75FDCCAC86464)
+-- min build: 1355
+---@param ped number
+---@return number
+function _GetPedTranquilizer(ped) end
+
+-- _GET_PED_WHO_HOGITIED_THIS_PED  (0x3D9F958834AB9C30)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedWhoHogitiedThisPed(ped) end
+
+-- _GET_PEDS_IN_COMBAT_WITH_TARGET  (0x7BE607DAFF382FD2)
+-- min build: 1207
+---@param ped number
+---@param itemset number
+---@param flag number
+---@return number
+function _GetPedsInCombatWithTarget(ped, itemset, flag) end
+
+-- _GET_PELT_FROM_HORSE  (0x0CEEB6F4780B1F2F)
+-- Returns peltId
+-- min build: 1207
+---@param horse number
+---@param index number
+---@return number
+function _GetPeltFromHorse(horse, index) end
+
+-- _GET_PLAYER_CURRENT_ANIMAL_DAMAGE_MODIFIER  (0xEE2D5C819A65BF26)
+-- Returns animal skin quality modifier
+-- min build: 1311
+---@param player number
+---@return number
+function _GetPlayerCurrentAnimalDamageModifier(player) end
+
+-- _GET_PLAYER_DISMOUNT_TIMESTAMP  (0xE8D1CCB9375C101B)
+-- min build: 1207
+---@param mount number
+---@param player number
+---@return number
+function _GetPlayerDismountTimestamp(mount, player) end
+
+-- _GET_PLAYER_PED_WATER_DEPTH  (0x2942457417A5FD24)
+-- Returns how deep the water is below the ped (if in water)
+-- -1.0f = Not in water
+-- 10.0f = Max water depth
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPlayerPedWaterDepth(ped) end
+
+-- _GET_RIDER_OF_MOUNT  (0xB676EFDA03DADA52)
+-- min build: 1207
+---@param mount number
+---@param p1 boolean
+---@return number
+function _GetRiderOfMount(mount, p1) end
+
+-- _GET_SHOP_ITEM_BASE_LAYERS  (0x63342C50EC115CE8)
+-- min build: 1207
+---@param shopItem number
+---@param p1 any
+---@param ped number
+---@param metapedType number
+---@param p4 boolean
+---@return boolean
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+---@return number
+function _GetShopItemBaseLayers(shopItem, p1, ped, metapedType, p4) end
+
+-- _GET_SHOP_ITEM_COMPONENT_AT_INDEX  (0x77BA37622E22023B)
+-- Returns 0 if index invalid/unresolvable; else the shop component hash.
+-- resolveSelection: true -> run the resolver (rebuild from ped meta/outfit - MP “net shop” style); false -> use cached entry only (singleplayer - offline).
+-- outStatusFlag: Set to 1 if the entry's internal status byte != 0.
+-- outWearableState: See _UPDATE_SHOP_ITEM_WEARABLE_STATE
+-- min build: 1207
+---@param ped number
+---@param index number
+---@param resolveSelection boolean
+---@return number
+---@return boolean
+---@return number
+function _GetShopItemComponentAtIndex(ped, index, resolveSelection) end
+
+-- _GET_SHOP_ITEM_COMPONENT_CATEGORY  (0x5FF9A878C3D115B8)
+-- min build: 1207
+---@param componentHash number
+---@param metapedType number
+---@param isMP boolean
+---@return number
+function _GetShopItemComponentCategory(componentHash, metapedType, isMP) end
+
+-- _GET_SHOP_ITEM_HAT_COMPONENT  (0x7E02E4218D916B94)
+-- min build: 1207
+---@param ped number
+---@param metapedType number
+---@param p2 boolean
+---@return any
+function _GetShopItemHatComponent(ped, metapedType, p2) end
+
+-- _GET_SHOP_ITEM_NUM_WEARABLE_STATES  (0xFFCC2DB2D9953401)
+-- Returns the number of wearable states available for a shop item / component. p2 seems to be true in scripts.
+-- 
+-- For use with 0x6243635AF2F1B826 (_GET_SHOP_ITEM_AVAILABLE_WEARABLE_STATE_BY_INDEX)
+-- min build: 1207
+---@param componentHash number
+---@param isMpFemale boolean
+---@param p2 boolean
+---@return number
+function _GetShopItemNumWearableStates(componentHash, isMpFemale, p2) end
+
+-- _GET_SHOP_ITEM_WEARABLE_STATE_BY_INDEX  (0x6243635AF2F1B826)
+-- Gets an available wearable state by index for a shop item / component - it does not retreive what the current state is. p3 seems to be true in scripts.
+-- 
+-- Use 0xFFCC2DB2D9953401 (_GET_SHOP_ITEM_NUM_WEARABLE_STATES) to get the number of available wearable states
+-- min build: 1207
+---@param componentHash number
+---@param wearableStateIndex number
+---@param isMpFemale boolean
+---@param p3 boolean
+---@return number
+function _GetShopItemWearableStateByIndex(componentHash, wearableStateIndex, isMpFemale, p3) end
+
+-- _GET_STAMINA_DEPLETION_MULTIPLIER  (0x825F6DD559A0895B)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetStaminaDepletionMultiplier(ped) end
+
+-- _GET_STAMINA_RECHARGE_MULTIPLIER  (0xE7687EB2F634ABF0)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetStaminaRechargeMultiplier(ped) end
+
+-- _GET_TOTAL_PED_DAMAGE_FROM_AI  (0x92C8EACA29F6BED6)
+-- _GET_WA*
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetTotalPedDamageFromAi(ped) end
+
+-- _GET_TRANSPORT_PED_IS_SEATED_ON  (0x849BD6C6314793D0)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetTransportPedIsSeatedOn(ped) end
+
+-- _GET_VEHICLE_DRAFT_HORSE_IS_ATTACHED_TO  (0xE4770DA1B8FF4FD1)
+-- min build: 1207
+---@param horse number
+---@return number
+function _GetVehicleDraftHorseIsAttachedTo(horse) end
+
+-- _GIVE_PED_HASH_COMMAND  (0xD65FDC686A031C83)
+-- Ped Command Hash are special commands, that can be activated to change conditional anim variations or trigger transitions between conditional anims.
+-- https://github.com/femga/rdr3_discoveries/blob/master/animations/scenarios
+-- min build: 1207
+---@param ped number
+---@param commandHash number
+---@param activationDuration number
+function _GivePedHashCommand(ped, commandHash, activationDuration) end
+
+-- _GIVE_PED_SCENARIO_PROP  (0x3BBDD6143FF16F98)
+-- min build: 1207
+---@param ped number
+---@param object number
+---@param conditionalAnim string
+---@param p3 string
+---@param p4 string
+---@param p5 boolean
+---@return boolean
+function _GivePedScenarioProp(ped, object, conditionalAnim, p3, p4, p5) end
+
+-- _GIVE_PED_SCENARIO_PROP_DYNAMIC  (0xA0774E388CE4A679)
+-- Only used in SP R* Script rcm_jack2
+-- min build: 1207
+---@param ped number
+---@param object number
+---@param p2 string
+---@param p3 string
+---@param p4 boolean
+---@return boolean
+function _GivePedScenarioPropDynamic(ped, object, p2, p3, p4) end
+
+-- _HAS_META_PED_ASSET_LOADED  (0xB0B2C6D170B0E8E5)
+-- min build: 1207
+---@param requestId number
+---@return boolean
+function _HasMetaPedAssetLoaded(requestId) end
+
+-- _HAS_META_PED_OUTFIT_LOADED  (0x610438375E5D1801)
+-- min build: 1207
+---@param requestId number
+---@return boolean
+function _HasMetaPedOutfitLoaded(requestId) end
+
+-- _HAS_META_PED_REQUEST_LOADED  (0xC0940AC858C1E126)
+-- min build: 1207
+---@param requestId number
+---@return boolean
+function _HasMetaPedRequestLoaded(requestId) end
+
+-- _HAS_PED_BEEN_SHOVED_RECENTLY  (0x29FCE825613FEFCA)
+-- min build: 1207
+---@param ped number
+---@param ms number
+---@return boolean
+function _HasPedBeenShovedRecently(ped, ms) end
+
+-- _HAS_PED_EMOTIONAL_PRESET_LOADED  (0xDE3904B22695D9F9)
+-- See _REQUEST_PED_EMOTIONAL_PRESET
+-- min build: 1207
+---@param ped number
+---@param name string
+---@return boolean
+function _HasPedEmotionalPresetLoaded(ped, name) end
+
+-- _HAS_PED_KNOCKED_ON_DOOR  (0xFA8C10DCE0706D43)
+-- Checks whether the specified ped has completed a door knocking interaction.
+-- Typically used with _SET_DOOR_KNOCKING_WHEN_LOCKED. Returns true after the knocking interaction/animation has completed, not while it is still playing. Does not detect normal door-handle interaction.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _HasPedKnockedOnDoor(ped) end
+
+-- _HAS_PED_SHOT_RECENTLY  (0xB7DBB2986B87E230)
+-- True if the ped fired a weapon within the last `seconds` (seconds -> compared in ms internally). Returns false if no recent shot is recorded.
+-- min build: 1207
+---@param ped number
+---@param seconds number
+---@return boolean
+function _HasPedShotRecently(ped, seconds) end
+
+-- _HAS_PED_TAKEN_GORE_DAMAGE  (0xBA208A8D6399A3AC)
+-- limb: 3 = Left Hand, 4 = Left Arm, 6 = Right Hand, 7 = Right Arm, 9 = Left Foot, 10 = Left Leg, 12 = Right Foot, 13 = Right Leg, 37 = Head
+-- min build: 1207
+---@param ped number
+---@param limb number
+---@return boolean
+function _HasPedTakenGoreDamage(ped, limb) end
+
+-- _HIDE_PED_REINS  (0xCAC43D060099EA72)
+-- Hides the visible reins/lead straps associated with the specified ped.
+-- In practical use this is expected to be a horse ped, causing the hanging rein geometry to disappear.
+-- min build: 1207
+---@param ped number
+function _HidePedReins(ped) end
+
+-- _HORSE_AGITATE  (0xBAE08F00021BFFB2)
+-- _H* - _I*
+-- min build: 1207
+---@param mount number
+---@param kickOffRider boolean
+function _HorseAgitate(mount, kickOffRider) end
+
+-- _INCAPACITATED_REVIVE  (0xF6262491C7704A63)
+-- min build: 1207
+---@param ped number
+---@param ped2 number
+function _IncapacitatedRevive(ped, ped2) end
+
+-- _IS_ANIMAL_CONTROLLED_BY_A_PLAYER  (0x0E2F43516F998269)
+-- Returns true only if it's a player ped and an animal as well.
+-- _IS_ANY_* - _IS_CONTROL_*
+-- min build: 1311
+---@param ped number
+---@return boolean
+function _IsAnimalControlledByAPlayer(ped) end
+
+-- _IS_ANIMAL_INTERACTION_RUNNING  (0x7FC84E85D98F063D)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsAnimalInteractionRunning(ped) end
+
+-- _IS_ANIMAL_SKINNED  (0x88A5564B19C15391)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsAnimalSkinned(ped) end
+
+-- _IS_META_PED_ASSET_VALID  (0x93FFD92F05EC32FD)
+-- min build: 1207
+---@param requestId number
+---@return boolean
+function _IsMetaPedAssetValid(requestId) end
+
+-- _IS_META_PED_FISH  (0x118D476A6F1A13F1)
+-- Returns true if given ped is a fish.
+-- _IS_ME* - _IS_MO*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsMetaPedFish(ped) end
+
+-- _IS_META_PED_OUTFIT_EQUIPPED  (0x98082246107A6ACF)
+-- Used in script function HORSE_IS_META_PED_OUTFIT_SADDLE_EQUIPPED
+-- min build: 1207
+---@param ped number
+---@param outfit number
+---@return boolean
+function _IsMetaPedOutfitEquipped(ped, outfit) end
+
+-- _IS_META_PED_OUTFIT_REQUEST_VALID  (0xB25E57FC8E37114D)
+-- min build: 1207
+---@param requestId number
+---@return boolean
+function _IsMetaPedOutfitRequestValid(requestId) end
+
+-- _IS_META_PED_REQUEST_VALID  (0x43E4DA469541A9C9)
+-- min build: 1207
+---@param requestId number
+---@return boolean
+function _IsMetaPedRequestValid(requestId) end
+
+-- _IS_META_PED_USING_COMPONENT  (0xFB4891BD7578CDC1)
+-- min build: 1207
+---@param ped number
+---@param component number
+---@return boolean
+function _IsMetaPedUsingComponent(ped, component) end
+
+-- _IS_MOUNT_SEAT_FREE  (0xAAB0FE202E9FC9F0)
+-- min build: 1207
+---@param mount number
+---@param seat number
+---@return boolean
+function _IsMountSeatFree(mount, seat) end
+
+-- _IS_PED_ACTION_DISABLE_FLAG_ENABLED  (0xB346C85D49CC998E)
+-- min build: 1207
+---@param ped number
+---@param actionDisableFlag number
+---@return boolean
+function _IsPedActionDisableFlagEnabled(ped, actionDisableFlag) end
+
+-- _IS_PED_CHILD  (0x137772000DAF42C5)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedChild(ped) end
+
+-- _IS_PED_CLIMBING_LADDER  (0x59643424B68D52B5)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedClimbingLadder(ped) end
+
+-- _IS_PED_COWERING  (0xB086C8C0F5701D14)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedCowering(ped) end
+
+-- _IS_PED_DOING_SCENARIO_TRANSITION  (0xC488B8C0E52560D8)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedDoingScenarioTransition(ped) end
+
+-- _IS_PED_DRAGGING  (0x226CF9B159E38F42)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedDragging(ped) end
+
+-- _IS_PED_DRUNK  (0x50F124E6EF188B22)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedDrunk(ped) end
+
+-- _IS_PED_GROUP_LEADER  (0x878B68960C1C2A35)
+-- min build: 1207
+---@param ped number
+---@param groupId number
+---@return boolean
+function _IsPedGroupLeader(ped, groupId) end
+
+-- _IS_PED_IN_NAVIGABLE_WATER  (0xDC88D06719070C39)
+-- Detects if ped is afloat in water like swimming or in a boat (driving or standing on it)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedInNavigableWater(ped) end
+
+-- _IS_PED_IN_POINT  (0x078076AB50FB117F)
+-- If returned true: There are enemy peds near friendly turn in ped. Going to aggro.
+-- If returned false: Moving back to idle as there aren't any remaining enemy peds near ped
+-- _IS_PED_IN_*
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p5 boolean
+---@return boolean
+function _IsPedInPoint(ped, x, y, z, radius, p5) end
+
+-- _IS_PED_INTIMIDATED  (0x57779B55B83E2BEA)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedIntimidated(ped) end
+
+-- _IS_PED_INVESTIGATING  (0x7583A9D35248B83F)
+-- _IS_PED_IN*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedInvestigating(ped) end
+
+-- _IS_PED_LEADING_ANY_GROUP  (0x917760CFE7A0E0F1)
+-- _IS_PED_L* - _IS_PED_M*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedLeadingAnyGroup(ped) end
+
+-- _IS_PED_MODEL_SUPPRESSED  (0xAA9F048DCF69B6DC)
+-- min build: 1207
+---@param model number
+---@return boolean
+function _IsPedModelSuppressed(model) end
+
+-- _IS_PED_QUEUED_FOR_DELETION  (0x8D9BFCE3352DE47F)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedQueuedForDeletion(ped) end
+
+-- _IS_PED_SLIDING  (0xD6740E14E4CEFC0B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedSliding(ped) end
+
+-- _IS_PED_TARGET_ACTION_DISABLE_FLAG_ENABLED  (0x02AA2096FE00F3E1)
+-- min build: 1207
+---@param ped number
+---@param actionDisableFlag number
+---@return boolean
+function _IsPedTargetActionDisableFlagEnabled(ped, actionDisableFlag) end
+
+-- _IS_PED_USING_ACTION_MODE_2  (0xEBB208D6AE712C03)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedUsingActionMode2(ped) end
+
+-- _IS_PED_VISIBILITY_TRACKED  (0x5102307CE88798EB)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedVisibilityTracked(ped) end
+
+-- _IS_SCENARIO_BLOCKING_AREA_VALID  (0x91A5F9CBEBB9D936)
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function _IsScenarioBlockingAreaValid(p0) end
+
+-- _IS_TARGET  (0x6E5CBCB3941D7D08)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@return boolean
+function _IsTarget(ped, targetPed) end
+
+-- _IS_TEXTURE_VALID  (0x31DC8D3F216D8509)
+-- min build: 1207
+---@param textureId number
+---@return boolean
+function _IsTextureValid(textureId) end
+
+-- _IS_THIS_MODEL_A_HORSE  (0x772A1969F649E902)
+-- min build: 1207
+---@param model number
+---@return boolean
+function _IsThisModelAHorse(model) end
+
+-- _IS_TRACKED_PED_VISIBILITY_PERCENTAGE_NOT_LESS_THAN  (0x164CECC59E70DF86)
+-- min build: 1207
+---@param ped number
+---@param percent number
+---@return boolean
+function _IsTrackedPedVisibilityPercentageNotLessThan(ped, percent) end
+
+-- _IS_USING_SLIPSTREAM  (0xAF61B3CD8C3B82C3)
+-- _IS_TRACKED_* - IS_V*
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsUsingSlipstream(ped) end
+
+-- _PED_APPLY_SPEECH_RELATIONSHIP  (0x1E017404784AA6A3)
+-- Applies speech relationship hash on given ped.
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function _PedApplySpeechRelationship(ped, p1) end
+
+-- _PED_CLEAR_LOCO_MOTION  (0x935CF6E42BAF7F4D)
+-- min build: 1207
+---@param ped number
+function _PedClearLocoMotion(ped) end
+
+-- _PED_DUELING_DID_PLAYER_HEADSHOT_OPPONENT  (0xBD6B242B8BD5543A)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _PedDuelingDidPlayerHeadshotOpponent(ped) end
+
+-- _PED_EMOTIONAL_PRESET_LOCO_MOTION  (0xAAB050DA48B57978)
+-- target: 0 affects everyone
+-- duration: -1 indefinite
+-- flag: always 4 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param presetName string
+---@param targetPed number
+---@param duration number
+---@param flag number
+function _PedEmotionalPresetLocoMotion(ped, presetName, targetPed, duration, flag) end
+
+-- _PED_REMOVE_SPEECH_RELATIONSHIP  (0x2B4CE170DE09F346)
+-- Removes speech relationship hash on given ped.
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _PedRemoveSpeechRelationship(ped, p1) end
+
+-- _PED_SET_SIMPLE_PLAYER_MEMORY  (0xC494C76A34266E82)
+-- memoryType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/_PED_SET_SIMPLE_PLAYER_MEMORY
+-- min build: 1207
+---@param ped number
+---@param memoryType number
+function _PedSetSimplePlayerMemory(ped, memoryType) end
+
+-- _PED_WAS_KILLED_BY_HEADSHOT  (0x06FA94C835787C64)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _PedWasKilledByHeadshot(ped) end
+
+-- _PROPITEM_PLAY_CONDITIONAL_ANIM_WITH_OBJECT  (0xCE7A6C1D5CDE1F9D)
+-- Plays a conditional locomotion animation with a prop item (commonly used for carry/attach interactions like crates).
+-- 
+-- Notes:
+-- - propItemId is a ConditionalAnims.propitem identifier (e.g. "P_CS_CRATETNT01X_PH_R_HAND").
+-- - conditionalAnimName is the conditional locomotion anim name/key (e.g. "LOCO_ATTACH_CRATE_TNT").
+-- - targetEntity is the linked/context entity (often the object being manipulated).
+-- - This primarily drives the conditional anim + propitem state; scripts often still attach/detach the physical entity manually.
+-- - Pair with _REMOVE_CONDITIONAL_ANIM_PROPITEM to stop/clear the state.
+-- - Example video: https://imgur.com/a/1H3xmbv
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param propItemId string
+---@param conditionalAnimName string
+function _PropitemPlayConditionalAnimWithObject(ped, targetEntity, propItemId, conditionalAnimName) end
+
+-- _REFRESH_CARRIED_PED_FOR_PED  (0x6B67320E0D57856A)
+-- Outputs the carried ped.
+-- Params: p2 is alsways 2, p3 is always false.
+-- min build: 1207
+---@param ped number
+---@param p2 number
+---@param p3 boolean
+---@return number
+function _RefreshCarriedPedForPed(ped, p2, p3) end
+
+-- _REFRESH_CARRY_STATE_FOR_PED  (0x4642182A298187D0)
+-- Queries/refreshes the current 'carry' action for a ped and (optionally) returns involved entities.
+-- Usage/Example: https://pastebin.com/qVstcVfz
+-- min build: 1207
+---@param ped number
+---@param carryType number
+---@param outEntsCount number
+---@param filterFlags number
+---@return number
+---@return any
+function _RefreshCarryStateForPed(ped, carryType, outEntsCount, filterFlags) end
+
+-- _REFRESH_LOOT_STATE_FOR_PED  (0x5463C962BC7777C3)
+-- Returns loot state
+-- enum eLootState
+-- {
+-- 	LAP_NONE,
+-- 	LAP_RESUMING,
+-- 	LAP_GETTING_ON_FOOT,
+-- 	LAP_DISTANT_NAV,
+-- 	LAP_CHOOSING_ACTION,
+-- 	LAP_APPROACHING,
+-- 	LAP_ENTERING,
+-- 	LAP_LOOTING,
+-- 	LAP_EXITING
+-- };
+-- 
+-- _POSSE_* - _REGISTER_HATED*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p3 number
+---@param p4 number
+---@return number
+---@return number
+function _RefreshLootStateForPed(ped, p1, p3, p4) end
+
+-- _REFRESH_META_PED_SHOP_ITEMS  (0x59BD177A1A48600A)
+-- p1 is always 1
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _RefreshMetaPedShopItems(ped, p1) end
+
+-- _REGISTER_HATED_TARGETS_IN_AREA  (0xD8736EFDA38EDC5C)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+function _RegisterHatedTargetsInArea(ped, x, y, z, radius) end
+
+-- _RELEASE_META_PED_ASSET_REQUEST  (0x13E7320C762F0477)
+-- min build: 1207
+---@param requestId number
+function _ReleaseMetaPedAssetRequest(requestId) end
+
+-- _RELEASE_META_PED_OUTFIT_REQUEST  (0x4592B8B9B0EF5F48)
+-- min build: 1207
+---@param requestId number
+function _ReleaseMetaPedOutfitRequest(requestId) end
+
+-- _RELEASE_META_PED_REQUEST  (0x3972F78A78B5D9DF)
+-- min build: 1207
+---@param requestId number
+function _ReleaseMetaPedRequest(requestId) end
+
+-- _RELEASE_TEXTURE  (0x6BEFAA907B076859)
+-- Removes a texture created by 0xC5E7204F322E49EB.
+-- min build: 1207
+---@param textureId number
+function _ReleaseTexture(textureId) end
+
+-- _REMOVE_CONDITIONAL_ANIM_PROPITEM  (0x3A50753042B6891B)
+-- Stops and clears a running conditional locomotion animation state on the ped for the given prop item id (started via _PROPITEM_PLAY_CONDITIONAL_ANIM_WITH_OBJECT).
+-- 
+-- Notes:
+-- - Ends the conditional locomotion/propitem state; it does not delete/detach any physical object entity.
+-- 
+-- Old name: _REMOVE_PED_PROP
+-- min build: 1207
+---@param ped number
+---@param propItemId string
+function _RemoveConditionalAnimPropitem(ped, propItemId) end
+
+-- _REMOVE_GRAVITY_WELL  (0x87247BC60B60BED8)
+-- Removes gravity well by handle returned from 0x4F5EBE70081E5A20
+-- min build: 1207
+---@param handle number
+function _RemoveGravityWell(handle) end
+
+-- _REMOVE_MOTION_TYPE_ASSET  (0xDE7B2B4144906CDF)
+-- min build: 1207
+---@param nameHash number
+---@param ped number
+function _RemoveMotionTypeAsset(nameHash, ped) end
+
+-- _REMOVE_PED_BLACKBOARD_BOOL  (0xA6F67BEC53379A32)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+function _RemovePedBlackboardBool(ped, variableName) end
+
+-- _REMOVE_PED_BLACKBOARD_FLOAT  (0x411189E51B8020BA)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+function _RemovePedBlackboardFloat(ped, variableName) end
+
+-- _REMOVE_PED_BLACKBOARD_HASH  (0x0E17378642156790)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+function _RemovePedBlackboardHash(ped, variableName) end
+
+-- _REMOVE_PED_BLACKBOARD_INT  (0x81B75428A7813E67)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+function _RemovePedBlackboardInt(ped, variableName) end
+
+-- _REMOVE_PED_EMOTIONAL_PRESET  (0xFC3BAB1801A8255A)
+-- See _REQUEST_PED_EMOTIONAL_PRESET
+-- min build: 1207
+---@param ped number
+---@param name string
+function _RemovePedEmotionalPreset(ped, name) end
+
+-- _REMOVE_PED_FROM_MOUNT  (0x5337B721C51883A9)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+function _RemovePedFromMount(ped, p1, p2) end
+
+-- _REMOVE_PED_OVERLAY  (0x96C349DE04C49011)
+-- min build: 1207
+---@param textureId number
+---@param overlayId number
+function _RemovePedOverlay(textureId, overlayId) end
+
+-- _REMOVE_PED_STAY_OUT_VOLUME  (0x0CAB404CD2DB41F5)
+-- min build: 1207
+---@param ped number
+---@param volume number
+---@return boolean
+function _RemovePedStayOutVolume(ped, volume) end
+
+-- _REMOVE_PED_SUBSCRIBE_TO_LEGENDARY_BLIPS  (0x011A42FD923D41CA)
+-- min build: 1311
+---@param ped number
+---@return boolean
+function _RemovePedSubscribeToLegendaryBlips(ped) end
+
+-- _REMOVE_SHOP_ITEM_FROM_PED  (0x0D7FFA1B2F69ED82)
+-- Directly removes a shop item component from a ped
+-- Params: p2 and p3 are always 0
+-- min build: 1355
+---@param ped number
+---@param componentHash number
+---@param p2 number
+---@param p3 boolean
+function _RemoveShopItemFromPed(ped, componentHash, p2, p3) end
+
+-- _REMOVE_TARGET  (0x4707E9C23D8CA3FE)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+function _RemoveTarget(ped, targetPed) end
+
+-- _REQUEST_META_PED  (0xF97C34C33487D569)
+-- Returns requestId
+-- Params: p1 = 1 in R* Scripts (Used in SP only)
+-- min build: 1207
+---@param model number
+---@param p1 number
+---@return number
+function _RequestMetaPed(model, p1) end
+
+-- _REQUEST_META_PED_ASSET_BUNDLE  (0x91FE941F9FCFB702)
+-- Returns requestId
+-- Params: p1 = 1 in R* Scripts
+-- min build: 1207
+---@param asset number
+---@param p1 number
+---@return number
+function _RequestMetaPedAssetBundle(asset, p1) end
+
+-- _REQUEST_META_PED_COMPONENT  (0xF6D9E1F3560CBF8E)
+-- min build: 1207
+---@param metaPedType number
+---@param p1 any
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@return any
+function _RequestMetaPedComponent(metaPedType, p1, p2, p3, p4) end
+
+-- _REQUEST_META_PED_OUTFIT  (0x13154A76CE0CF9AB)
+-- https://github.com/femga/rdr3_discoveries/blob/master/clothes/metaped_outfits.lua
+-- Returns requestId, to be used with 0x74F512E29CB717E2
+-- min build: 1207
+---@param model number
+---@param outfit number
+---@return number
+function _RequestMetaPedOutfit(model, outfit) end
+
+-- _REQUEST_MOTION_TYPE_ASSET  (0xF7EA250B9A919E03)
+-- min build: 1207
+---@param nameHash number
+---@param ped number
+function _RequestMotionTypeAsset(nameHash, ped) end
+
+-- _REQUEST_PED_EMOTIONAL_PRESET  (0x5C3C55EAAD19915F)
+-- For more information, see common:/data/emotional_presets.meta
+-- min build: 1207
+---@param ped number
+---@param name string
+function _RequestPedEmotionalPreset(ped, name) end
+
+-- _REQUEST_PED_FACIAL_MOOD_THIS_FRAME  (0x8B3B71C80A29A4BB)
+-- mood: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/fwFacialAnimRequest__Mood
+-- Params: p2 = 6 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param mood number
+---@param p2 number
+function _RequestPedFacialMoodThisFrame(ped, mood, p2) end
+
+-- _REQUEST_PED_FOR_SCENARIO_TYPE  (0xBDED916A9F9B0604)
+-- min build: 1207
+---@param ped number
+---@param object number
+---@param p2 string
+---@param scenarioType number
+---@param p4 string
+---@param p5 boolean
+---@return any
+function _RequestPedForScenarioType(ped, object, p2, scenarioType, p4, p5) end
+
+-- _REQUEST_PED_GETUP_ANIMATION  (0xEAA8242C8479C27D)
+-- Known get up animation types: REAR, FRONT
+-- min build: 1207
+---@param ped number
+---@param getUpType string
+function _RequestPedGetupAnimation(ped, getUpType) end
+
+-- _REQUEST_PROP_SCENARIO_PED  (0xBEC65C6049B3219D)
+-- min build: 1207
+---@param ped number
+---@param object number
+---@param p2 string
+---@param p3 string
+---@param p4 string
+---@param p5 boolean
+---@return any
+function _RequestPropScenarioPed(ped, object, p2, p3, p4, p5) end
+
+-- _REQUEST_TEXTURE  (0xC5E7204F322E49EB)
+-- Creates a texture override data for ped and returns it's index.
+-- So you can replace any texture of any ped's component.
+-- Also, you can add overlays on it, such as aging, lipstick and more.
+-- Textures can be reused by multiple peds at once.
+-- You can keep only 32 textures at once(including other peds).
+-- 
+-- https://github.com/femga/rdr3_discoveries/blob/master/clothes/change_overlays_script.lua
+-- materialHash: https://github.com/femga/rdr3_discoveries/blob/master/clothes/cloth_drawable_albedo_normal_material_TEMPORARY.lua
+-- min build: 1207
+---@param albedoHash number
+---@param normalHash number
+---@param materialHash number
+---@return number
+function _RequestTexture(albedoHash, normalHash, materialHash) end
+
+-- _RESERVE_AMBIENT_PEDS  (0xED9582B3DA8F02B4)
+-- min build: 1207
+---@param numPeds number
+function _ReserveAmbientPeds(numPeds) end
+
+-- _RESERVE_AMBIENT_PEDS_TOTAL  (0xF008E0BA1FE1D644)
+-- min build: 1207
+---@param numPeds number
+function _ReserveAmbientPedsTotal(numPeds) end
+
+-- _RESET_PED_COMPONENTS  (0x0BFA1BD465CDFEFD)
+-- min build: 1207
+---@param ped number
+function _ResetPedComponents(ped) end
+
+-- _RESET_PED_INCAPACITATION_BLEED_OUT_DURATION  (0x4B9668DB91DC39B8)
+-- min build: 1207
+---@param ped number
+function _ResetPedIncapacitationBleedOutDuration(ped) end
+
+-- _RESET_PED_LADDER_MOVEMENT_SPEED_MODIFIER  (0x801917E7D7BCE418)
+-- min build: 1207
+---@param ped number
+function _ResetPedLadderMovementSpeedModifier(ped) end
+
+-- _RESET_PED_STAMINA  (0x36513AFFC703C60D)
+-- Seems to set the peds stamina to 30%
+-- min build: 1207
+---@param ped number
+function _ResetPedStamina(ped) end
+
+-- _RESET_PED_TEXTURE  (0x8472A1789478F82F)
+-- Removes every texture layer but the base layer
+-- Clearing texture's data: setting params to default values, but keep overlays.
+-- min build: 1207
+---@param textureId number
+function _ResetPedTexture(textureId) end
+
+-- _RESTORE_PED_STAMINA  (0x675680D089BFA21F)
+-- 0.0 <= stamina <= 100.0
+-- min build: 1207
+---@param ped number
+---@param stamina number
+function _RestorePedStamina(ped, stamina) end
+
+-- _SET_ACCURACY_AGAINST_LOCAL_PLAYER_MODIFIER  (0xC2266AA617668AD3)
+-- min build: 1207
+---@param ped number
+---@param modifier number
+function _SetAccuracyAgainstLocalPlayerModifier(ped, modifier) end
+
+-- _SET_ACTIVE_META_PED_COMPONENTS_UPDATED  (0xAAB86462966168CE)
+-- Related to _0x704C908E9C405136 for component loading
+-- Can be used to fix missing outfit changes, always paired with _UPDATE_PED_VARIATION
+-- Doesn't actually return anything.
+-- min build: 1207
+---@param ped number
+---@param isMP boolean
+---@return any
+function _SetActiveMetaPedComponentsUpdated(ped, isMP) end
+
+-- _SET_AMBIENT_ANIMAL_DENSITY_MULTIPLIER_THIS_FRAME  (0xC0258742B034DFAF)
+-- min build: 1207
+---@param multiplier number
+function _SetAmbientAnimalDensityMultiplierThisFrame(multiplier) end
+
+-- _SET_AMBIENT_HUMAN_DENSITY_MULTIPLIER_THIS_FRAME  (0xBA0980B5C0A11924)
+-- min build: 1207
+---@param multiplier number
+function _SetAmbientHumanDensityMultiplierThisFrame(multiplier) end
+
+-- _SET_AMBIENT_PED_DENSITY_MULTIPLIER_THIS_FRAME  (0xAB0D553FE20A6E25)
+-- min build: 1207
+---@param multiplier number
+function _SetAmbientPedDensityMultiplierThisFrame(multiplier) end
+
+-- _SET_CHAR_EXPRESSION  (0x5653AB26C82938CF)
+-- Sets MetaPedExpression at index specified. Morphs components, such as changing body size or facial features.
+-- 
+-- Note: You have to update the ped's variation (using 0xCC8CA3E88256E58F) after calling this native
+-- 
+-- index = MetaPedExpression IDs
+-- List of face features: https://pastebin.com/9jb88FXW
+-- Full list of MetaPedExpressions: https://pastebin.com/Ld76cAn7
+-- value: -1.0 to 1.0 (values beyond this likely won't sync to other clients)
+-- 
+-- This native also allows you to change a horse's gender.
+-- 
+-- Old name: _SET_PED_FACE_FEATURE
+-- min build: 1207
+---@param ped number
+---@param index number
+---@param value number
+function _SetCharExpression(ped, index, value) end
+
+-- _SET_CURRENT_DEFENSE_AGAINST_PLAYERS_MODIFIER  (0x069EDDF1FD4DEB0A)
+-- min build: 1207
+---@param horse number
+---@param modifier number
+function _SetCurrentDefenseAgainstPlayersModifier(horse, modifier) end
+
+-- _SET_DEFENSE_MODIFIER_FOR_PED  (0x9B6808EC46BE849B)
+-- min build: 1207
+---@param ped number
+---@param modifier number
+function _SetDefenseModifierForPed(ped, modifier) end
+
+-- _SET_FORMATION_AUTO_ASSIGN_POSITION  (0x478F6B9920446CE2)
+-- min build: 1207
+---@param groupId number
+---@param toggle boolean
+function _SetFormationAutoAssignPosition(groupId, toggle) end
+
+-- _SET_HEALTH_RECHARGE_MULTIPLIER  (0xDE1B1907A83A1550)
+-- min build: 1207
+---@param ped number
+---@param multiplier number
+function _SetHealthRechargeMultiplier(ped, multiplier) end
+
+-- _SET_HORSE_SCRIPTED_FLAG  (0xB8AB265426CFE6DD)
+-- Sets an internal horse-component flag (bit 0x04) used for scripted control of mounts (e.g., after placing/rider-seating). Pass true to set, false to clear. No effect on non-horses.
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetHorseScriptedFlag(ped, toggle) end
+
+-- _SET_INTERACTION_LOCKON_FLAG  (0xFECA2081F61ED2CD)
+-- min build: 1207
+---@param ped number
+---@param player number
+---@param flag number
+---@param enable boolean
+function _SetInteractionLockonFlag(ped, player, flag, enable) end
+
+-- _SET_META_PED_TAG  (0xBC6DF00D7A4A6819)
+-- Use to apply metaped player components
+-- Replaces asset, alternatively you can remove assets using REMOVE_TAG_FROM_META_PED
+-- min build: 1207
+---@param ped number
+---@param drawable number
+---@param albedo number
+---@param normal number
+---@param material number
+---@param palette number
+---@param tint0 number
+---@param tint1 number
+---@param tint2 number
+function _SetMetaPedTag(ped, drawable, albedo, normal, material, palette, tint0, tint1, tint2) end
+
+-- _SET_META_PED_WEARINESS  (0x314C5465195F3B30)
+-- Sets ped eye redness, weariness: 0.f to 1.f
+-- min build: 1207
+---@param ped number
+---@param weariness number
+function _SetMetaPedWeariness(ped, weariness) end
+
+-- _SET_MIN_PED_HEALTH_THRESHOLD  (0x7883AA809DF43D98)
+-- min build: 1355
+---@param ped number
+---@param healthAmount number
+function _SetMinPedHealthThreshold(ped, healthAmount) end
+
+-- _SET_MOUNT_BONDING_LEVEL  (0xA69899995997A63B)
+-- min build: 1207
+---@param ped number
+---@param bondingLevel number
+function _SetMountBondingLevel(ped, bondingLevel) end
+
+-- _SET_MOUNT_SECURITY_ENABLED  (0x11E6B9629C46D6EC)
+-- Note: this native was added in build 1232.40
+-- min build: 1232
+---@param ped number
+---@param toggle boolean
+function _SetMountSecurityEnabled(ped, toggle) end
+
+-- _SET_PED_ACTION_DISABLE_FLAG  (0xB8DE69D9473B7593)
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_ACTION_DISABLE_FLAGS
+-- min build: 1207
+---@param ped number
+---@param actionDisableFlag number
+function _SetPedActionDisableFlag(ped, actionDisableFlag) end
+
+-- _SET_PED_ACTIVATE_WOUND_EFFECT  (0xFFD54D9FE71B966A)
+-- bloodFountainPressure: visible effect from 0.0 till 20.0
+-- yaw: visible effect from -3.0 till 3.0
+-- bloodFountainDirection: 1.0 left side, -1.0 right side
+-- bloodFountainPulse: from 0.1 (low) till 1.0 (fast)
+-- make blood fountain from your stomach: _SET_PED_ACTIVATE_WOUND_EFFECT(ped, unk, 2, 14411, 0.0, 0.1, 0.0, 0.0, 3.0, -1.0, 1.0)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param boneId number
+---@param moveWoundLeftRight number
+---@param bloodFountainPressure number
+---@param yaw number
+---@param bloodFountainDirection number
+---@param bloodFountainPulse number
+---@param p8 number
+---@param p9 number
+function _SetPedActivateWoundEffect(ped, p1, boneId, moveWoundLeftRight, bloodFountainPressure, yaw, bloodFountainDirection, bloodFountainPulse, p8, p9) end
+
+-- _SET_PED_ACTIVE_PLAYER_TYPE  (0xB285AD0EC870B2DF)
+-- Params: hash - ARTHUR or JOHN
+-- _SET_PED_(A-D)*
+-- min build: 1207
+---@param ped number
+---@param playerType number
+function _SetPedActivePlayerType(ped, playerType) end
+
+-- _SET_PED_ANIMAL_DETECTION_MODIFIER  (0x43CA928E892CFDB8)
+-- min build: 1311
+---@param ped number
+---@param modifier number
+function _SetPedAnimalDetectionModifier(ped, modifier) end
+
+-- _SET_PED_BEAT_MULTIPLIER  (0x6DBF2D78709AD70B)
+-- NET_FETCH_CLIENT_UPDATE_PED_FIGHT_PROFICIENCY: Changing parry multiplier for ped
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _SetPedBeatMultiplier(ped, p1) end
+
+-- _SET_PED_BLACKBOARD_BOOL  (0xCB9401F918CB0F75)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@param value boolean
+---@param removeTimer number
+function _SetPedBlackboardBool(ped, variableName, value, removeTimer) end
+
+-- _SET_PED_BLACKBOARD_FLOAT  (0x437C08DB4FEBE2BD)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@param value number
+---@param removeTimer number
+function _SetPedBlackboardFloat(ped, variableName, value, removeTimer) end
+
+-- _SET_PED_BLACKBOARD_HASH  (0xA762C9D6CF165E0D)
+-- p1:
+-- BodyPartChained
+-- OverloadMostInjuredBodyPart
+-- 
+-- p2:
+-- LeftLeg
+-- Legs
+-- RightArm
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@param value string
+---@param removeTimer number
+function _SetPedBlackboardHash(ped, variableName, value, removeTimer) end
+
+-- _SET_PED_BLACKBOARD_INT  (0x5F53010C4C3F6BAF)
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/BLACKBOARDS
+-- Blackboard natives allow you to apply and check certain data to/for peds.
+-- Blackboard bools, floats and strings are subdivided into 6 sections: "all", "animation", "any", "code", "global" and "script"
+-- Most changes are only visible for "script" blackboards, some "script" blackboards change ped motions
+-- "removeTimer" is self-removal timer, can be "-1" so your data will not be removed by the game (forever); 100 = 1 second
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@param value number
+---@param removeTimer number
+function _SetPedBlackboardInt(ped, variableName, value, removeTimer) end
+
+-- _SET_PED_BLEEDOUT_PROFILE  (0x66C047719B0E80E1)
+-- Bleedout profiles:
+-- Animal_FastBleedout
+-- Animal_Generic
+-- Human_FastBleedout
+-- Human_Generic
+-- Human_Mission
+-- 
+-- For more information, see common/data/ai/peddamageinfo.meta
+-- min build: 1207
+---@param ped number
+---@param bleedoutProfile number
+function _SetPedBleedoutProfile(ped, bleedoutProfile) end
+
+-- _SET_PED_BRAWLING_STYLE  (0x8BA83CC4288CD56D)
+-- brawlingStyle:
+-- enum eBrawlingStyle : Hash
+-- {
+-- 	BS_AI = 0x802C604D,
+-- 	BS_AI_BARBRAWL = 0x4FF5F0C7,
+-- 	BS_AI_DEFENSIVE = 0xD888F2FD,
+-- 	BS_AI_MOONSHINE_BARBRAWL = 0xA01B433A,
+-- 	BS_ALLIGATOR = 0x7A5548ED,
+-- 	BS_ALLIGATOR_LARGE = 0x368EC7CB,
+-- 	BS_ALLY = 0x69C76C14,
+-- 	BS_ANIMAL = 0xD777C754,
+-- 	BS_BADGER = 0x7E7C3F53,
+-- 	BS_BEAR = 0x0BC66E35,
+-- 	BS_BEAVER = 0x4E313783,
+-- 	BS_BOAR = 0x176A5831,
+-- 	BS_BOUNTY_HUNTER = 0x3900654C,
+-- 	BS_BRUISER = 0x4514DB61,
+-- 	BS_BULL = 0x4E50C5D2,
+-- 	BS_COUGAR = 0x9DAA7CCB,
+-- 	BS_COW = 0xB0E91295,
+-- 	BS_COYOTE = 0xA448EB69,
+-- 	BS_DEER = 0xA781E6B3,
+-- 	BS_DOG = 0x5A4155C4,
+-- 	BS_ELK = 0x408697F0,
+-- 	BS_FEMALE = 0x6A3BB2C2,
+-- 	BS_FEMALE_STRONG = 0x4DAFDD84,
+-- 	BS_GANGUP = 0xD0CECFF2,
+-- 	BS_GOAT = 0x078E649F,
+-- 	BS_HORSE = 0xF6B775F3,
+-- 	BS_MICAH_FINALE = 0x1F0BB27A,
+-- 	BS_MOOSE = 0x968917AB,
+-- 	BS_MUSKRAT = 0x1EDC33AC,
+-- 	BS_NO_MELEE = 0x25B5F931,
+-- 	BS_PIG = 0x22EAD110,
+-- 	BS_PLAYER = 0x78BAEF07,
+-- 	BS_PLAYER_FINALE = 0xF9E77D2D,
+-- 	BS_PLAYER_MOONSHINER = 0x687BF19F,
+-- 	BS_PLAYER_WINTER1 = 0x3C6A802F,
+-- 	BS_QUICK = 0xC4CABB1B,
+-- 	BS_RACCOON = 0x505F8917,
+-- 	BS_SHEEP = 0x6827CCCF,
+-- 	BS_SNAKE = 0x82BEBC4B,
+-- 	BS_TIMID = 0x431AEF77,
+-- 	BS_WOLF = 0xA8F023D4
+-- };
+-- min build: 1207
+---@param ped number
+---@param brawlingStyle number
+function _SetPedBrawlingStyle(ped, brawlingStyle) end
+
+-- _SET_PED_CAN_BE_LASSOED  (0xFD6943B6DF77E449)
+-- SET_PED_CAN_*
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedCanBeLassoed(ped, toggle) end
+
+-- _SET_PED_CAN_UNK_BODYPART_IK  (0xEE9DF765990E8D1D)
+-- _SET_PED_CAN_(?)_IK*
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedCanUnkBodypartIk(ped, toggle) end
+
+-- _SET_PED_COMBAT_ATTRIBUTE_HASH  (0xBD75500141E4725C)
+-- Hashes: GUARD, COMBAT_ANIMAL, LAW, LAW_SHERIFF
+-- _SET_PED_COMBAT_A* - _SET_PED_COMBAT_M*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _SetPedCombatAttributeHash(ped, p1) end
+
+-- _SET_PED_COMBAT_BEHAVIOUR  (0x9238A3D970BBB0A9)
+-- min build: 1207
+---@param ped number
+---@param behaviour number
+function _SetPedCombatBehaviour(ped, behaviour) end
+
+-- _SET_PED_COMBAT_SPEED  (0x815C0074A1BC0D93)
+-- Sets the ped combat speed enum. Get/set pair with _GET_PED_COMBAT_SPEED.
+-- 
+-- enum CCombatData__Speed
+-- {
+-- 	CS_Invalid = -1,
+-- 	CS_Default = 0,
+-- 	CS_Slow = 1,
+-- 	CS_Fast = 2,
+-- 	CS_Sprint = 3,
+-- 	CS_LastSpeed = 4,
+-- };
+-- min build: 1207
+---@param ped number
+---@param speed number
+function _SetPedCombatSpeed(ped, speed) end
+
+-- _SET_PED_COMBAT_STYLE  (0x8ACC0506743A8A5C)
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_STYLES
+-- Params: p2 is usually 1, sometimes 0 or 2
+-- duration in seconds, -1.0 = forever
+-- min build: 1207
+---@param ped number
+---@param combatStyleHash number
+---@param p2 number
+---@param duration number
+function _SetPedCombatStyle(ped, combatStyleHash, p2, duration) end
+
+-- _SET_PED_COMBAT_STYLE_MOD  (0x8B1E8E35A6E814EA)
+-- duration in seconds, -1.0 = forever
+-- min build: 1207
+---@param ped number
+---@param combatStyleModHash number
+---@param duration number
+function _SetPedCombatStyleMod(ped, combatStyleModHash, duration) end
+
+-- _SET_PED_CROUCH_MOVEMENT  (0x7DE9692C6F64CFE8)
+-- min build: 1207
+---@param ped number
+---@param state boolean
+---@param p2 number
+---@param immediately boolean
+function _SetPedCrouchMovement(ped, state, p2, immediately) end
+
+-- _SET_PED_CULL_RANGE  (0x8AC1D721B2097B6E)
+-- The higher the multiplier the less the engine renders culls (https://docs.unity3d.com/Manual/OcclusionCulling.html)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function _SetPedCullRange(ped, p1, p2) end
+
+-- _SET_PED_DAMAGE_CLEANLINESS  (0x7528720101A807A5)
+-- damageCleanliness: see _GET_PED_DAMAGE_CLEANLINESS
+-- min build: 1207
+---@param ped number
+---@param damageCleanliness number
+function _SetPedDamageCleanliness(ped, damageCleanliness) end
+
+-- _SET_PED_DAMAGED  (0xDACE03C65C6666DB)
+-- min build: 1207
+---@param ped number
+---@param damaged boolean
+function _SetPedDamaged(ped, damaged) end
+
+-- _SET_PED_DEFENSIVE_AREA_TO_ANGLED_AREA  (0xEB2BFE5D009F0331)
+-- _SET_PED_(A?)*
+-- min build: 1232
+---@param ped number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p7 any
+---@param p8 boolean
+---@param p9 boolean
+---@param entity number
+---@param p11 boolean
+function _SetPedDefensiveAreaToAngledArea(ped, x1, y1, z1, x2, y2, z2, p7, p8, p9, entity, p11) end
+
+-- _SET_PED_DEFENSIVE_SPHERE_ATTACHED_TO_ENTITY  (0x1854217C640B39EC)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p6 number
+---@param p7 boolean
+function _SetPedDefensiveSphereAttachedToEntity(ped, entity, x, y, z, radius, p6, p7) end
+
+-- _SET_PED_DESIRED_LOCO_FOR_MODEL  (0x923583741DC87BCE)
+-- Seems to set the ped's loco type.
+-- Values used in the scripts:
+-- algie
+-- angry_female
+-- arthur_healthy
+-- cowboy
+-- cowboy_f
+-- default
+-- default_female
+-- free_slave_01
+-- free_slave_02
+-- gold_panner
+-- guard_lantern
+-- injured_general
+-- john_marston
+-- lilly_millet
+-- lone_prisoner
+-- lost_man
+-- mp_ova_hunter
+-- mp_ova_hunter_female
+-- murfree
+-- old_female
+-- primate
+-- rally
+-- waiter
+-- war_veteran
+-- min build: 1207
+---@param ped number
+---@param locomotionArchetype string
+function _SetPedDesiredLocoForModel(ped, locomotionArchetype) end
+
+-- _SET_PED_DESIRED_LOCO_MOTION_TYPE  (0x89F5E7ADECCCB49C)
+-- Sets peds motion type
+-- min build: 1207
+---@param ped number
+---@param locoMotionType string
+function _SetPedDesiredLocoMotionType(ped, locoMotionType) end
+
+-- _SET_PED_DESIRES_GROUP  (0xBAD2A311667A50D7)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedDesiresGroup(ped, toggle) end
+
+-- _SET_PED_DIRT_CLEANED  (0xE3144B932DFDFF65)
+-- Params: ped, 0f, -1, true, true in R* MP Scripts
+-- _SET_PED_DE* - _SET_PED_F*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 boolean
+---@param p4 boolean
+function _SetPedDirtCleaned(ped, p1, p2, p3, p4) end
+
+-- _SET_PED_DISABLE_KICK_MOVE  (0xADD31A5C7A5FAA73)
+-- Disables being able to kick move ped.
+-- min build: 1207
+---@param ped number
+---@param disable boolean
+function _SetPedDisableKickMove(ped, disable) end
+
+-- _SET_PED_DRUNKNESS  (0x406CCF555B04FAD3)
+-- SOBER = 0.0f, SLIGHTLY_DRUNK = 0.25f, MODERATELY_DRUNK = 0.5f, VERY_DRUNK = 1.0f
+-- min build: 1207
+---@param ped number
+---@param enabled boolean
+---@param drunknessLevel number
+function _SetPedDrunkness(ped, enabled, drunknessLevel) end
+
+-- _SET_PED_FIRING_PATTERN_2  (0x20E54854DEF6A54A)
+-- Used in R* MP Script fm_mission_controller and various R* SP Scripts for ambush*
+-- min build: 1207
+---@param ped number
+---@param patternHash number
+function _SetPedFiringPattern2(ped, patternHash) end
+
+-- _SET_PED_FIRING_PATTERN_3  (0x244E8C282188E40F)
+-- Only used in R* MP Script fm_mission_controller
+-- min build: 1207
+---@param ped number
+---@param patternHash number
+function _SetPedFiringPattern3(ped, patternHash) end
+
+-- _SET_PED_FORMATION_POSITION  (0x0E9E95FDEDCC9D35)
+-- min build: 1207
+---@param ped number
+---@param position number
+---@param toggle boolean
+function _SetPedFormationPosition(ped, position, toggle) end
+
+-- _SET_PED_GETUP_ANIMATION  (0x3AE3552E7C207CC5)
+-- min build: 1207
+---@param ped number
+---@param animName string
+---@param p2 boolean
+function _SetPedGetupAnimation(ped, animName, p2) end
+
+-- _SET_PED_GRAPPLE_ACTION  (0x8301D87B1B89E219)
+-- min build: 1207
+---@param ped number
+---@param grappleAction number
+function _SetPedGrappleAction(ped, grappleAction) end
+
+-- _SET_PED_GRAPPLE_ANIMATION  (0x56E9C26CD29D1ED6)
+-- min build: 1207
+---@param ped number
+---@param grappleAnim number
+function _SetPedGrappleAnimation(ped, grappleAnim) end
+
+-- _SET_PED_GRAPPLE_EFFECT_MULTIPLIER  (0x99A6E246C315BF60)
+-- min build: 1207
+---@param ped number
+---@param multiplier number
+---@return any
+function _SetPedGrappleEffectMultiplier(ped, multiplier) end
+
+-- _SET_PED_GRAPPLE_FLAG  (0x789DABD18E9024DB)
+-- min build: 1207
+---@param ped number
+---@param flag number
+---@param enable boolean
+function _SetPedGrappleFlag(ped, flag, enable) end
+
+-- _SET_PED_GRAPPLE_SEQUENCE  (0x604190F0CF0DF158)
+-- min build: 1207
+---@param ped number
+---@param grappleSequence string
+function _SetPedGrappleSequence(ped, grappleSequence) end
+
+-- _SET_PED_GRAPPLE_STYLE  (0x630E7B01F091A197)
+-- Hashes: GS_DRAGGING, GS_FACE_TO_BACK, GS_FACE_TO_FACE, GS_FACE_TO_FACE_WALL, GS_MOUNTED
+-- min build: 1207
+---@param ped number
+---@param style number
+---@return any
+function _SetPedGrappleStyle(ped, style) end
+
+-- _SET_PED_HEADSHOT_DAMAGE_MULTIPLIER  (0x2BA918C823B8BA56)
+-- min build: 1207
+---@param ped number
+---@param multiplier number
+function _SetPedHeadshotDamageMultiplier(ped, multiplier) end
+
+-- _SET_PED_HEALTH_CONFIG  (0xF6B82FCE03B43A37)
+-- configHash: see pedhealth.meta
+-- min build: 1207
+---@param ped number
+---@param configHash number
+function _SetPedHealthConfig(ped, configHash) end
+
+-- _SET_PED_IMMERSION_FLAG  (0x7FB0088E8769CDDB)
+-- Only used in R* Script beat_sharp_shooter
+-- Blocks ped from swimming underwater
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedImmersionFlag(ped, toggle) end
+
+-- _SET_PED_INCAPACITATION_FLAGS  (0xD67B6F3BCF81BA47)
+-- min build: 1207
+---@param ped number
+---@param flags number
+function _SetPedIncapacitationFlags(ped, flags) end
+
+-- _SET_PED_INCAPACITATION_MODIFIERS  (0x39ED303390DDEAC7)
+-- min build: 1207
+---@param ped number
+---@param canBeIncapacitated boolean
+---@param threshold number
+---@param bleedoutTime number
+---@param p4 number
+function _SetPedIncapacitationModifiers(ped, canBeIncapacitated, threshold, bleedoutTime, p4) end
+
+-- _SET_PED_INCAPACITATION_TOTAL_BLEED_OUT_DURATION  (0x2890418B39BC8FFF)
+-- min build: 1207
+---@param ped number
+---@param duration number
+function _SetPedIncapacitationTotalBleedOutDuration(ped, duration) end
+
+-- _SET_PED_INTERACTION_NEGATIVE_RESPONSE  (0xA3C53CDE922BC78B)
+-- min build: 1207
+---@param ped number
+---@param speech string
+function _SetPedInteractionNegativeResponse(ped, speech) end
+
+-- _SET_PED_INTERACTION_PERSONALITY  (0x24C82EF607105FAA)
+-- personality (script_mp_rel): NONE, AGGRESSIVE, TIMID (non-aggressive), CRIPPS, SCRIPTEDINTIMIDATION, MAGGIE, MARCEL, SCRIPTEDSALOON
+-- personality (script_rel): AVOID, SCRIPTEDOUTLAW, TIMIDGUARDDOG, SCRIPTEDTIMIDROB, AGGRESSIVECAMPER, LAZYDOG, KIERANTIEDUP, SCRIPTEDGALA
+-- min build: 1207
+---@param ped number
+---@param personality number
+function _SetPedInteractionPersonality(ped, personality) end
+
+-- _SET_PED_INTERACTION_POSITIVE_RESPONSE  (0x20C5459379D75C1C)
+-- min build: 1207
+---@param ped number
+---@param speech string
+function _SetPedInteractionPositiveResponse(ped, speech) end
+
+-- _SET_PED_KNOCKED_BY_ONE_HIT  (0x5BCF0B79D4F5DBA3)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _SetPedKnockedByOneHit(ped, p1) end
+
+-- _SET_PED_LADDER_MOVEMENT_SPEED_MODIFIER  (0x05CE6AF4DF071D23)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _SetPedLadderMovementSpeedModifier(ped, p1) end
+
+-- _SET_PED_LIGHTS  (0x13A210949FCBD92B)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedLights(ped, toggle) end
+
+-- _SET_PED_LOCAL_VFX_COLOR  (0xDD9540E7B1C9714F)
+-- Sets the RGB color for a specific volumetric VFX/particle node attached to a ped outfit or component.
+-- Observed from RDO fm_mission_controller. The native only works if the component containing the VFX node is equipped.
+-- It colors smoke/volumetrics and leaves core fire sprites untouched. Color values are normalized floats in the 0.0..1.0 range.
+-- min build: 1207
+---@param ped number
+---@param vfxNodeHash number
+---@param r number
+---@param g number
+---@param b number
+function _SetPedLocalVfxColor(ped, vfxNodeHash, r, g, b) end
+
+-- _SET_PED_MELEE_ACTION  (0xC48AF420371C7407)
+-- Requests a specific melee action, grapple move, or execution for the ped's next valid melee opportunity.
+-- The actionHash is resolved from the internal AR_* action table, such as AR_GRAPPLE_EXECUTION or AR_GRAPPLE_FRONT_FROM_FRONT.
+-- Returns false if the ped is invalid, not in a valid gameplay state, has no melee intelligence task, or the action hash is not registered.
+-- min build: 1207
+---@param ped number
+---@param actionHash number
+---@return boolean
+function _SetPedMeleeAction(ped, actionHash) end
+
+-- _SET_PED_MELEE_FORCED_DURATION  (0x6DB875AFC584FA32)
+-- If the ped has an active TASK_MELEE, force-keep it active for durationMs starting now; returns true on success (no effect if melee task not running).
+-- min build: 1207
+---@param ped number
+---@param durationMs number
+---@return boolean
+function _SetPedMeleeForcedDuration(ped, durationMs) end
+
+-- _SET_PED_MOTIVATION  (0x06D26A96CA1BCA75)
+-- enum eMotivationState
+-- {
+-- 	TOILET_STATE,
+-- 	FEAR_STATE,
+-- 	ANGRY_STATE,
+-- 	AGITATION_STATE,
+-- 	HUNGRY_STATE,
+-- 	TIRED_STATE,
+-- 	SAD_STATE,
+-- 	BRAVE_STATE,
+-- 	OFFER_ITEM_STATE,
+-- 	SUSPICION,
+-- 	DRUNK_STATE
+-- };
+-- 
+-- If targetPed is set to 0 the ped motivationState affects everyone
+-- min build: 1207
+---@param ped number
+---@param motivationState number
+---@param threshold number
+---@param targetPed number
+function _SetPedMotivation(ped, motivationState, threshold, targetPed) end
+
+-- _SET_PED_MOTIVATION_MODIFIER  (0xA1EB5D029E0191D3)
+-- The higher the modifier, the slower the motivationState value will decrease
+-- min build: 1207
+---@param ped number
+---@param motivationState number
+---@param modifier number
+function _SetPedMotivationModifier(ped, motivationState, modifier) end
+
+-- _SET_PED_MOTIVATION_STATE_OVERRIDE  (0x2EB75FB86C41F026)
+-- motivationState: see _SET_PED_MOTIVATION
+-- min build: 1207
+---@param ped number
+---@param motivationState number
+---@param enabled boolean
+function _SetPedMotivationStateOverride(ped, motivationState, enabled) end
+
+-- _SET_PED_PERSONALITY  (0xB8B6430EAD2D2437)
+-- Hashes: STANDARD_PED_AGRO_GUARD, BOUNTY_HUNTER, PLAYER_HORSE, LAW_POLICE, GUARD_DOG, ATTACK_DOG
+-- Personalities can also be found in common:/data/ai/interactionpersonalities
+-- min build: 1207
+---@param ped number
+---@param personality number
+function _SetPedPersonality(ped, personality) end
+
+-- _SET_PED_PROMPT_NAME  (0x4A48B6E03BABB4AC)
+-- min build: 1207
+---@param ped number
+---@param name string
+function _SetPedPromptName(ped, name) end
+
+-- _SET_PED_PROMPT_NAME_2  (0x19B14E04B009E28B)
+-- min build: 1207
+---@param ped number
+---@param name string
+function _SetPedPromptName2(ped, name) end
+
+-- _SET_PED_PROMPT_NAME_FROM_GXT_ENTRY  (0xFCA8FB9E15FA80D3)
+-- min build: 1207
+---@param ped number
+---@param gxtEntryHash number
+function _SetPedPromptNameFromGxtEntry(ped, gxtEntryHash) end
+
+-- _SET_PED_PROMPT_NAME_FROM_GXT_ENTRY_2  (0xC2745D9261664901)
+-- min build: 1207
+---@param ped number
+---@param gxtEntryHash number
+function _SetPedPromptNameFromGxtEntry2(ped, gxtEntryHash) end
+
+-- _SET_PED_QUALITY  (0xCE6B874286D640BB)
+-- quality: see _GET_PED_QUALITY
+-- min build: 1207
+---@param ped number
+---@param quality number
+function _SetPedQuality(ped, quality) end
+
+-- _SET_PED_RAGDOLL_BONE_SCALE  (0xC17A94CC8FC3C61A)
+-- Modifies the size/scale of the collision capsule or hitbox for a specific ped bone.
+-- Default scale values are typically 1.0, 1.0, 1.0. Values below 1.0 shrink the collision boundary, while values above 1.0 enlarge it.
+-- min build: 1207
+---@param ped number
+---@param boneId number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+function _SetPedRagdollBoneScale(ped, boneId, scaleX, scaleY, scaleZ) end
+
+-- _SET_PED_SCALE  (0x25ACFC650B65C538)
+-- min build: 1207
+---@param ped number
+---@param scale number
+function _SetPedScale(ped, scale) end
+
+-- _SET_PED_SCENT  (0x01B21B81865E2A1F)
+-- 0.0 - 1.0
+-- Modifies the "scent line" on the ped's body when using Eagle Eye.
+-- min build: 1207
+---@param ped number
+---@param scent number
+function _SetPedScent(ped, scent) end
+
+-- _SET_PED_TARGET_ACTION_DISABLE_FLAG  (0xC163DAC52AC975D3)
+-- min build: 1207
+---@param ped number
+---@param actionDisableFlag number
+function _SetPedTargetActionDisableFlag(ped, actionDisableFlag) end
+
+-- _SET_PED_TO_BE_REMOVED  (0x36E4B61DC56DE77C)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 any
+function _SetPedToBeRemoved(ped, p1, p2, p3, p4) end
+
+-- _SET_PED_TO_DISABLE_RAGDOLL  (0x221F4D9912B7FE86)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedToDisableRagdoll(ped, toggle) end
+
+-- _SET_PED_TRAIL_EFFECT  (0xA5950E16B8F31052)
+-- duration in seconds
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param duration number
+function _SetPedTrailEffect(ped, p1, duration) end
+
+-- _SET_PED_USE_HORSE_MAP_COLLISION  (0xEB72453B6F5B45B0)
+-- Doesn't actually return anything.
+-- min build: 1232
+---@param ped number
+---@param toggle boolean
+---@return any
+function _SetPedUseHorseMapCollision(ped, toggle) end
+
+-- _SET_PED_VARIATION_PRESET  (0xFFA1594703ED27CA)
+-- Sets a predefined variation preset for the ped's appearance.
+-- Works on ambient/population peds, mp_male, mp_female, and animals. Does not work on story characters such as Dutch, Sadie, or Arthur; use _EQUIP_META_PED_OUTFIT_PRESET for those.
+-- min build: 1207
+---@param ped number
+---@param variationIndex number
+function _SetPedVariationPreset(ped, variationIndex) end
+
+-- _SET_PED_VOICE_VOLUME  (0xD05AD61F242C626B)
+-- _SET_PED_S* - _SET_PED_T*
+-- min build: 1207
+---@param ped number
+---@param volume number
+function _SetPedVoiceVolume(ped, volume) end
+
+-- _SET_PED_WETNESS_AMOUNT  (0xF9CFF5BB70E8A2CB)
+-- To be used with SET_PED_WETNESS_HEIGHT, see R* Scripts
+-- min build: 1207
+---@param ped number
+---@param amount number
+function _SetPedWetnessAmount(ped, amount) end
+
+-- _SET_PED_WRITHING_DURATION  (0x4DB9D03AC4E1FA84)
+-- min build: 1207
+---@param ped number
+---@param writhingDuration1 number
+---@param writhingDuration2 number
+---@param p3 number
+function _SetPedWrithingDuration(ped, writhingDuration1, writhingDuration2, p3) end
+
+-- _SET_PELT_FOR_HORSE  (0xA73F50E8796150D5)
+-- min build: 1207
+---@param horse number
+---@param peltId number
+function _SetPeltForHorse(horse, peltId) end
+
+-- _SET_PELT_FOR_HORSE_BY_INVENTORY_ITEM  (0xC412AA1C73111FE0)
+-- Adds a pelt to a horse from an inventoryItem hash and albedoHash, optionally normalHash textures.
+-- min build: 1207
+---@param horse number
+---@param inventoryItem number
+---@param albedoHash number
+---@param normalHash number
+---@param p4 boolean
+function _SetPeltForHorseByInventoryItem(horse, inventoryItem, albedoHash, normalHash, p4) end
+
+-- _SET_PLAYER_ANTAGONIZE_DISABLED_FOR_PED  (0x5708EDD71B50C008)
+-- min build: 1207
+---@param ped number
+---@param player number
+---@param duration number
+function _SetPlayerAntagonizeDisabledForPed(ped, player, duration) end
+
+-- _SET_PLAYER_CURRENT_ANIMAL_DAMAGE_MODIFIER  (0x9EFF3C91DF38304F)
+-- Animal Skin Quality Modifier
+-- Params: p2 = 2, p3 = 3 in R* Scripts
+-- min build: 1311
+---@param player number
+---@param modifier number
+---@param p2 number
+---@param p3 number
+---@return any
+function _SetPlayerCurrentAnimalDamageModifier(player, modifier, p2, p3) end
+
+-- _SET_PLAYER_DISMOUNT_TIMESTAMP  (0xA691C10054275290)
+-- min build: 1207
+---@param mount number
+---@param player number
+---@param dismountedTimestamp number
+function _SetPlayerDismountTimestamp(mount, player, dismountedTimestamp) end
+
+-- _SET_PLAYER_GREET_DISABLED_FOR_PED  (0x19173C3F15367B54)
+-- min build: 1207
+---@param ped number
+---@param player number
+---@param duration number
+function _SetPlayerGreetDisabledForPed(ped, player, duration) end
+
+-- _SET_RANDOM_OUTFIT_VARIATION  (0x283978A15512B2FE)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function _SetRandomOutfitVariation(ped, p1) end
+
+-- _SET_RELATIONSHIP_GROUP_SCRIPT_REGISTERED  (0xDC91F22F09BC6C2F)
+-- Registers/unregisters a relationship group as a script resource (type 0x24).
+-- Pass false to register, true to unregister.
+-- min build: 1207
+---@param group number
+---@param unregister boolean
+function _SetRelationshipGroupScriptRegistered(group, unregister) end
+
+-- _SET_REMOVE_PED_NETWORKED  (0x39A2FC5AF55A52B1)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _SetRemovePedNetworked(ped, p1) end
+
+-- _SET_SCENARIO_ANIMAL_DENSITY_MULTIPLIER_THIS_FRAME  (0xDB48E99F8E064E56)
+-- min build: 1207
+---@param multiplier number
+function _SetScenarioAnimalDensityMultiplierThisFrame(multiplier) end
+
+-- _SET_SCENARIO_HUMAN_DENSITY_MULTIPLIER_THIS_FRAME  (0x28CB6391ACEDD9DB)
+-- min build: 1207
+---@param multiplier number
+function _SetScenarioHumanDensityMultiplierThisFrame(multiplier) end
+
+-- _SET_SCENARIO_PED_DENSITY_THIS_FRAME  (0x95423627A9CA598E)
+-- Sets the scenario ped density to the given config.
+-- 
+-- Valid configs:
+-- - BLACKWATER
+-- - DEFAULT
+-- - NEWBORDEAUX
+-- - RHODES
+-- - STRAWBERRY
+-- - TUMBLEWEED
+-- - VALENTINE
+-- - VANHORN
+-- 
+-- See common/data/ai/densityscoringconfigs.meta for more information.
+-- min build: 1207
+---@param configHash number
+function _SetScenarioPedDensityThisFrame(configHash) end
+
+-- _SET_SCENARIO_PED_RANGE_MULTIPLIER_THIS_FRAME  (0xA77FA7BE9312F8C0)
+-- min build: 1207
+---@param multiplier number
+function _SetScenarioPedRangeMultiplierThisFrame(multiplier) end
+
+-- _SET_SCENARIO_PED_VOLUME_REFERENCE  (0x9E3842E5DAD69F80)
+-- Registers the given volume with ped/scenario systems (stores a global ref). Used by SP scripts to keep a volume alive; calling again replaces the previous ref.
+-- min build: 1207
+---@param volume number
+function _SetScenarioPedVolumeReference(volume) end
+
+-- _SET_STAGED_PED_FLAG  (0x028E7B3BBA0BD2FC)
+-- Sets ScriptData bit 0x8000 on the ped (one-way). Used by scripts to mark a staged/special ped (e.g., scripted corpse) affecting cleanup/interaction.
+-- min build: 1207
+---@param ped number
+function _SetStagedPedFlag(ped) end
+
+-- _SET_STAMINA_DEPLETION_MULTIPLIER  (0xEF5A3D2285D8924B)
+-- min build: 1207
+---@param ped number
+---@param multiplier number
+function _SetStaminaDepletionMultiplier(ped, multiplier) end
+
+-- _SET_STAMINA_RECHARGE_MULTIPLIER  (0x345C9F993A8AB4A4)
+-- min build: 1207
+---@param ped number
+---@param multiplier number
+function _SetStaminaRechargeMultiplier(ped, multiplier) end
+
+-- _SET_TANK_ATTRIBUTE_SIZE  (0x7FF72DE061DF55E2)
+-- Size will be permanent
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param size number
+function _SetTankAttributeSize(ped, attributeIndex, size) end
+
+-- _SET_TEXTURE_LAYER_ALPHA  (0x6C76BC24F8BB709A)
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param texAlpha number
+function _SetTextureLayerAlpha(textureId, layerId, texAlpha) end
+
+-- _SET_TEXTURE_LAYER_MOD  (0xF2EA041F1146D75B)
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param modTextureHash number
+---@param modAlpha number
+---@param modChannel number
+function _SetTextureLayerMod(textureId, layerId, modTextureHash, modAlpha, modChannel) end
+
+-- _SET_TEXTURE_LAYER_PALLETE  (0x1ED8588524AC9BE1)
+-- paletteHash: https://raw.githubusercontent.com/femga/rdr3_discoveries/master/clothes/cloth_color_palletes.lua
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param paletteHash number
+function _SetTextureLayerPallete(textureId, layerId, paletteHash) end
+
+-- _SET_TEXTURE_LAYER_ROUGHNESS  (0x057C4F092E2298BE)
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param texRough number
+function _SetTextureLayerRoughness(textureId, layerId, texRough) end
+
+-- _SET_TEXTURE_LAYER_SHEET_GRID_INDEX  (0x3329AAE2882FC8E4)
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param sheetGridIndex number
+function _SetTextureLayerSheetGridIndex(textureId, layerId, sheetGridIndex) end
+
+-- _SET_TEXTURE_LAYER_TEXTURE_MAP  (0x253A63B5BADBC398)
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param albedoHash number
+---@param normalHash number
+---@param materialHash number
+function _SetTextureLayerTextureMap(textureId, layerId, albedoHash, normalHash, materialHash) end
+
+-- _SET_TEXTURE_LAYER_TINT  (0x2DF59FFE6FFD6044)
+-- Seem color is not RGB or HSV
+-- min build: 1207
+---@param textureId number
+---@param layerId number
+---@param tint0 number
+---@param tint1 number
+---@param tint2 number
+function _SetTextureLayerTint(textureId, layerId, tint0, tint1, tint2) end
+
+-- _SET_TEXTURE_OUTFIT_TINTS  (0x4EFC1F8FF1AD94DE)
+-- Used in script function METAPED_CLOTHING__XML__APPLY_OUTFIT_TINTS_TO_PED
+-- min build: 1207
+---@param ped number
+---@param componentCategory number
+---@param palette number
+---@param tint0 number
+---@param tint1 number
+---@param tint2 number
+function _SetTextureOutfitTints(ped, componentCategory, palette, tint0, tint1, tint2) end
+
+-- _SET_TOTAL_PED_DAMAGE_FALLOFF_BONUS  (0x932786CE3C76477C)
+-- _SET_W(EAPON?)*
+-- min build: 1207
+---@param ped number
+---@param bonus number
+function _SetTotalPedDamageFalloffBonus(ped, bonus) end
+
+-- _SET_TOTAL_PED_DAMAGE_FROM_AI  (0x73B6F907B913C860)
+-- _SET_W(EAPON?)*
+-- min build: 1207
+---@param ped number
+---@param totalDamage number
+function _SetTotalPedDamageFromAi(ped, totalDamage) end
+
+-- _SHOOT_TRIGGER_AT_COORDS  (0x4C57F27D1554E6B0)
+-- Triggers a gunshot
+-- Params: p5 = -1 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@return any
+function _ShootTriggerAtCoords(ped, x, y, z, p4, p5, p6, p7) end
+
+-- _SPAWNPOINTS_START_SEARCH_WITH_VOLUME  (0x83ED1FC9DF3411F5)
+-- min build: 1311
+---@param volume number
+---@param spawnpointsFlag number
+---@param p2 number
+---@param duration number
+---@param p4 number
+function _SpawnpointsStartSearchWithVolume(volume, spawnpointsFlag, p2, duration, p4) end
+
+-- _TOGGLE_PLAYER_PED_FLINCH  (0x09E378C52B1433B5)
+-- _TOGGLE_S* - _UPDATE_*
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param scale number
+function _TogglePlayerPedFlinch(ped, x, y, z, scale) end
+
+-- _UNRESERVE_AMBIENT_PEDS  (0x7D4E70A67A651C71)
+-- min build: 1207
+---@param numPeds number
+function _UnreserveAmbientPeds(numPeds) end
+
+-- _UPDATE_ANIMAL_DAMAGE_MODIFIER  (0x0F9E754EBE8FDBFA)
+-- min build: 1311
+---@param player number
+function _UpdateAnimalDamageModifier(player) end
+
+-- _UPDATE_PED_TEXTURE  (0x92DAABA2C1C10B0E)
+-- Should be called at least once for any new texture override.
+-- Otherwise component textures will be just black.
+-- Also needs to be called for updating any ped overlays to apply the changes.
+-- min build: 1207
+---@param textureId number
+function _UpdatePedTexture(textureId) end
+
+-- _UPDATE_PED_VARIATION  (0xCC8CA3E88256E58F)
+-- Update variation on ped, needed after first creation, or when component or texture/overlay is changed
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+---@param p5 boolean
+function _UpdatePedVariation(ped, p1, p2, p3, p4, p5) end
+
+-- _UPDATE_PED_WOUND_EFFECT  (0x66B1CB778D911F49)
+-- Params: 0.0f to remove wound effects
+-- min build: 1207
+---@param ped number
+---@param value number
+function _UpdatePedWoundEffect(ped, value) end
+
+-- _UPDATE_SHOP_ITEM_WEARABLE_STATE  (0x66B957AAC2EAAEAB)
+-- Possible way to pull up / down bandana for male and female models: https://imgur.com/a/Zr4pjze
+-- Params: p3 = 0, p4 = true, p5 = 1
+-- wearableState: https://github.com/Jump-On-Studios/RedM-jo_libs/blob/main/jo_libs/modules/component/g_client.lua#L138
+-- min build: 1207
+---@param ped number
+---@param componentHash number
+---@param wearableState number
+---@param p3 number
+---@param isMp boolean
+---@param p5 number
+function _UpdateShopItemWearableState(ped, componentHash, wearableState, p3, isMp, p5) end
+
+-- _WARP_PED_OUT_OF_VEHICLE  (0xE0B61ED8BB37712F)
+-- min build: 1207
+---@param ped number
+function _WarpPedOutOfVehicle(ped) end
+
+-- ADD_ARMOUR_TO_PED  (0x5BA652A0CD14DF2F)
+-- Same as SET_PED_ARMOUR, but ADDS 'amount' to the armor the Ped already has.
+-- min build: 1207
+---@param ped number
+---@param amount number
+function AddArmourToPed(ped, amount) end
+
+-- ADD_CUSTOM_FORMATION_LOCATION  (0x4E23CD07BD161E06)
+-- min build: 1207
+---@param groupId number
+---@param x number
+---@param y number
+---@param z number
+---@param position number
+function AddCustomFormationLocation(groupId, x, y, z, position) end
+
+-- ADD_FORMATION_LOCATION  (0xB05945C1E9E60D91)
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@return boolean
+function AddFormationLocation(groupId, p1, p2, p3) end
+
+-- ADD_RELATIONSHIP_GROUP  (0xF372BC22FCB88606)
+-- The hash of the created relationship group is output in the second parameter.
+-- min build: 1207
+---@param name string
+---@return boolean
+---@return number
+function AddRelationshipGroup(name) end
+
+-- ADD_SCENARIO_BLOCKING_AREA  (0x1B5C85C612E5256E)
+-- blockingFlags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eScenarioBlockingFlags
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p6 boolean
+---@param blockingFlags number
+---@return number
+function AddScenarioBlockingArea(x1, y1, z1, x2, y2, z2, p6, blockingFlags) end
+
+-- APPLY_DAMAGE_TO_PED  (0x697157CED63F18D4)
+-- damages a ped with the given amount
+-- min build: 1207
+---@param ped number
+---@param damageAmount number
+---@param damageArmour boolean
+---@param boneId number
+---@param pedKiller number
+function ApplyDamageToPed(ped, damageAmount, damageArmour, boneId, pedKiller) end
+
+-- APPLY_PED_BLOOD_SPECIFIC  (0xEF0D582CBF2D9B0F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 any
+---@param p7 number
+---@return any
+function ApplyPedBloodSpecific(ped, p1, p2, p3, p4, p5, p6, p7) end
+
+-- APPLY_PED_DAMAGE_PACK  (0x46DF918788CB093F)
+-- https://github.com/femga/rdr3_discoveries/blob/master/peds_customization/ped_decals.lua
+-- min build: 1207
+---@param ped number
+---@param damagePack string
+---@param damage number
+---@param mult number
+function ApplyPedDamagePack(ped, damagePack, damage, mult) end
+
+-- CAN_KNOCK_PED_OFF_VEHICLE  (0x51AC07A44D4F5B8A)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function CanKnockPedOffVehicle(ped) end
+
+-- CAN_PED_BE_MOUNTED  (0x2D64376CF437363E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function CanPedBeMounted(ped) end
+
+-- CAN_PED_IN_COMBAT_SEE_TARGET  (0xEAD42DE3610D0721)
+-- min build: 1207
+---@param ped number
+---@param target number
+---@return boolean
+function CanPedInCombatSeeTarget(ped, target) end
+
+-- CAN_PED_RAGDOLL  (0x128F79EDCECE4FD5)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function CanPedRagdoll(ped) end
+
+-- CAN_PED_SEE_ENTITY  (0x7F9B9791D4CB71F6)
+-- Returns:
+-- 0 - CTR_CANNOT_TARGET
+-- 1 - CTR_CAN_TARGET
+-- 2 - CTR_NOT_SURE_YET
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param p2 boolean
+---@param doFoliageCheck boolean
+---@return number
+function CanPedSeeEntity(ped, targetEntity, p2, doFoliageCheck) end
+
+-- CAN_PED_SEE_PED_CACHED  (0x9D9473CB82D83A30)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 boolean
+---@return number
+function CanPedSeePedCached(ped, targetPed, p2) end
+
+-- CLEAR_FACIAL_IDLE_ANIM_OVERRIDE  (0x726256CC1EEB182F)
+-- min build: 1207
+---@param ped number
+function ClearFacialIdleAnimOverride(ped) end
+
+-- CLEAR_PED_BLOOD_DAMAGE  (0x8FE22675A5A45817)
+-- min build: 1207
+---@param ped number
+function ClearPedBloodDamage(ped) end
+
+-- CLEAR_PED_BLOOD_DAMAGE_BY_ZONE  (0x56E3B78C5408D9F4)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function ClearPedBloodDamageByZone(ped, p1) end
+
+-- CLEAR_PED_DAMAGE_DECAL_BY_ZONE  (0x523C79AEEFCC4A2A)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 string
+function ClearPedDamageDecalByZone(ped, p1, p2) end
+
+-- CLEAR_PED_DECORATIONS  (0x0E5173C163976E38)
+-- min build: 1207
+---@param ped number
+function ClearPedDecorations(ped) end
+
+-- CLEAR_PED_ENV_DIRT  (0x6585D955A68452A5)
+-- min build: 1207
+---@param ped number
+function ClearPedEnvDirt(ped) end
+
+-- CLEAR_PED_LAST_DAMAGE_BONE  (0x8EF6B7AC68E2F01B)
+-- min build: 1207
+---@param ped number
+function ClearPedLastDamageBone(ped) end
+
+-- CLEAR_PED_NON_CREATION_AREA  (0x2E05208086BA0651)
+-- min build: 1207
+function ClearPedNonCreationArea() end
+
+-- CLEAR_PED_WETNESS  (0x9C720776DAA43E7E)
+-- It clears the wetness of the selected Ped/Player. Clothes have to be wet to notice the difference.
+-- min build: 1207
+---@param ped number
+function ClearPedWetness(ped) end
+
+-- CLEAR_RAGDOLL_BLOCKING_FLAGS  (0xD86D101FCFD00A4B)
+-- flags: see SET_RAGDOLL_BLOCKING_FLAGS
+-- min build: 1207
+---@param ped number
+---@param flags number
+function ClearRagdollBlockingFlags(ped, flags) end
+
+-- CLEAR_RELATIONSHIP_BETWEEN_GROUPS  (0x5E29243FB56FC6D4)
+-- min build: 1207
+---@param relationship number
+---@param group1 number
+---@param group2 number
+function ClearRelationshipBetweenGroups(relationship, group1, group2) end
+
+-- CLONE_PED  (0xEF29A16337FACADB)
+-- min build: 1207
+---@param ped number
+---@param isNetwork boolean
+---@param bScriptHostPed boolean
+---@param copyHeadBlendFlag boolean
+---@return number
+function ClonePed(ped, isNetwork, bScriptHostPed, copyHeadBlendFlag) end
+
+-- CLONE_PED_TO_TARGET  (0xE952D6431689AD9A)
+-- Copies ped's components and props to targetPed.
+-- Can be used to clear anything from a ped by cloning it, including bullet holes.
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+function ClonePedToTarget(ped, targetPed) end
+
+-- COMPUTE_SATCHEL_ITEM_FOR_PED_DAMAGE  (0x9E7738B291706746)
+-- min build: 1207
+---@param p0 any
+---@param pedAttached number
+---@param damageCleanliness number
+---@return boolean
+function ComputeSatchelItemForPedDamage(p0, pedAttached, damageCleanliness) end
+
+-- COUNT_PEDS_IN_COMBAT_WITH_TARGET  (0x5407B7288D0478B7)
+-- min build: 1207
+---@param ped number
+---@param flag number
+---@return number
+function CountPedsInCombatWithTarget(ped, flag) end
+
+-- COUNT_PEDS_IN_COMBAT_WITH_TARGET_WITHIN_RADIUS  (0x336B3D200AB007CB)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param flag number
+---@return number
+function CountPedsInCombatWithTargetWithinRadius(ped, x, y, z, radius, flag) end
+
+-- CREATE_GROUP  (0x90370EBE0FEE1A3D)
+-- Creates a new ped group.
+-- Groups can contain up to 8 peds.
+-- 
+-- The parameter is unused.
+-- 
+-- Returns a handle to the created group, or 0 if a group couldn't be created.
+-- min build: 1207
+---@param taskAllocator number
+---@return number
+function CreateGroup(taskAllocator) end
+
+-- CREATE_PED  (0xD49F9B0955C367DE)
+-- min build: 1207
+---@param modelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param isNetwork boolean
+---@param bScriptHostPed boolean
+---@param p7 boolean
+---@param p8 boolean
+---@return number
+function CreatePed(modelHash, x, y, z, heading, isNetwork, bScriptHostPed, p7, p8) end
+
+-- CREATE_PED_INSIDE_VEHICLE  (0x7DD959874C1FD534)
+-- seatIndex:
+-- enum eVehicleSeat
+-- {
+-- 	VS_ANY_PASSENGER = -2,
+-- 	VS_DRIVER,
+-- 	VS_FRONT_RIGHT,
+-- 	VS_BACK_LEFT,
+-- 	VS_BACK_RIGHT,
+-- 	VS_EXTRA_LEFT_1,
+-- 	VS_EXTRA_RIGHT_1,
+-- 	VS_EXTRA_LEFT_2,
+-- 	VS_EXTRA_RIGHT_2,
+-- 	VS_EXTRA_LEFT_3,
+-- 	VS_EXTRA_RIGHT_3,
+-- 	VS_NUM_SEATS
+-- };
+-- min build: 1207
+---@param vehicle number
+---@param modelHash number
+---@param seatIndex number
+---@param p3 boolean
+---@param p4 boolean
+---@param p5 boolean
+---@return number
+function CreatePedInsideVehicle(vehicle, modelHash, seatIndex, p3, p4, p5) end
+
+-- CREATE_PED_ON_MOUNT  (0xF89AA2BD01FC06B7)
+-- min build: 1207
+---@param mount number
+---@param modelHash number
+---@param index number
+---@param p3 boolean
+---@param p4 boolean
+---@param p5 boolean
+---@param p6 boolean
+---@return number
+function CreatePedOnMount(mount, modelHash, index, p3, p4, p5, p6) end
+
+-- DELETE_PED  (0xCC0EF140F99365C5)
+-- Deletes the specified ped, then sets the handle pointed to by the pointer to NULL.
+-- min build: 1207
+---@return number
+function DeletePed() end
+
+-- DETACH_CARRIABLE_ENTITY  (0xED00D72F81CF7278)
+-- min build: 1207
+---@param entity number
+---@param p1 boolean
+---@param p2 boolean
+function DetachCarriableEntity(entity, p1, p2) end
+
+-- DISABLE_PED_INJURED_ON_GROUND_BEHAVIOUR  (0x733C87D4CE22BEA2)
+-- min build: 1207
+---@param ped number
+function DisablePedInjuredOnGroundBehaviour(ped) end
+
+-- DOES_GROUP_EXIST  (0x7C6B0C22F9F40BBE)
+-- min build: 1207
+---@param groupId number
+---@return boolean
+function DoesGroupExist(groupId) end
+
+-- EXPLODE_PED_HEAD  (0x2D05CED3A38D0F3A)
+-- Forces the ped to fall back and kills it.
+-- 
+-- It doesn't really explode the ped's head but it kills the ped
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+function ExplodePedHead(ped, weaponHash) end
+
+-- FADE_AND_DESTROY_PED  (0x7043D0681285BA2D)
+-- min build: 1207
+---@return number
+function FadeAndDestroyPed() end
+
+-- FIND_ALL_ATTACHED_CARRIABLE_ENTITIES  (0xB5ACE8B23A438EC0)
+-- min build: 1207
+---@param ped number
+---@param itemset number
+function FindAllAttachedCarriableEntities(ped, itemset) end
+
+-- FORCE_ALL_HEADING_VALUES_TO_ALIGN  (0xFF287323B0E2C69A)
+-- Old name: _FREEZE_PED_CAMERA_ROTATION
+-- min build: 1207
+---@param ped number
+function ForceAllHeadingValuesToAlign(ped) end
+
+-- FORCE_PED_AI_AND_ANIMATION_UPDATE  (0x2208438012482A1A)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+function ForcePedAiAndAnimationUpdate(ped, p1, p2) end
+
+-- FORCE_PED_MOTION_STATE  (0xF28965D04F570DCA)
+-- motionStateHash: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CPedMotionStates__eMotionState
+-- min build: 1207
+---@param ped number
+---@param motionStateHash number
+---@param p2 boolean
+---@param p3 number
+---@param p4 boolean
+---@return boolean
+function ForcePedMotionState(ped, motionStateHash, p2, p3, p4) end
+
+-- GET_ANIM_INITIAL_OFFSET_POSITION  (0xBE22B26DD764C040)
+-- min build: 1207
+---@param animDict string
+---@param animName string
+---@param x number
+---@param y number
+---@param z number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param p8 number
+---@param p9 number
+---@return vector3
+function GetAnimInitialOffsetPosition(animDict, animName, x, y, z, xRot, yRot, zRot, p8, p9) end
+
+-- GET_ANIM_INITIAL_OFFSET_ROTATION  (0x4B805E6046EE9E47)
+-- min build: 1207
+---@param animDict string
+---@param animName string
+---@param x number
+---@param y number
+---@param z number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param p8 number
+---@param p9 number
+---@return vector3
+function GetAnimInitialOffsetRotation(animDict, animName, x, y, z, xRot, yRot, zRot, p8, p9) end
+
+-- GET_CARRIED_ATTACHED_INFO_FOR_SLOT  (0x608BC6A6AACD5036)
+-- Outputs carriable info for a ped's carriable slot (see TASK_CARRIABLE slot indices). p3 is always 0 in R* scripts. Returns true if outData was filled.
+-- 
+-- outData: script struct<4> (32 bytes); each field is 8-byte (alignas(8)):
+-- 	struct CarriedAttachedInfo
+-- 	{
+-- 		alignas(8) Hash   model;         // carried entity model
+-- 		alignas(8) Hash   carryConfig;   // carry config (e.g. DEAD_CARRIABLE_FOX)
+-- 		alignas(8) int    carriableSlot; // slot index queried
+-- 		alignas(8) Entity entity;        // carried entity handle (0 if none)
+-- 	};
+-- 
+-- Example image: https://imgur.com/a/2wjt6PT
+-- min build: 1207
+---@param ped number
+---@param carriableSlot number
+---@param p3 number
+---@return boolean
+---@return any
+function GetCarriedAttachedInfoForSlot(ped, carriableSlot, p3) end
+
+-- GET_CLOSEST_PED  (0xC33AB876A77F8164)
+-- Gets the closest ped in a radius.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 boolean
+---@param p5 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 boolean
+---@param pedType number
+---@return boolean
+---@return number
+function GetClosestPed(x, y, z, radius, p4, p5, p7, p8, p9, pedType) end
+
+-- GET_COMBAT_FLOAT  (0x52DFF8A10508090A)
+-- min build: 1207
+---@param ped number
+---@param combatType number
+---@return number
+function GetCombatFloat(ped, combatType) end
+
+-- GET_CURRENT_TARGET_FOR_PED  (0xCD66FEA29400A0B5)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetCurrentTargetForPed(ped) end
+
+-- GET_DEAD_PED_PICKUP_COORDS  (0xCD5003B097200F36)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@return vector3
+function GetDeadPedPickupCoords(ped, p1, p2) end
+
+-- GET_GROUP_SIZE  (0x8DE69FE35CA09A45)
+-- min build: 1207
+---@param groupId number
+---@return boolean
+---@return number
+function GetGroupSize(groupId) end
+
+-- GET_IS_PED_RESPONDING_TO_NEGATIVE_INTERACTION  (0xA454D234E45BB6E5)
+-- min build: 1207
+---@param ped number
+---@param player number
+---@return boolean
+function GetIsPedRespondingToNegativeInteraction(ped, player) end
+
+-- GET_IS_PED_RESPONDING_TO_POSITIVE_INTERACTION  (0x9337183FDA2E9035)
+-- min build: 1207
+---@param ped number
+---@param player number
+---@return boolean
+function GetIsPedRespondingToPositiveInteraction(ped, player) end
+
+-- GET_JACK_TARGET  (0x5486A79D9FBD342D)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetJackTarget(ped) end
+
+-- GET_LOOTING_PICKUP_TARGET_ENTITY  (0x14169FA823679E41)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetLootingPickupTargetEntity(ped) end
+
+-- GET_MELEE_TARGET_FOR_PED  (0x18A3E9EE1297FD39)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetMeleeTargetForPed(ped) end
+
+-- GET_META_PED_ASSET_GUIDS  (0xA9C28516A6DC9D56)
+-- This is a way to get what drawables a ped has equipped
+-- Example: you are able to tell if the ped has the drawable PLAYER_ZERO_HAT_017 attached
+-- Note: this works with non shop components, direct .ydd files.
+-- min build: 1207
+---@param ped number
+---@param index number
+---@return boolean
+---@return number
+---@return number
+---@return number
+---@return number
+function GetMetaPedAssetGuids(ped, index) end
+
+-- GET_META_PED_ASSET_TINT  (0xE7998FEC53A33BBE)
+-- min build: 1207
+---@param ped number
+---@param index number
+---@return boolean
+---@return number
+---@return number
+---@return number
+---@return number
+function GetMetaPedAssetTint(ped, index) end
+
+-- GET_MOUNT  (0xE7E11B8DCBED1058)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetMount(ped) end
+
+-- GET_NUM_META_PED_OUTFITS  (0x10C70A515BC03707)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetNumMetaPedOutfits(ped) end
+
+-- GET_PED_ACCURACY  (0x37F4AD56ECBC0CD6)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedAccuracy(ped) end
+
+-- GET_PED_AS_GROUP_LEADER  (0x5CCE68DBD5FE93EC)
+-- min build: 1207
+---@param groupID number
+---@return number
+function GetPedAsGroupLeader(groupID) end
+
+-- GET_PED_AS_GROUP_MEMBER  (0x51455483CF23ED97)
+-- min build: 1207
+---@param groupID number
+---@param memberNumber number
+---@return number
+function GetPedAsGroupMember(groupID, memberNumber) end
+
+-- GET_PED_BLACKBOARD_SCRIPT_BOOL  (0x4912DFE492DB98CD)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@return boolean
+function GetPedBlackboardScriptBool(ped, variableName) end
+
+-- GET_PED_BLACKBOARD_SCRIPT_FLOAT  (0xA29FD00D45311EB7)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@return number
+function GetPedBlackboardScriptFloat(ped, variableName) end
+
+-- GET_PED_BLACKBOARD_SCRIPT_INT  (0xB71B91B398F8F067)
+-- min build: 1207
+---@param ped number
+---@param variableName string
+---@return number
+function GetPedBlackboardScriptInt(ped, variableName) end
+
+-- GET_PED_BONE_COORDS  (0x17C07FC640E86B4E)
+-- Gets the position of the specified bone of the specified ped.
+-- 
+-- ped: The ped to get the position of a bone from.
+-- boneId: The ID of the bone to get the position from. This is NOT the index.
+-- offsetX: The X-component of the offset to add to the position relative to the bone's rotation.
+-- offsetY: The Y-component of the offset to add to the position relative to the bone's rotation.
+-- offsetZ: The Z-component of the offset to add to the position relative to the bone's rotation.
+-- min build: 1207
+---@param ped number
+---@param boneId number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@return vector3
+function GetPedBoneCoords(ped, boneId, offsetX, offsetY, offsetZ) end
+
+-- GET_PED_BONE_INDEX  (0x3F428D08BE5AAE31)
+-- no bone = -1
+-- min build: 1207
+---@param ped number
+---@param boneId number
+---@return number
+function GetPedBoneIndex(ped, boneId) end
+
+-- GET_PED_CAUSE_OF_DEATH  (0x16FFE42AB2D2DC59)
+-- Returns the hash of the weapon/model/object that killed the ped.
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedCauseOfDeath(ped) end
+
+-- GET_PED_COMBAT_MOVEMENT  (0xDEA92412FCAEB3F5)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedCombatMovement(ped) end
+
+-- GET_PED_CONFIG_FLAG  (0x7EE53118C892B513)
+-- flagId: see SET_PED_CONFIG_FLAG
+-- min build: 1207
+---@param ped number
+---@param flagId number
+---@param p2 boolean
+---@return boolean
+function GetPedConfigFlag(ped, flagId, p2) end
+
+-- GET_PED_CROUCH_MOVEMENT  (0xD5FE956C70FF370B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetPedCrouchMovement(ped) end
+
+-- GET_PED_CURRENT_MOVE_BLEND_RATIO  (0xF60165E1D2C5370B)
+-- Old name: _GET_PED_CURRENT_MOVEMENT_SPEED
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return number
+---@return number
+function GetPedCurrentMoveBlendRatio(ped) end
+
+-- GET_PED_DEFENSIVE_AREA_POSITION  (0x3C06B8786DD94CD1)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return vector3
+function GetPedDefensiveAreaPosition(ped, p1) end
+
+-- GET_PED_GRAPPLE_STATE  (0x2311F15D971AA680)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedGrappleState(ped) end
+
+-- GET_PED_GROUP_INDEX  (0xF162E133B4E7A675)
+-- Returns the groupId of which the specified ped is a member of.
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedGroupIndex(ped) end
+
+-- GET_PED_IS_BEING_GRAPPLED  (0x3BDFCF25B58B0415)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetPedIsBeingGrappled(ped) end
+
+-- GET_PED_IS_DOING_COMBAT_ROLL  (0xC48A9EB0D499B3E5)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetPedIsDoingCombatRoll(ped) end
+
+-- GET_PED_IS_GRAPPLING  (0x0E99E3BF11BB6367)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetPedIsGrappling(ped) end
+
+-- GET_PED_LAST_DAMAGE_BONE  (0xD75960F6BD9EA49C)
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return number
+function GetPedLastDamageBone(ped) end
+
+-- GET_PED_LOOT_STATUS_MP  (0xC737697C41628340)
+-- enum ePedLootStatus
+-- {
+-- 	PLS_NONE,
+-- 	PLS_PRE_LOOT,
+-- 	PLS_SAMPLING,
+-- 	PLS_SKINNING
+-- };
+-- min build: 1311
+---@param ped number
+---@return number
+function GetPedLootStatusMp(ped) end
+
+-- GET_PED_MAX_HEALTH  (0x4700A416E8324EF3)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedMaxHealth(ped) end
+
+-- GET_PED_MONEY  (0x3F69145BBA87BAE7)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedMoney(ped) end
+
+-- GET_PED_MOTION_FOCUS_ENTITY  (0x243E1B4607040057)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedMotionFocusEntity(ped) end
+
+-- GET_PED_NEARBY_PEDS  (0x23F8F5FC7E8C4A6B)
+-- min build: 1207
+---@param ped number
+---@param ignoredPedType number
+---@param p3 number
+---@return number
+---@return any
+function GetPedNearbyPeds(ped, ignoredPedType, p3) end
+
+-- GET_PED_NEARBY_VEHICLES  (0xCFF869CBFA210D82)
+-- min build: 1207
+---@param ped number
+---@return number
+---@return any
+function GetPedNearbyVehicles(ped) end
+
+-- GET_PED_RELATIONSHIP_GROUP_DEFAULT_HASH  (0x42FDD0F017B1E38E)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedRelationshipGroupDefaultHash(ped) end
+
+-- GET_PED_RELATIONSHIP_GROUP_HASH  (0x7DBDD04862D95F04)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedRelationshipGroupHash(ped) end
+
+-- GET_PED_RESET_FLAG  (0xAF9E59B1B1FBF2A0)
+-- min build: 1207
+---@param ped number
+---@param flagId number
+---@return boolean
+function GetPedResetFlag(ped, flagId) end
+
+-- GET_PED_SOURCE_OF_DEATH  (0x93C8B64DEB84728C)
+-- Returns the entity that killed the ped
+-- 
+-- It is best to check if the Ped is dead before asking for its killer.
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedSourceOfDeath(ped) end
+
+-- GET_PED_STEALTH_MOVEMENT  (0x7C2AC9CA66575FBF)
+-- Returns whether the entity is in stealth mode
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetPedStealthMovement(ped) end
+
+-- GET_PED_TIME_OF_DEATH  (0x1E98817B311AE98A)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedTimeOfDeath(ped) end
+
+-- GET_PED_TO_PLAYER_WEAPON_DAMAGE_MODIFIER  (0x936E7CAD0AE2EE14)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedToPlayerWeaponDamageModifier(ped) end
+
+-- GET_PED_TYPE  (0xFF059E1E4C01E63C)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedType(ped) end
+
+-- GET_PEDS_JACKER  (0x9B128DC36C1E04CF)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedsJacker(ped) end
+
+-- GET_PLAYER_PED_IS_FOLLOWING  (0x6A3975DEA89F9A17)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPlayerPedIsFollowing(ped) end
+
+-- GET_RELATIONSHIP_BETWEEN_GROUPS  (0x9E6B70061662AE5C)
+-- min build: 1207
+---@param group1 number
+---@param group2 number
+---@return number
+function GetRelationshipBetweenGroups(group1, group2) end
+
+-- GET_RELATIONSHIP_BETWEEN_PEDS  (0xEBA5AD3A0EAF7121)
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+---@return number
+function GetRelationshipBetweenPeds(ped1, ped2) end
+
+-- GET_SEAT_PED_IS_TRYING_TO_ENTER  (0x6F4C85ACD641BCD2)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetSeatPedIsTryingToEnter(ped) end
+
+-- GET_SEAT_PED_IS_USING  (0x4E76CB57222A00E5)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetSeatPedIsUsing(ped) end
+
+-- GET_TRACKED_PED_PIXELCOUNT  (0x511F1A683387C7E2)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetTrackedPedPixelcount(ped) end
+
+-- GET_VEHICLE_PED_IS_ENTERING  (0xF92691AED837A5FC)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetVehiclePedIsEntering(ped) end
+
+-- GET_VEHICLE_PED_IS_IN  (0x9A9112A0FE9A4713)
+-- Gets the vehicle the specified Ped is in.
+-- 
+-- If the Ped is not in a vehicle and includeLastVehicle is true, the vehicle they were last in is returned.
+-- min build: 1207
+---@param ped number
+---@param lastVehicle boolean
+---@return number
+function GetVehiclePedIsIn(ped, lastVehicle) end
+
+-- GET_VEHICLE_PED_IS_USING  (0x6094AD011A2EA87D)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetVehiclePedIsUsing(ped) end
+
+-- GIVE_PED_HASH_SCENARIO_PROP  (0x2B02DB082258625F)
+-- min build: 1207
+---@param ped number
+---@param object number
+---@param conditionalAnim string
+---@param scenarioType number
+---@param p4 number
+---@param p5 boolean
+---@return boolean
+function GivePedHashScenarioProp(ped, object, conditionalAnim, scenarioType, p4, p5) end
+
+-- HAS_MOTION_TYPE_ASSET_LOADED  (0x854BC9B1A1CCD034)
+-- min build: 1207
+---@param nameHash number
+---@param ped number
+---@return boolean
+function HasMotionTypeAssetLoaded(nameHash, ped) end
+
+-- INIT_PED_DEFAULT_HEALTH  (0x7DD7FB3480D8083E)
+-- min build: 1207
+---@param ped number
+function InitPedDefaultHealth(ped) end
+
+-- INSTANTLY_FILL_PED_POPULATION  (0x4759CC730F947C81)
+-- min build: 1207
+function InstantlyFillPedPopulation() end
+
+-- IS_ANIMAL_INTERACTION_POSSIBLE  (0xD543D3A8FDE4F185)
+-- min build: 1207
+---@param ped number
+---@param animal number
+---@return boolean
+function IsAnimalInteractionPossible(ped, animal) end
+
+-- IS_ANY_HOSTILE_PED_NEAR_POINT  (0x68772DB2B2526F9F)
+-- min build: 1311
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function IsAnyHostilePedNearPoint(ped, x, y, z, radius) end
+
+-- IS_ANY_PED_NEAR_POINT  (0x083961498679DC9F)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function IsAnyPedNearPoint(x, y, z, radius) end
+
+-- IS_ANY_PED_SHOOTING_IN_AREA  (0xA0D3D71EA1086C55)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p6 boolean
+---@param p7 boolean
+---@return boolean
+function IsAnyPedShootingInArea(x1, y1, z1, x2, y2, z2, p6, p7) end
+
+-- IS_EVENT_IN_QUEUE  (0xC8D523BF5BBD3808)
+-- min build: 1207
+---@param ped number
+---@param eventType number
+---@return boolean
+function IsEventInQueue(ped, eventType) end
+
+-- IS_GROUP_LOCALLY_CONTROLLED  (0x909AD9E9A92A10DF)
+-- min build: 1207
+---@param groupId number
+---@return boolean
+function IsGroupLocallyControlled(groupId) end
+
+-- IS_INSTANTLY_FILL_PED_POPULATION_FINISHED  (0x0EE3F0D7FECCC54F)
+-- min build: 1207
+---@return boolean
+function IsInstantlyFillPedPopulationFinished() end
+
+-- IS_LOCATION_SPAWN_SAFE  (0xFB1E7998B8595825)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function IsLocationSpawnSafe(ped, p1) end
+
+-- IS_PED_A_PLAYER  (0x12534C348C6CB68B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedAPlayer(ped) end
+
+-- IS_PED_AIMING_FROM_COVER  (0x3998B1276A3300E5)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedAimingFromCover(ped) end
+
+-- IS_PED_BEING_DRAGGED  (0xEF3A8772F085B4AA)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedBeingDragged(ped) end
+
+-- IS_PED_BEING_HOGTIED  (0xD453BB601D4A606E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedBeingHogtied(ped) end
+
+-- IS_PED_BEING_JACKED  (0x9A497FE2DF198913)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedBeingJacked(ped) end
+
+-- IS_PED_BEING_STEALTH_KILLED  (0x863B23EFDE9C5DF2)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedBeingStealthKilled(ped) end
+
+-- IS_PED_BEING_STUNNED  (0x4FBACCE3B4138EE8)
+-- min build: 1207
+---@param ped number
+---@param weaponType number
+---@return boolean
+function IsPedBeingStunned(ped, weaponType) end
+
+-- IS_PED_CARRYING_SOMETHING  (0xA911EE21EDF69DAF)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedCarryingSomething(ped) end
+
+-- IS_PED_CLIMBING  (0x53E8CB4F48BFE623)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedClimbing(ped) end
+
+-- IS_PED_DEAD_OR_DYING  (0x3317DEDB88C95038)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function IsPedDeadOrDying(ped, p1) end
+
+-- IS_PED_DEFENSIVE_AREA_ACTIVE  (0xBA63D9FE45412247)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function IsPedDefensiveAreaActive(ped, p1) end
+
+-- IS_PED_DIVING  (0x5527B8246FEF9B11)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedDiving(ped) end
+
+-- IS_PED_ENTERING_ANY_TRANSPORT  (0x1D46B417F926D34D)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedEnteringAnyTransport(ped) end
+
+-- IS_PED_EVASIVE_DIVING  (0x414641C26E105898)
+-- Presumably returns the Entity that the Ped is currently diving out of the way of.
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return number
+function IsPedEvasiveDiving(ped) end
+
+-- IS_PED_FACING_PED  (0xD71649DB0A545AA3)
+-- angle is ped's view cone
+-- min build: 1207
+---@param ped number
+---@param otherPed number
+---@param angle number
+---@return boolean
+function IsPedFacingPed(ped, otherPed, angle) end
+
+-- IS_PED_FALLING  (0xFB92A102F1C4DFA3)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedFalling(ped) end
+
+-- IS_PED_FALLING_OVER  (0x3E592D0486DEC0F6)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedFallingOver(ped) end
+
+-- IS_PED_FATALLY_INJURED  (0xD839450756ED5A80)
+-- Gets a value indicating whether this ped's health is below its fatally injured threshold. The default threshold is 100.
+-- If the handle is invalid, the function returns true.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedFatallyInjured(ped) end
+
+-- IS_PED_FLEEING  (0xBBCCE00B381F8482)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedFleeing(ped) end
+
+-- IS_PED_FULLY_ON_MOUNT  (0x95CBC65780DE7EB1)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function IsPedFullyOnMount(ped, p1) end
+
+-- IS_PED_GETTING_INTO_A_VEHICLE  (0xBB062B2B5722478E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedGettingIntoAVehicle(ped) end
+
+-- IS_PED_GOING_INTO_COVER  (0x9F65DBC537E59AD5)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedGoingIntoCover(ped) end
+
+-- IS_PED_GROUP_MEMBER  (0x9BB01E3834671191)
+-- min build: 1207
+---@param ped number
+---@param groupId number
+---@param p2 boolean
+---@return boolean
+function IsPedGroupMember(ped, groupId, p2) end
+
+-- IS_PED_HANGING_ON_TO_VEHICLE  (0x1C86D8AEF8254B78)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedHangingOnToVehicle(ped) end
+
+-- IS_PED_HEADING_TOWARDS_POSITION  (0xFCF37A457CB96DC0)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@return boolean
+function IsPedHeadingTowardsPosition(ped, x, y, z, p4) end
+
+-- IS_PED_HEADTRACKING_ENTITY  (0x813A0A7C9D2E831F)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@return boolean
+function IsPedHeadtrackingEntity(ped, entity) end
+
+-- IS_PED_HEADTRACKING_PED  (0x5CD3CB88A7F8850D)
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+---@return boolean
+function IsPedHeadtrackingPed(ped1, ped2) end
+
+-- IS_PED_HOGTIED  (0x3AA24CCC0D451379)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedHogtied(ped) end
+
+-- IS_PED_HOGTYING  (0x42429C674B61238B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedHogtying(ped) end
+
+-- IS_PED_HUMAN  (0xB980061DA992779D)
+-- Returns true/false if the ped is/isn't humanoid.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedHuman(ped) end
+
+-- IS_PED_IN_ANY_BOAT  (0x2E0E1C2B4F6CB339)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInAnyBoat(ped) end
+
+-- IS_PED_IN_ANY_HELI  (0x298B91AE825E5705)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInAnyHeli(ped) end
+
+-- IS_PED_IN_ANY_PLANE  (0x5FFF4CFC74D8FB80)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInAnyPlane(ped) end
+
+-- IS_PED_IN_ANY_TAXI  (0x6E575D6A898AB852)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInAnyTaxi(ped) end
+
+-- IS_PED_IN_ANY_TRAIN  (0x6F972C1AB75A1ED0)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInAnyTrain(ped) end
+
+-- IS_PED_IN_ANY_VEHICLE  (0x997ABD671D25CA0B)
+-- Gets a value indicating whether the specified ped is in any vehicle.
+-- min build: 1207
+---@param ped number
+---@param atGetIn boolean
+---@return boolean
+function IsPedInAnyVehicle(ped, atGetIn) end
+
+-- IS_PED_IN_COMBAT  (0x4859F1FC66A6278E)
+-- min build: 1207
+---@param ped number
+---@param target number
+---@return boolean
+function IsPedInCombat(ped, target) end
+
+-- IS_PED_IN_COVER  (0x60DFD0691A170B88)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@return boolean
+function IsPedInCover(ped, p1, p2) end
+
+-- IS_PED_IN_COVER_FACING_LEFT  (0x845333B3150583AB)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInCoverFacingLeft(ped) end
+
+-- IS_PED_IN_FLYING_VEHICLE  (0x9134873537FA419C)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInFlyingVehicle(ped) end
+
+-- IS_PED_IN_GROUP  (0x5891CAC5D4ACFF74)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInGroup(ped) end
+
+-- IS_PED_IN_MELEE_COMBAT  (0x4E209B2C1EAD5159)
+-- Notes: The function only returns true while the ped is: 
+-- A.) Swinging a random melee attack (including pistol-whipping)
+-- 
+-- B.) Reacting to being hit by a melee attack (including pistol-whipping)
+-- 
+-- C.) Is locked-on to an enemy (arms up, strafing/skipping in the default fighting-stance, ready to dodge+counter). 
+-- 
+-- You don't have to be holding the melee-targeting button to be in this stance; you stay in it by default for a few seconds after swinging at someone. If you do a sprinting punch, it returns true for the duration of the punch animation and then returns false again, even if you've punched and made-angry many peds
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInMeleeCombat(ped) end
+
+-- IS_PED_IN_MODEL  (0x796D90EFB19AA332)
+-- min build: 1207
+---@param ped number
+---@param modelHash number
+---@return boolean
+function IsPedInModel(ped, modelHash) end
+
+-- IS_PED_IN_VEHICLE  (0xA3EE4A07279BB9DB)
+-- Gets a value indicating whether the specified ped is in the specified vehicle.
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param atGetIn boolean
+---@return boolean
+function IsPedInVehicle(ped, vehicle, atGetIn) end
+
+-- IS_PED_INCAPACITATED  (0xB655DB7582AEC805)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedIncapacitated(ped) end
+
+-- IS_PED_INJURED  (0x84A2DD9AC37C35C1)
+-- Gets a value indicating whether this ped's health is below its injured threshold.
+-- 
+-- The default threshold is 100.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInjured(ped) end
+
+-- IS_PED_JACKING  (0x4AE4FF911DFB61DA)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedJacking(ped) end
+
+-- IS_PED_JUMPING  (0xCEDABC5900A0BF97)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedJumping(ped) end
+
+-- IS_PED_LASSOED  (0x9682F850056C9ADE)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedLassoed(ped) end
+
+-- IS_PED_MALE  (0x6D9F5FAA7488BA46)
+-- Returns true/false if the ped is/isn't male.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedMale(ped) end
+
+-- IS_PED_MODEL  (0xC9D55B1A358A5BF7)
+-- min build: 1207
+---@param ped number
+---@param modelHash number
+---@return boolean
+function IsPedModel(ped, modelHash) end
+
+-- IS_PED_ON_FOOT  (0x01FEE67DB37F59B2)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedOnFoot(ped) end
+
+-- IS_PED_ON_MOUNT  (0x460BC76A0E10655E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedOnMount(ped) end
+
+-- IS_PED_ON_SPECIFIC_VEHICLE  (0xEC5F66E459AF3BB2)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@return boolean
+function IsPedOnSpecificVehicle(ped, vehicle) end
+
+-- IS_PED_ON_VEHICLE  (0x67722AEB798E5FAB)
+-- Gets a value indicating whether the specified ped is on top of any vehicle.
+-- 
+-- Return 1 when ped is on vehicle.
+-- Return 0 when ped is not on a vehicle.
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function IsPedOnVehicle(ped, p1) end
+
+-- IS_PED_OPENING_DOOR  (0x26AF0E8E30BD2A2C)
+-- Returns true if the ped is currently opening a door (CTaskOpenDoor).
+-- 
+-- Old name: _IS_PED_OPENING_A_DOOR
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedOpeningDoor(ped) end
+
+-- IS_PED_PERFORMING_MELEE_ACTION  (0xDCCA191DF9980FD7)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@return boolean
+function IsPedPerformingMeleeAction(ped, p1, p2) end
+
+-- IS_PED_PLANTING_BOMB  (0xC70B5FAE151982D8)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedPlantingBomb(ped) end
+
+-- IS_PED_PRONE  (0xD6A86331A537A7B9)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedProne(ped) end
+
+-- IS_PED_RAGDOLL  (0x47E4E977581C5B55)
+-- If the ped handle passed through the parenthesis is in a ragdoll state this will return true.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRagdoll(ped) end
+
+-- IS_PED_READY_TO_RENDER  (0xA0BC8FAED8CFEB3C)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedReadyToRender(ped) end
+
+-- IS_PED_RELOADING  (0x24B100C68C645951)
+-- Returns whether the specified ped is reloading.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedReloading(ped) end
+
+-- IS_PED_RESPONDING_TO_EVENT  (0x625B774D75C87068)
+-- eventType: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- min build: 1207
+---@param ped number
+---@param eventType number
+---@return boolean
+function IsPedRespondingToEvent(ped, eventType) end
+
+-- IS_PED_RESPONDING_TO_THREAT  (0x77525BBF433F2CD6)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRespondingToThreat(ped) end
+
+-- IS_PED_RUNNING_MOBILE_PHONE_TASK  (0x2AFE52F782F25775)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRunningMobilePhoneTask(ped) end
+
+-- IS_PED_RUNNING_RAGDOLL_TASK  (0xE3B6097CC25AA69E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRunningRagdollTask(ped) end
+
+-- IS_PED_SHOOTING  (0x34616828CD07F1A1)
+-- Returns whether the specified ped is shooting.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedShooting(ped) end
+
+-- IS_PED_SITTING  (0x84D0BF2B21862059)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedSitting(ped) end
+
+-- IS_PED_SITTING_IN_ANY_VEHICLE  (0x826AA586EDB9FEF8)
+-- Detect if ped is in any vehicle
+-- [True/False]
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedSittingInAnyVehicle(ped) end
+
+-- IS_PED_SITTING_IN_VEHICLE  (0xA808AA1D79230FC2)
+-- Detect if ped is sitting in the specified vehicle
+-- [True/False]
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@return boolean
+function IsPedSittingInVehicle(ped, vehicle) end
+
+-- IS_PED_STOPPED  (0x530944F6F4B8A214)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedStopped(ped) end
+
+-- IS_PED_SWIMMING  (0x9DE327631295B4C2)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedSwimming(ped) end
+
+-- IS_PED_SWIMMING_UNDER_WATER  (0xC024869A53992F34)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedSwimmingUnderWater(ped) end
+
+-- IS_PED_USING_ACTION_MODE  (0x00E73468D085F745)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedUsingActionMode(ped) end
+
+-- IS_PED_USING_ANY_SCENARIO  (0x57AB4A3080F85143)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedUsingAnyScenario(ped) end
+
+-- IS_PED_USING_SCENARIO_HASH  (0x34D6AC1157C8226C)
+-- Equivalent to IS_PED_USING_SCENARIO from V but takes a hash instead of a string.
+-- min build: 1207
+---@param ped number
+---@param scenarioHash number
+---@return boolean
+function IsPedUsingScenarioHash(ped, scenarioHash) end
+
+-- IS_PED_USING_THIS_SCENARIO  (0x9C54041BB66BCF9E)
+-- min build: 1207
+---@param ped number
+---@param scenario number
+---@return boolean
+function IsPedUsingThisScenario(ped, scenario) end
+
+-- IS_PED_VAULTING  (0x117C70D1F5730B5E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedVaulting(ped) end
+
+-- IS_TARGET_PED_IN_PERCEPTION_AREA  (0x06087579E7AA85A9)
+-- Returns true if ped is in perception (focused and looking at target ped)
+-- Most float params are -1.f in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+---@param customDistance number
+---@param p4 number
+---@param p5 number
+---@return boolean
+function IsTargetPedInPerceptionArea(ped, targetPed, p2, customDistance, p4, p5) end
+
+-- IS_TRACKED_PED_VISIBLE  (0x91C8E617F64188AC)
+-- Returns whether or not a ped is visible within your FOV, not this check auto's to false after a certain distance.
+-- Target needs to be tracked first, won't work otherwise.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsTrackedPedVisible(ped) end
+
+-- KNOCK_OFF_PED_PROP  (0x6FD7816A36615F48)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+function KnockOffPedProp(ped, p1, p2, p3, p4) end
+
+-- KNOCK_PED_OFF_VEHICLE  (0x45BBCBA77C29A841)
+-- min build: 1207
+---@param ped number
+function KnockPedOffVehicle(ped) end
+
+-- PED_COWER_IN_PLACE  (0xF6E1E9F47A7686F8)
+-- min build: 1207
+---@param ped number
+---@param ped2 number
+function PedCowerInPlace(ped, ped2) end
+
+-- PED_COWER_MOVE_TO_POINT  (0x1E4C940233FC0C6F)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param ped2 number
+---@param p5 number
+function PedCowerMoveToPoint(ped, p1, p2, p3, ped2, p5) end
+
+-- REGISTER_HATED_TARGETS_AROUND_PED  (0x9222F300BF8354FE)
+-- Based on TASK_COMBAT_HATED_TARGETS_AROUND_PED, the parameters are likely similar (PedHandle, and area to attack in).
+-- min build: 1207
+---@param ped number
+---@param radius number
+function RegisterHatedTargetsAroundPed(ped, radius) end
+
+-- REGISTER_TARGET  (0x2F25D9AEFA34FBA2)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 boolean
+function RegisterTarget(ped, targetPed, p2) end
+
+-- RELEASE_PED_VISIBILITY_TRACKING  (0x3088634CF8C819CF)
+-- min build: 1207
+---@param ped number
+function ReleasePedVisibilityTracking(ped) end
+
+-- REMOVE_GROUP  (0x8EB2F69076AF7053)
+-- min build: 1207
+---@param groupId number
+function RemoveGroup(groupId) end
+
+-- REMOVE_PED_DEFENSIVE_AREA  (0x74D4E028107450A9)
+-- Ped will no longer get angry when you stay near him.
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function RemovePedDefensiveArea(ped, toggle) end
+
+-- REMOVE_PED_FROM_GROUP  (0xED74007FFB146BC2)
+-- min build: 1207
+---@param ped number
+function RemovePedFromGroup(ped) end
+
+-- REMOVE_RELATIONSHIP_GROUP  (0xB6BA2444AB393DA2)
+-- min build: 1207
+---@param groupHash number
+function RemoveRelationshipGroup(groupHash) end
+
+-- REMOVE_SCENARIO_BLOCKING_AREA  (0x31D16B74C6E29D66)
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+function RemoveScenarioBlockingArea(p0, p1) end
+
+-- REMOVE_SCENARIO_BLOCKING_AREAS  (0xD37401D78A929A49)
+-- min build: 1207
+function RemoveScenarioBlockingAreas() end
+
+-- REMOVE_SHOP_ITEM_FROM_PED_BY_CATEGORY  (0xDF631E4BCE1B1FC4)
+-- Params: p2, p3 usually 0 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param componentCategory number
+---@param p2 number
+---@param p3 boolean
+function RemoveShopItemFromPedByCategory(ped, componentCategory, p2, p3) end
+
+-- REMOVE_TAG_FROM_META_PED  (0xD710A5007C2AC539)
+-- min build: 1207
+---@param ped number
+---@param component number
+---@param p2 number
+function RemoveTagFromMetaPed(ped, component, p2) end
+
+-- REQUEST_PED_USE_SMALL_BBOX_VISIBILITY_TRACKING  (0x75BA1CB3B7D40CAF)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function RequestPedUseSmallBboxVisibilityTracking(ped, p1) end
+
+-- REQUEST_PED_VEHICLE_VISIBILITY_TRACKING  (0x2BC338A7B21F4608)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function RequestPedVehicleVisibilityTracking(ped, p1) end
+
+-- REQUEST_PED_VISIBILITY_TRACKING  (0x7D7A2E43E74E2EB8)
+-- min build: 1207
+---@param ped number
+function RequestPedVisibilityTracking(ped) end
+
+-- RESET_AI_WEAPON_DAMAGE_MODIFIER  (0xEA16670E7BA4743C)
+-- min build: 1207
+function ResetAiWeaponDamageModifier() end
+
+-- RESET_GROUP_FORMATION_DEFAULT_SPACING  (0x63DAB4CCB3273205)
+-- min build: 1207
+---@param groupId number
+function ResetGroupFormationDefaultSpacing(groupId) end
+
+-- RESET_HORSE_AVOIDANCE_LEVEL_TO_DEFAULT  (0x2A5AFD2B8381A6E1)
+-- min build: 1207
+---@param horse number
+function ResetHorseAvoidanceLevelToDefault(horse) end
+
+-- RESET_PED_IN_VEHICLE_CONTEXT  (0x22EF8FF8778030EB)
+-- min build: 1207
+---@param ped number
+function ResetPedInVehicleContext(ped) end
+
+-- RESET_PED_LAST_VEHICLE  (0xBB8DE8CF6A8DD8BB)
+-- Resets the value for the last vehicle driven by the Ped.
+-- min build: 1207
+---@param ped number
+function ResetPedLastVehicle(ped) end
+
+-- RESET_PED_RAGDOLL_TIMER  (0x9FA4664CF62E47E8)
+-- min build: 1207
+---@param ped number
+function ResetPedRagdollTimer(ped) end
+
+-- RESET_PED_WEAPON_MOVEMENT_CLIPSET  (0x97B0DB5B4AA74E77)
+-- min build: 1207
+---@param ped number
+function ResetPedWeaponMovementClipset(ped) end
+
+-- RESURRECT_PED  (0x71BC8E838B9C6035)
+-- This function will simply bring the dead ped back to life.
+-- 
+-- Before calling this function, you may want to declare the position, where your Resurrected ped to be spawn at because theres a chance the ped will fall through the map
+-- 
+-- Also, disabling any assigned task immediately helped in the number of scenarios, where If you want peds to perform certain decided tasks.
+-- min build: 1207
+---@param ped number
+function ResurrectPed(ped) end
+
+-- REVIVE_INJURED_PED  (0x8D8ACD8388CD99CE)
+-- min build: 1207
+---@param ped number
+function ReviveInjuredPed(ped) end
+
+-- SET_AI_MELEE_WEAPON_DAMAGE_MODIFIER  (0x66460DEDDD417254)
+-- min build: 1207
+---@param modifier number
+function SetAiMeleeWeaponDamageModifier(modifier) end
+
+-- SET_AI_WEAPON_DAMAGE_MODIFIER  (0x1B1E2A40A65B8521)
+-- min build: 1207
+---@param value number
+function SetAiWeaponDamageModifier(value) end
+
+-- SET_BLOCKING_OF_NON_TEMPORARY_EVENTS  (0x9F8AA94D6D97DBF4)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetBlockingOfNonTemporaryEvents(ped, toggle) end
+
+-- SET_BLOCKING_OF_NON_TEMPORARY_EVENTS_FOR_AMBIENT_PEDS_THIS_FRAME  (0x9911F4A24485F653)
+-- min build: 1207
+---@param p0 boolean
+function SetBlockingOfNonTemporaryEventsForAmbientPedsThisFrame(p0) end
+
+-- SET_COMBAT_FLOAT  (0xFF41B4B141ED981C)
+-- combatType: https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_FLOATS 
+-- https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eCombatAttributeFloats
+-- min build: 1207
+---@param ped number
+---@param combatType number
+---@param newValue number
+function SetCombatFloat(ped, combatType, newValue) end
+
+-- SET_CREATE_RANDOM_COPS  (0x102E68B2024D536D)
+-- min build: 1207
+---@param toggle boolean
+function SetCreateRandomCops(toggle) end
+
+-- SET_ENABLE_BOUND_ANKLES  (0xC52E0F855C58FC2E)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetEnableBoundAnkles(ped, toggle) end
+
+-- SET_ENABLE_HANDCUFFS  (0xDF1AF8B5D56542FA)
+-- Ped can not pull out a weapon when true
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+function SetEnableHandcuffs(ped, p1, p2) end
+
+-- SET_FACIAL_IDLE_ANIM_OVERRIDE  (0xFFC24B988B938B38)
+-- min build: 1207
+---@param ped number
+---@param animName string
+---@param animDict string
+function SetFacialIdleAnimOverride(ped, animName, animDict) end
+
+-- SET_FORMATION_POSITIONS_TARGET_RADIUS  (0x7CC7D3B7AF7FB71F)
+-- min build: 1207
+---@param groupId number
+---@param radius number
+---@return boolean
+function SetFormationPositionsTargetRadius(groupId, radius) end
+
+-- SET_GROUP_FORMATION  (0xCE2F5FC3AF7E8C1E)
+-- eFormationType
+-- 
+-- 0: Default
+-- 1: Circle Around Leader
+-- 2: Alternative Circle Around Leader
+-- 3: Line, with Leader at center
+-- min build: 1207
+---@param groupId number
+---@param formationType number
+function SetGroupFormation(groupId, formationType) end
+
+-- SET_GROUP_FORMATION_SPACING  (0x1D9D45004C28C916)
+-- min build: 1207
+---@param groupId number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+function SetGroupFormationSpacing(groupId, p1, p2, p3) end
+
+-- SET_GROUP_SEPARATION_RANGE  (0x4102C7858CFEE4E4)
+-- Sets the range at which members will automatically leave the group.
+-- min build: 1207
+---@param groupId number
+---@param separationRange number
+function SetGroupSeparationRange(groupId, separationRange) end
+
+-- SET_HORSE_AVOIDANCE_LEVEL  (0xDDCF6FEA5D7ACC17)
+-- -1 - HORSE_ASSIST__NO_CHANGE
+--  0 - HORSE_ASSIST__MANUAL
+--  1 - HORSE_ASSIST__SEMIASSIST
+--  2 - HORSE_ASSIST__FULLASSIST
+-- min build: 1207
+---@param horse number
+---@param avoidanceLevel number
+function SetHorseAvoidanceLevel(horse, avoidanceLevel) end
+
+-- SET_IK_TARGET  (0xC32779C16FCEECD9)
+-- min build: 1207
+---@param ped number
+---@param ikIndex number
+---@param entityLookAt number
+---@param boneLookAt number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param p7 any
+---@param blendInDuration number
+---@param blendOutDuration number
+function SetIkTarget(ped, ikIndex, entityLookAt, boneLookAt, offsetX, offsetY, offsetZ, p7, blendInDuration, blendOutDuration) end
+
+-- SET_LOOTING_FLAG  (0x6569F31A01B4C097)
+-- https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CLootingFlags__Flags
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/LOOTING_FLAGS
+-- 
+-- lootFlag:
+-- enum eLootFlag
+-- {
+-- 	LOOT_FLAG_IS_CRITICAL_LOOT_TARGET = 7,
+-- 	LOOT_FLAG_IGNORE_WATER_CHECKS = 8,
+-- 	LOOT_FLAG_ANIMAL_FLAGGED_FOR_TAGGING = 23,
+-- };
+-- min build: 1207
+---@param ped number
+---@param lootFlag number
+---@param enabled boolean
+function SetLootingFlag(ped, lootFlag, enabled) end
+
+-- SET_PAUSE_PED_WRITHE_BLEEDOUT  (0x925A160133003AC6)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPausePedWritheBleedout(ped, toggle) end
+
+-- SET_PED_ACCURACY  (0x7AEFB85C1D49DEB6)
+-- accuracy = 0-100, 100 being perfectly accurate
+-- min build: 1207
+---@param ped number
+---@param accuracy number
+function SetPedAccuracy(ped, accuracy) end
+
+-- SET_PED_AS_COP  (0xBB03C38DD3FB7FFD)
+-- Turns the desired ped into a cop. If you use this on the player ped, you will become almost invisible to cops dispatched for you. You will also report your own crimes, get a generic cop voice, get a cop-vision-cone on the radar, and you will be unable to shoot at other cops. Toggling ped as "false" has no effect; you must change p0's ped model to disable the effect.
+-- toggle = bSetRelGroup
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedAsCop(ped, toggle) end
+
+-- SET_PED_AS_GROUP_LEADER  (0x2A7819605465FBCE)
+-- min build: 1207
+---@param ped number
+---@param groupId number
+---@param p2 boolean
+function SetPedAsGroupLeader(ped, groupId, p2) end
+
+-- SET_PED_AS_GROUP_MEMBER  (0x9F3480FE65DB31B5)
+-- min build: 1207
+---@param ped number
+---@param groupId number
+function SetPedAsGroupMember(ped, groupId) end
+
+-- SET_PED_CAN_ARM_IK  (0x6C3B4D6D13B4C841)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanArmIk(ped, toggle) end
+
+-- SET_PED_CAN_BE_INCAPACITATED  (0x5240864E847C691C)
+-- When set on a player ped, its just like when you die in RDO
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanBeIncapacitated(ped, toggle) end
+
+-- SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE  (0x7A6535691B477C48)
+-- state:
+-- enum eKnockOffVehicle
+-- {
+-- 	KNOCKOFFVEHICLE_DEFAULT,
+-- 	KNOCKOFFVEHICLE_NEVER,
+-- 	KNOCKOFFVEHICLE_EASY,
+-- 	KNOCKOFFVEHICLE_HARD
+-- };
+-- min build: 1207
+---@param ped number
+---@param state number
+function SetPedCanBeKnockedOffVehicle(ped, state) end
+
+-- SET_PED_CAN_BE_TARGETTED  (0x63F58F7C80513AAD)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanBeTargetted(ped, toggle) end
+
+-- SET_PED_CAN_BE_TARGETTED_BY_PLAYER  (0x66B57B72E0836A76)
+-- min build: 1207
+---@param ped number
+---@param player number
+---@param toggle boolean
+function SetPedCanBeTargettedByPlayer(ped, player, toggle) end
+
+-- SET_PED_CAN_BE_TARGETTED_BY_TEAM  (0xBF1CA77833E58F2C)
+-- min build: 1207
+---@param ped number
+---@param team number
+---@param toggle boolean
+function SetPedCanBeTargettedByTeam(ped, team, toggle) end
+
+-- SET_PED_CAN_HEAD_IK  (0xC11C18092C5530DC)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanHeadIk(ped, toggle) end
+
+-- SET_PED_CAN_LEG_IK  (0x73518ECE2485412B)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanLegIk(ped, toggle) end
+
+-- SET_PED_CAN_PLAY_AMBIENT_ANIMS  (0x6373D1349925A70E)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanPlayAmbientAnims(ped, toggle) end
+
+-- SET_PED_CAN_PLAY_AMBIENT_BASE_ANIMS  (0x0EB0585D15254740)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanPlayAmbientBaseAnims(ped, toggle) end
+
+-- SET_PED_CAN_PLAY_GESTURE_ANIMS  (0xBAF20C5432058024)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function SetPedCanPlayGestureAnims(ped, p1, p2) end
+
+-- SET_PED_CAN_RAGDOLL  (0xB128377056A54E2A)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanRagdoll(ped, toggle) end
+
+-- SET_PED_CAN_RAGDOLL_FROM_PLAYER_IMPACT  (0xDF993EE5E90ABA25)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanRagdollFromPlayerImpact(ped, toggle) end
+
+-- SET_PED_CAN_TELEPORT_TO_GROUP_LEADER  (0x2E2F4240B3F24647)
+-- This only will teleport the ped to the group leader if the group leader teleports (sets coords).
+-- 
+-- Only works in singleplayer
+-- min build: 1207
+---@param pedHandle number
+---@param groupId number
+---@param toggle boolean
+function SetPedCanTeleportToGroupLeader(pedHandle, groupId, toggle) end
+
+-- SET_PED_CAN_TORSO_IK  (0xF2B7106D37947CE0)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanTorsoIk(ped, toggle) end
+
+-- SET_PED_CAN_TORSO_REACT_IK  (0xF5846EDB26A98A24)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanTorsoReactIk(ped, toggle) end
+
+-- SET_PED_CAN_TORSO_VEHICLE_IK  (0x6647C5F6F5792496)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanTorsoVehicleIk(ped, toggle) end
+
+-- SET_PED_CAN_USE_AUTO_CONVERSATION_LOOKAT  (0xEC4686EC06434678)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedCanUseAutoConversationLookat(ped, toggle) end
+
+-- SET_PED_CAPSULE  (0x364DF566EC833DE2)
+-- Overrides the ped's collision capsule radius for the current tick.
+-- Must be called every tick to be effective.
+-- 
+-- Setting this to 0.001 will allow warping through some objects.
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedCapsule(ped, value) end
+
+-- SET_PED_CLOTH_PIN_FRAMES  (0x78C4E9961DB3EB5B)
+-- Old name: SET_PED_CLOTH_PACKAGE_INDEX
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function SetPedClothPinFrames(ped, p1) end
+
+-- SET_PED_COMBAT_ABILITY  (0xC7622C0D36B2FDA8)
+-- abilityLevel:
+-- enum eCombatAbilityLevel
+-- {
+-- 	CAL_POOR,
+-- 	CAL_AVERAGE,
+-- 	CAL_PROFESSIONAL
+-- };
+-- min build: 1207
+---@param ped number
+---@param abilityLevel number
+function SetPedCombatAbility(ped, abilityLevel) end
+
+-- SET_PED_COMBAT_ATTRIBUTES  (0x9F7794730795E019)
+-- attributeIndex: https://alloc8or.re/rdr3/doc/enums/eCombatAttribute.txt
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/COMBAT_ATTRIBUTES
+-- min build: 1207
+---@param ped number
+---@param attributeIndex number
+---@param enabled boolean
+function SetPedCombatAttributes(ped, attributeIndex, enabled) end
+
+-- SET_PED_COMBAT_MOVEMENT  (0x4D9CA1009AFBD057)
+-- 0 - Stationary (Will just stand in place)
+-- 1 - Defensive (Will try to find cover and very likely to blind fire)
+-- 2 - Offensive (Will attempt to charge at enemy but take cover as well)
+-- 3 - Suicidal Offensive (Will try to flank enemy in a suicidal attack)
+-- min build: 1207
+---@param ped number
+---@param combatMovement number
+function SetPedCombatMovement(ped, combatMovement) end
+
+-- SET_PED_COMBAT_RANGE  (0x3C606747B23E497B)
+-- range:
+-- enum eCombatRange
+-- {
+-- 	CR_NEAR,
+-- 	CR_MEDIUM,
+-- 	CR_FAR,
+-- 	CR_VERY_FAR
+-- };
+-- min build: 1207
+---@param ped number
+---@param range number
+function SetPedCombatRange(ped, range) end
+
+-- SET_PED_CONFIG_FLAG  (0x1913FE4CBF41C463)
+-- flagId: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ePedScriptConfigFlags
+-- https://alloc8or.re/rdr3/doc/enums/ePedScriptConfigFlags.txt
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/CPED_CONFIG_FLAGS
+-- min build: 1207
+---@param ped number
+---@param flagId number
+---@param value boolean
+function SetPedConfigFlag(ped, flagId, value) end
+
+-- SET_PED_DEFENSIVE_AREA_DIRECTION  (0x413C6C763A4AFFAD)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+function SetPedDefensiveAreaDirection(ped, p1, p2, p3, p4) end
+
+-- SET_PED_DEFENSIVE_AREA_VOLUME  (0xFC3DB99C8144CD81)
+-- min build: 1207
+---@param ped number
+---@param volume number
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+function SetPedDefensiveAreaVolume(ped, volume, p2, p3, p4) end
+
+-- SET_PED_DESIRED_HEADING  (0xAA5A7ECE2AA8FE70)
+-- min build: 1207
+---@param ped number
+---@param heading number
+function SetPedDesiredHeading(ped, heading) end
+
+-- SET_PED_FIRING_PATTERN  (0x9AC577F5A12AD8A9)
+-- Used in various R* MP & SP Scripts
+-- min build: 1207
+---@param ped number
+---@param patternHash number
+function SetPedFiringPattern(ped, patternHash) end
+
+-- SET_PED_FLEE_ATTRIBUTES  (0x70A2D1137C8ED7C9)
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/FLEE_ATTRIBUTES
+-- 
+-- attributeFlags:
+-- enum eFleeAttribute
+-- {
+-- 	FA_FORCE_EXIT_VEHICLE = (1 << 16),
+-- 	FA_DISABLE_MOUNT_USAGE = (1 << 20),
+-- 	FA_DISABLE_ENTER_VEHICLES = (1 << 22),
+-- };
+-- min build: 1207
+---@param ped number
+---@param attributeFlags number
+---@param enable boolean
+function SetPedFleeAttributes(ped, attributeFlags, enable) end
+
+-- SET_PED_GESTURE_GROUP  (0xDDF803377F94AAA8)
+-- min build: 1207
+---@param ped number
+---@param gesture string
+---@param p2 number
+function SetPedGestureGroup(ped, gesture, p2) end
+
+-- SET_PED_GRAVITY  (0x9FF447B6B6AD960A)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedGravity(ped, toggle) end
+
+-- SET_PED_GROUP_MEMBER_PASSENGER_INDEX  (0x0BDDB8D9EC6BCF3C)
+-- min build: 1207
+---@param ped number
+---@param index number
+function SetPedGroupMemberPassengerIndex(ped, index) end
+
+-- SET_PED_HEARING_RANGE  (0x33A8F7F7D5F7F33C)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedHearingRange(ped, value) end
+
+-- SET_PED_HIGHLY_PERCEPTIVE  (0x52D59AB61DDC05DD)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedHighlyPerceptive(ped, toggle) end
+
+-- SET_PED_ID_RANGE  (0xF107E836A70DCE05)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedIdRange(ped, value) end
+
+-- SET_PED_INJURED_ON_GROUND_BEHAVIOUR  (0xEC4B4B3B9908052A)
+-- min build: 1311
+---@param ped number
+---@param unk number
+function SetPedInjuredOnGroundBehaviour(ped, unk) end
+
+-- SET_PED_INTO_VEHICLE  (0xF75B0D629E1C063D)
+-- Ped: The ped to warp.
+-- vehicle: The vehicle to warp the ped into.
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param seatIndex number
+function SetPedIntoVehicle(ped, vehicle, seatIndex) end
+
+-- SET_PED_KEEP_TASK  (0x971D38760FBC02EF)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedKeepTask(ped, toggle) end
+
+-- SET_PED_LASSO_HOGTIE_FLAG  (0xAE6004120C18DF97)
+-- min build: 1207
+---@param ped number
+---@param flagId number
+---@param value boolean
+function SetPedLassoHogtieFlag(ped, flagId, value) end
+
+-- SET_PED_LEG_IK_MODE  (0xC396F5B86FF9FEBD)
+-- min build: 1207
+---@param ped number
+---@param mode number
+function SetPedLegIkMode(ped, mode) end
+
+-- SET_PED_LOD_MULTIPLIER  (0xDC2C5C242AAC342B)
+-- min build: 1207
+---@param ped number
+---@param multiplier number
+function SetPedLodMultiplier(ped, multiplier) end
+
+-- SET_PED_MAX_HEALTH  (0xF5F6378C4F3419D3)
+-- Sets the maximum health of a ped.
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedMaxHealth(ped, value) end
+
+-- SET_PED_MAX_MOVE_BLEND_RATIO  (0x433083750C5E064A)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedMaxMoveBlendRatio(ped, value) end
+
+-- SET_PED_MAX_TIME_IN_WATER  (0x43C851690662113D)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedMaxTimeInWater(ped, value) end
+
+-- SET_PED_MAX_TIME_UNDERWATER  (0x6BA428C528D9E522)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedMaxTimeUnderwater(ped, value) end
+
+-- SET_PED_MIN_MOVE_BLEND_RATIO  (0x01A898D26E2333DD)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedMinMoveBlendRatio(ped, value) end
+
+-- SET_PED_MODEL_IS_SUPPRESSED  (0xE163A4BCE4DE6F11)
+-- min build: 1207
+---@param model number
+---@param toggle boolean
+function SetPedModelIsSuppressed(model, toggle) end
+
+-- SET_PED_MONEY  (0xA9C8960E8684C1B5)
+-- min build: 1207
+---@param ped number
+---@param amount number
+function SetPedMoney(ped, amount) end
+
+-- SET_PED_MOVE_ANIMS_BLEND_OUT  (0x9E8C908F41584ECD)
+-- min build: 1207
+---@param ped number
+function SetPedMoveAnimsBlendOut(ped) end
+
+-- SET_PED_MOVE_RATE_OVERRIDE  (0x085BF80FA50A39D1)
+-- Min: 0.0f
+-- Max: 1.15f
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedMoveRateOverride(ped, value) end
+
+-- SET_PED_NAME_DEBUG  (0x98EFA132A4117BE1)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param ped number
+---@param name string
+function SetPedNameDebug(ped, name) end
+
+-- SET_PED_NON_CREATION_AREA  (0xEE01041D559983EA)
+-- The distance between these points, is the diagonal of a box (remember it's 3D).
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+function SetPedNonCreationArea(x1, y1, z1, x2, y2, z2) end
+
+-- SET_PED_ONTO_MOUNT  (0x028F76B6E78246EB)
+-- min build: 1207
+---@param ped number
+---@param mount number
+---@param seatIndex number
+---@param p3 boolean
+function SetPedOntoMount(ped, mount, seatIndex, p3) end
+
+-- SET_PED_OWNS_ANIMAL  (0x931B241409216C1F)
+-- min build: 1207
+---@param ped number
+---@param animal number
+---@param p2 boolean
+function SetPedOwnsAnimal(ped, animal, p2) end
+
+-- SET_PED_PANIC_EXIT_SCENARIO  (0xFE07FF6495D52E2A)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function SetPedPanicExitScenario(ped, x, y, z) end
+
+-- SET_PED_RAGDOLL_FORCE_FALL  (0x01F6594B923B9251)
+-- min build: 1207
+---@param ped number
+function SetPedRagdollForceFall(ped) end
+
+-- SET_PED_RAGDOLL_ON_COLLISION  (0xF0A4F1BBF4FA7497)
+-- Causes Ped to ragdoll on collision with any object (e.g Running into trashcan). If applied to player you will sometimes trip on the sidewalk.
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+---@param p2 boolean
+function SetPedRagdollOnCollision(ped, toggle, p2) end
+
+-- SET_PED_RANDOM_COMPONENT_VARIATION  (0xC8A9481A01E63C28)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function SetPedRandomComponentVariation(ped, p1) end
+
+-- SET_PED_RELATIONSHIP_GROUP_DEFAULT_HASH  (0xADB3F206518799E8)
+-- min build: 1207
+---@param ped number
+---@param hash number
+function SetPedRelationshipGroupDefaultHash(ped, hash) end
+
+-- SET_PED_RELATIONSHIP_GROUP_HASH  (0xC80A74AC829DDD92)
+-- min build: 1207
+---@param ped number
+---@param relationshipGroup number
+function SetPedRelationshipGroupHash(ped, relationshipGroup) end
+
+-- SET_PED_RESET_FLAG  (0xC1E8A365BF3B29F2)
+-- Needs to be called every frame
+-- 
+-- flagid:https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ePedScriptResetFlags
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/CPED_RESET_FLAGS
+-- min build: 1207
+---@param ped number
+---@param flagId number
+---@param doReset boolean
+function SetPedResetFlag(ped, flagId, doReset) end
+
+-- SET_PED_SEEING_RANGE  (0xF29CF591C4BF6CEE)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedSeeingRange(ped, value) end
+
+-- SET_PED_SHOOT_RATE  (0x614DA022990752DC)
+-- Params: shootRate = 0 - 1000
+-- min build: 1207
+---@param ped number
+---@param shootRate number
+function SetPedShootRate(ped, shootRate) end
+
+-- SET_PED_SHOULD_PLAY_COMBAT_SCENARIO_EXIT  (0x802092B07E3B1EEA)
+-- lookIntensity: see SET_PED_SHOULD_PLAY_FLEE_SCENARIO_EXIT
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param lookIntensity number
+---@return boolean
+function SetPedShouldPlayCombatScenarioExit(ped, x, y, z, lookIntensity) end
+
+-- SET_PED_SHOULD_PLAY_DIRECTED_NORMAL_SCENARIO_EXIT  (0xEC6935EBE0847B90)
+-- Old name: _SET_PED_SHOULD_PLAY_DIRECTED_SCENARIO_EXIT
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function SetPedShouldPlayDirectedNormalScenarioExit(ped, x, y, z) end
+
+-- SET_PED_SHOULD_PLAY_EMOTIONAL_SCENARIO_EXIT  (0x62FDAD5E01D2DD47)
+-- lookIntensity: see SET_PED_SHOULD_PLAY_FLEE_SCENARIO_EXIT
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param lookIntensity number
+---@param p5 boolean
+---@return boolean
+function SetPedShouldPlayEmotionalScenarioExit(ped, x, y, z, lookIntensity, p5) end
+
+-- SET_PED_SHOULD_PLAY_FLEE_SCENARIO_EXIT  (0xEEED8FAFEC331A70)
+-- lookIntensity:
+-- 0 - REACT_LOOK_NONE
+-- 1 - REACT_LOOK_LOW
+-- 2 - REACT_LOOK_MEDIUM
+-- 3 - REACT_LOOK_HIGH
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param lookIntensity number
+---@return boolean
+function SetPedShouldPlayFleeScenarioExit(ped, x, y, z, lookIntensity) end
+
+-- SET_PED_SHOULD_PLAY_IMMEDIATE_SCENARIO_EXIT  (0xF1C03A5352243A30)
+-- min build: 1207
+---@param ped number
+function SetPedShouldPlayImmediateScenarioExit(ped) end
+
+-- SET_PED_SHOULD_PLAY_NORMAL_SCENARIO_EXIT  (0xA3A9299C4F2ADB98)
+-- min build: 1207
+---@param ped number
+function SetPedShouldPlayNormalScenarioExit(ped) end
+
+-- SET_PED_SHOULD_PLAY_QUICK_SCENARIO_EXIT  (0x463803429297117C)
+-- lookIntensity: see SET_PED_SHOULD_PLAY_FLEE_SCENARIO_EXIT
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param lookIntensity number
+---@param p5 boolean
+---@return boolean
+function SetPedShouldPlayQuickScenarioExit(ped, x, y, z, lookIntensity, p5) end
+
+-- SET_PED_SPHERE_DEFENSIVE_AREA  (0x9D3151A373974804)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+function SetPedSphereDefensiveArea(ped, x, y, z, radius, p5, p6, p7) end
+
+-- SET_PED_STEALTH_MOVEMENT  (0x88CBB5CEB96B7BD2)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+---@param p2 any
+---@param p3 any
+function SetPedStealthMovement(ped, toggle, p2, p3) end
+
+-- SET_PED_SWEAT  (0x27B0405F59637D1F)
+-- min build: 1207
+---@param ped number
+---@param sweat number
+function SetPedSweat(ped, sweat) end
+
+-- SET_PED_TARGET_LOSS_RESPONSE  (0x0703B9079823DA4A)
+-- TLR_ExitTask = 0,
+-- TLR_NeverLoseTarget,
+-- TLR_SearchForTarget
+-- min build: 1207
+---@param ped number
+---@param responseType number
+function SetPedTargetLossResponse(ped, responseType) end
+
+-- SET_PED_TO_INFORM_RESPECTED_FRIENDS  (0x112942C6E708F70B)
+-- min build: 1207
+---@param ped number
+---@param radius number
+---@param maxFriends number
+function SetPedToInformRespectedFriends(ped, radius, maxFriends) end
+
+-- SET_PED_TO_PLAYER_WEAPON_DAMAGE_MODIFIER  (0xD77AE48611B7B10A)
+-- Old name: _SET_PED_DAMAGE_MODIFIER
+-- min build: 1207
+---@param ped number
+---@param damageModifier number
+function SetPedToPlayerWeaponDamageModifier(ped, damageModifier) end
+
+-- SET_PED_TO_RAGDOLL  (0xAE99FB955581844A)
+-- nmTaskMessageParameterName: See physicstasks.ymt. Search for DraggedByCart or 0xD00820D7 (Used in R* SP Script marston8)
+-- min build: 1207
+---@param ped number
+---@param timeMin number
+---@param timeMax number
+---@param ragdollType number
+---@param abortIfInjured boolean
+---@param abortIfDead boolean
+---@param nmTaskMessageParameterName string
+---@return boolean
+function SetPedToRagdoll(ped, timeMin, timeMax, ragdollType, abortIfInjured, abortIfDead, nmTaskMessageParameterName) end
+
+-- SET_PED_TO_RAGDOLL_WITH_FALL  (0xD76632D99E4966C8)
+-- min build: 1207
+---@param ped number
+---@param timeMin number
+---@param timeMax number
+---@param ragdollType number
+---@param falldirX number
+---@param falldirY number
+---@param falldirZ number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@param p11 number
+---@param p12 number
+---@param p13 number
+---@return boolean
+function SetPedToRagdollWithFall(ped, timeMin, timeMax, ragdollType, falldirX, falldirY, falldirZ, p7, p8, p9, p10, p11, p12, p13) end
+
+-- SET_PED_USING_ACTION_MODE  (0xD75ACCF5E0FB5367)
+-- min build: 1207
+---@param ped number
+---@param bActionModeEnabled boolean
+---@param p2 number
+---@param action string
+function SetPedUsingActionMode(ped, bActionModeEnabled, p2, action) end
+
+-- SET_PED_VISUAL_FIELD_CENTER_ANGLE  (0x3B6405E8AB34A907)
+-- min build: 1207
+---@param ped number
+---@param angle number
+function SetPedVisualFieldCenterAngle(ped, angle) end
+
+-- SET_PED_VISUAL_FIELD_MAX_ANGLE  (0x70793BDCA1E854D4)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedVisualFieldMaxAngle(ped, value) end
+
+-- SET_PED_VISUAL_FIELD_MIN_ANGLE  (0x2DB492222FB21E26)
+-- min build: 1207
+---@param ped number
+---@param value number
+function SetPedVisualFieldMinAngle(ped, value) end
+
+-- SET_PED_VISUAL_FIELD_PERIPHERAL_RANGE  (0x9C74B0BC831B753A)
+-- min build: 1207
+---@param ped number
+---@param range number
+function SetPedVisualFieldPeripheralRange(ped, range) end
+
+-- SET_PED_WETNESS_ENABLED_THIS_FRAME  (0xB5485E4907B53019)
+-- combined with PED::SET_PED_WETNESS_HEIGHT(), this native makes the ped drenched in water up to the height specified in the other function
+-- min build: 1207
+---@param ped number
+function SetPedWetnessEnabledThisFrame(ped) end
+
+-- SET_PED_WETNESS_HEIGHT  (0x44CB6447D2571AA0)
+-- It adds the wetness level to the player clothing/outfit. As if player just got out from water surface.
+-- min build: 1207
+---@param ped number
+---@param height number
+function SetPedWetnessHeight(ped, height) end
+
+-- SET_POP_CONTROL_SPHERE_THIS_FRAME  (0xD8C3BE3EE94CAF2D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function SetPopControlSphereThisFrame(p0, p1, p2, p3, p4) end
+
+-- SET_RAGDOLL_BLOCKING_FLAGS  (0x26695EC767728D84)
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/RAGDOLL_BLOCKING_FLAGS
+-- 
+-- flags:
+-- enum eRagdollBlockingFlags
+-- {
+-- 	RBF_BULLET_IMPACT = (1 << 0),
+-- 	RBF_VEHICLE_IMPACT = (1 << 1),
+-- 	RBF_FIRE = (1 << 2),
+-- 	RBF_ELECTROCUTION = (1 << 3),
+-- 	RBF_PLAYER_IMPACT = (1 << 4),
+-- 	RBF_EXPLOSION = (1 << 5),
+-- 	RBF_IMPACT_OBJECT = (1 << 6),
+-- 	RBF_MELEE = (1 << 7),
+-- 	RBF_RUBBER_BULLET = (1 << 8),
+-- 	RBF_FALLING = (1 << 9),
+-- 	RBF_WATER_JET = (1 << 10),
+-- 	RBF_DROWNING = (1 << 11),
+-- 	RBF_0x9F52E2C4 = (1 << 12),
+-- 	RBF_PLAYER_BUMP = (1 << 13),
+-- 	RBF_PLAYER_RAGDOLL_BUMP = (1 << 14),
+-- 	RBF_PED_RAGDOLL_BUMP = (1 << 15),
+-- 	RBF_VEHICLE_GRAB = (1 << 16),
+-- 	RBF_SMOKE_GRENADE = (1 << 17),
+-- 	RBF_HORSE_BUMP = (1 << 18),
+-- 	RBF_ACTIVATE_ON_COLLISION = (1 << 19)
+-- };
+-- min build: 1207
+---@param ped number
+---@param flags number
+function SetRagdollBlockingFlags(ped, flags) end
+
+-- SET_RELATIONSHIP_BETWEEN_GROUPS  (0xBF25EB89375A37AD)
+-- min build: 1207
+---@param relationship number
+---@param group1 number
+---@param group2 number
+function SetRelationshipBetweenGroups(relationship, group1, group2) end
+
+-- SET_SCENARIO_PED_DENSITY_MULTIPLIER_THIS_FRAME  (0x7A556143A1C03898)
+-- min build: 1207
+---@param multiplier number
+function SetScenarioPedDensityMultiplierThisFrame(multiplier) end
+
+-- SPAWNPOINTS_CANCEL_SEARCH  (0xFEE4A5459472A9F8)
+-- min build: 1207
+function SpawnpointsCancelSearch() end
+
+-- SPAWNPOINTS_GET_NUM_SEARCH_RESULTS  (0xA635C11B8C44AFC2)
+-- min build: 1207
+---@return number
+function SpawnpointsGetNumSearchResults() end
+
+-- SPAWNPOINTS_GET_SEARCH_RESULT  (0x280C7E3AC7F56E90)
+-- min build: 1207
+---@param randomInt number
+---@return number
+---@return any
+---@return number
+function SpawnpointsGetSearchResult(randomInt) end
+
+-- SPAWNPOINTS_GET_SEARCH_RESULT_FLAGS  (0xB782F8238512BAD5)
+-- min build: 1207
+---@param p0 any
+---@return any
+function SpawnpointsGetSearchResultFlags(p0) end
+
+-- SPAWNPOINTS_IS_SEARCH_ACTIVE  (0x3C67506996001F5E)
+-- min build: 1207
+---@return boolean
+function SpawnpointsIsSearchActive() end
+
+-- SPAWNPOINTS_IS_SEARCH_COMPLETE  (0xA586FBEB32A53DBB)
+-- min build: 1207
+---@return boolean
+function SpawnpointsIsSearchComplete() end
+
+-- SPAWNPOINTS_IS_SEARCH_FAILED  (0xF445DE8DA80A1792)
+-- min build: 1207
+---@return boolean
+function SpawnpointsIsSearchFailed() end
+
+-- SPAWNPOINTS_START_SEARCH  (0x2DF9038C90AD5264)
+-- Params: p4 = 35.f, duration = 5000 in R* Scripts
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param width number
+---@param p4 number
+---@param spawnpointsFlag number
+---@param p6 number
+---@param duration number
+---@param p8 number
+function SpawnpointsStartSearch(x, y, z, width, p4, spawnpointsFlag, p6, duration, p8) end
+
+-- SPAWNPOINTS_START_SEARCH_IN_ANGLED_AREA  (0xB2AFF10216DEFA2F)
+-- Searching area between coords 1 and 2
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param width number
+---@param spawnpointsFlag number
+---@param p8 number
+---@param duration number
+---@param p10 number
+function SpawnpointsStartSearchInAngledArea(x1, y1, z1, x2, y2, z2, width, spawnpointsFlag, p8, duration, p10) end
+
+-- SPECIAL_FUNCTION_DO_NOT_USE  (0xF9ACF4A08098EA25)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function SpecialFunctionDoNotUse(ped, p1) end
+
+-- TIME_SINCE_PED_LAST_SHOT  (0x285D36C5C72B0569)
+-- Returns time since the specified ped last shot, in seconds. (fPlayerJustShotTime)
+-- min build: 1207
+---@param ped number
+---@return number
+function TimeSincePedLastShot(ped) end
+
+-- TOGGLE_SCENARIO_PED_COWER_IN_PLACE  (0x9A77DFD295E29B09)
+-- If toggle is true, when the ped is using a scenario he will stop it and become scared
+-- If toggle is false, the ped will not be scared anymore and continue his scenario
+-- 
+-- Old name: _SET_PED_SCARED_WHEN_USING_SCENARIO
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function ToggleScenarioPedCowerInPlace(ped, toggle) end
+
+-- WAS_PED_SKELETON_UPDATED  (0x11B499C1E0FF8559)
+-- Despite this function's name, it simply returns whether the specified handle is a Ped.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function WasPedSkeletonUpdated(ped) end

--- a/.luals/redm-natives/PERSCHAR.lua
+++ b/.luals/redm-natives/PERSCHAR.lua
@@ -1,0 +1,296 @@
+---@meta
+
+-- RDR3 namespace: PERSCHAR -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x08FC896D2CB31FCC  (0x08FC896D2CB31FCC)
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+---@return number
+function N_0x08FC896D2CB31FCC(p0, p1) end
+
+-- _0x0B3A99AB6713AA52  (0x0B3A99AB6713AA52)
+-- min build: 1207
+---@param p0 any
+function N_0x0B3A99AB6713AA52(p0) end
+
+-- _0x112DDF56300BC6E5  (0x112DDF56300BC6E5)
+-- Returns the PersChar index of the persCharHash passed
+-- min build: 1207
+---@param persCharHash number
+---@return number
+function N_0x112DDF56300BC6E5(persCharHash) end
+
+-- _0x2E957AA81F2C61C9  (0x2E957AA81F2C61C9)
+-- min build: 1207
+function N_0x2E957AA81F2C61C9() end
+
+-- _0x406808610220405B  (0x406808610220405B)
+-- min build: 1207
+---@param p0 any
+function N_0x406808610220405B(p0) end
+
+-- _0x4AFC7288C77238B3  (0x4AFC7288C77238B3)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x4AFC7288C77238B3(p0) end
+
+-- _0x4F81EAD1DE8FA19B  (0x4F81EAD1DE8FA19B)
+-- min build: 1207
+---@param persChar number
+function N_0x4F81EAD1DE8FA19B(persChar) end
+
+-- _0x535A66AAD2BF68F9  (0x535A66AAD2BF68F9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x535A66AAD2BF68F9(p0, p1) end
+
+-- _0x59C7AD6FEA2AC449  (0x59C7AD6FEA2AC449)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x59C7AD6FEA2AC449(p0, p1, p2, p3) end
+
+-- _0x5EE6FCCC9C832CA2  (0x5EE6FCCC9C832CA2)
+-- min build: 1207
+---@param p0 any
+---@return vector3
+function N_0x5EE6FCCC9C832CA2(p0) end
+
+-- _0x63AA2B8EB087886A  (0x63AA2B8EB087886A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x63AA2B8EB087886A(p0, p1) end
+
+-- _0x669C25840C6F7AE2  (0x669C25840C6F7AE2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x669C25840C6F7AE2(p0, p1) end
+
+-- _0x6759BEE6762E140B  (0x6759BEE6762E140B)
+-- min build: 1207
+---@param persChar number
+function N_0x6759BEE6762E140B(persChar) end
+
+-- _0x69786495C92A3044  (0x69786495C92A3044)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x69786495C92A3044(p0) end
+
+-- _0x70605812ABC9FF0F  (0x70605812ABC9FF0F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x70605812ABC9FF0F(p0, p1) end
+
+-- _0x8AE4EFA464DAE42D  (0x8AE4EFA464DAE42D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8AE4EFA464DAE42D(p0, p1) end
+
+-- _0x8BC555034A5A5E8C  (0x8BC555034A5A5E8C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8BC555034A5A5E8C(p0, p1) end
+
+-- _0x92690B0822493CE0  (0x92690B0822493CE0)
+-- min build: 1207
+function N_0x92690B0822493CE0() end
+
+-- _0x94995829ED15A598  (0x94995829ED15A598)
+-- min build: 1207
+---@param p0 any
+---@return vector3
+function N_0x94995829ED15A598(p0) end
+
+-- _0x9C7F95946E304778  (0x9C7F95946E304778)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x9C7F95946E304778(p0, p1) end
+
+-- _0xA2B18FF8D39F6D87  (0xA2B18FF8D39F6D87)
+-- min build: 1207
+---@param p0 any
+function N_0xA2B18FF8D39F6D87(p0) end
+
+-- _0xA4DCB3F0DD7488BD  (0xA4DCB3F0DD7488BD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xA4DCB3F0DD7488BD(p0, p1, p2, p3, p4) end
+
+-- _0xA8120EBEAF290C7A  (0xA8120EBEAF290C7A)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xA8120EBEAF290C7A(p0) end
+
+-- _0xA8C406C2A56EDC16  (0xA8C406C2A56EDC16)
+-- min build: 1207
+---@param persChar number
+function N_0xA8C406C2A56EDC16(persChar) end
+
+-- _0xB173599D61FAEB31  (0xB173599D61FAEB31)
+-- min build: 1207
+function N_0xB173599D61FAEB31() end
+
+-- _0xB65E7F733956CF25  (0xB65E7F733956CF25)
+-- min build: 1207
+---@param persChar number
+function N_0xB65E7F733956CF25(persChar) end
+
+-- _0xBB68908CD11AEBDC  (0xBB68908CD11AEBDC)
+-- min build: 1207
+---@param persChar number
+function N_0xBB68908CD11AEBDC(persChar) end
+
+-- _0xCEB40B678E403759  (0xCEB40B678E403759)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xCEB40B678E403759(p0) end
+
+-- _0xD4B614179BCD0654  (0xD4B614179BCD0654)
+-- min build: 1207
+---@param p0 any
+function N_0xD4B614179BCD0654(p0) end
+
+-- _0xD95D777F828B2BBB  (0xD95D777F828B2BBB)
+-- min build: 1207
+---@param p0 any
+function N_0xD95D777F828B2BBB(p0) end
+
+-- _0xE0E65E0D261F7507  (0xE0E65E0D261F7507)
+-- min build: 1207
+---@param p0 any
+function N_0xE0E65E0D261F7507(p0) end
+
+-- _0xE4C51A8A3BD1664C  (0xE4C51A8A3BD1664C)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE4C51A8A3BD1664C(p0) end
+
+-- _0xEC254C2C9B0F08F1  (0xEC254C2C9B0F08F1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xEC254C2C9B0F08F1(p0, p1) end
+
+-- _0xEFC5C6670E0B99BA  (0xEFC5C6670E0B99BA)
+-- min build: 1207
+function N_0xEFC5C6670E0B99BA() end
+
+-- _0xF8DE7154F7D1458F  (0xF8DE7154F7D1458F)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF8DE7154F7D1458F(p0) end
+
+-- _0xFCC6DB8DBE709BC8  (0xFCC6DB8DBE709BC8)
+-- min build: 1207
+---@param persChar number
+function N_0xFCC6DB8DBE709BC8(persChar) end
+
+-- _CREATE_PERSISTENT_CHARACTER  (0x4F76E3676583D951)
+-- min build: 1207
+---@param hash number
+---@return number
+function _CreatePersistentCharacter(hash) end
+
+-- _DELETE_PERSCHAR  (0xFC77C5B44D5FF7C0)
+-- min build: 1207
+---@param persChar number
+function _DeletePerschar(persChar) end
+
+-- _FORCE_DESPAWN_PERSCHAR  (0x7B204F88F6C3D287)
+-- min build: 1207
+---@param persChar number
+function _ForceDespawnPerschar(persChar) end
+
+-- _FORCE_SPAWN_PERSCHAR  (0x0CADC3A977997472)
+-- min build: 1207
+---@param persChar number
+---@param p1 boolean
+---@return number
+function _ForceSpawnPerschar(persChar, p1) end
+
+-- _GET_PERSCHAR_INDEX_FROM_PED_INDEX  (0x32A1E3B83D501096)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPerscharIndexFromPedIndex(ped) end
+
+-- _GET_PERSCHAR_MODEL_NAME  (0xA00DF706C60173D1)
+-- min build: 1207
+---@param persCharHash number
+---@return number
+function _GetPerscharModelName(persCharHash) end
+
+-- _GET_PERSCHAR_OUTFIT  (0xDC9655D47DEC0353)
+-- min build: 1207
+---@param persCharHash number
+---@return number
+function _GetPerscharOutfit(persCharHash) end
+
+-- _GET_PERSCHAR_PED_INDEX  (0x31C70A716CAE1FEE)
+-- min build: 1207
+---@param persChar number
+---@return number
+function _GetPerscharPedIndex(persChar) end
+
+-- _IS_PERSISTENT_CHARACTER_DEAD  (0xEB98B38CA60742D7)
+-- min build: 1207
+---@param persChar number
+---@return boolean
+function _IsPersistentCharacterDead(persChar) end
+
+-- _IS_PERSISTENT_CHARACTER_VALID  (0x800DF3FC913355F3)
+-- min build: 1207
+---@param persChar number
+---@return boolean
+function _IsPersistentCharacterValid(persChar) end
+
+-- _RESET_PERSCHAR_SCHEDULE  (0x8B44273A92CD406C)
+-- min build: 1207
+---@param persCharHash number
+function _ResetPerscharSchedule(persCharHash) end
+
+-- _RETASK_PERSISTENT_CHARACTER  (0x631CD2D77FDC0316)
+-- min build: 1207
+---@param persChar number
+function _RetaskPersistentCharacter(persChar) end
+
+-- _REVIVE_PERSCHAR  (0x49A8C2CD97815215)
+-- min build: 1207
+---@param persChar number
+---@return boolean
+function _RevivePerschar(persChar) end
+
+-- _SET_PERSCHAR_OUTFIT  (0x2DF89CD2ED1D0BDE)
+-- min build: 1207
+---@param persCharHash number
+---@param outfit number
+function _SetPerscharOutfit(persCharHash, outfit) end
+
+-- _SET_PERSCHAR_SCHEDULE  (0x187D65F3AEC5D679)
+-- min build: 1207
+---@param persCharHash number
+---@param schedule string
+function _SetPerscharSchedule(persCharHash, schedule) end

--- a/.luals/redm-natives/PERSISTENCE.lua
+++ b/.luals/redm-natives/PERSISTENCE.lua
@@ -1,0 +1,147 @@
+---@meta
+
+-- RDR3 namespace: PERSISTENCE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x065887B694359799  (0x065887B694359799)
+-- min build: 1207
+---@param p0 any
+function N_0x065887B694359799(p0) end
+
+-- _0x1F56FB3FDB4EAF65  (0x1F56FB3FDB4EAF65)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x1F56FB3FDB4EAF65(p0) end
+
+-- _0x291CC21D1FB6790E  (0x291CC21D1FB6790E)
+-- min build: 1207
+---@param p0 any
+function N_0x291CC21D1FB6790E(p0) end
+
+-- _0x2E545965DF98D476  (0x2E545965DF98D476)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2E545965DF98D476(p0) end
+
+-- _0x3CA5E58C9731A16B  (0x3CA5E58C9731A16B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3CA5E58C9731A16B(p0, p1) end
+
+-- _0x5A79220F6D38D7C3  (0x5A79220F6D38D7C3)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x5A79220F6D38D7C3(p0) end
+
+-- _0x66DAA3A9274E8E82  (0x66DAA3A9274E8E82)
+-- _PERSISTENCE_*
+-- min build: 1232
+function N_0x66DAA3A9274E8E82() end
+
+-- _0x7A1BD123E5CDB6E5  (0x7A1BD123E5CDB6E5)
+-- min build: 1207
+function N_0x7A1BD123E5CDB6E5() end
+
+-- _0x8DE104BEC243A73B  (0x8DE104BEC243A73B)
+-- min build: 1207
+---@param p0 any
+function N_0x8DE104BEC243A73B(p0) end
+
+-- _0xB03140014ACA6C40  (0xB03140014ACA6C40)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xB03140014ACA6C40(p0, p1) end
+
+-- _0xBA2C49EA6A8D24FF  (0xBA2C49EA6A8D24FF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0xBA2C49EA6A8D24FF(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xCFDA2518F322D836  (0xCFDA2518F322D836)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xCFDA2518F322D836(p0) end
+
+-- _0xDC0A1F0ECEC9F0C0  (0xDC0A1F0ECEC9F0C0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDC0A1F0ECEC9F0C0(p0, p1) end
+
+-- _0xE225CEF1901F6108  (0xE225CEF1901F6108)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE225CEF1901F6108(p0, p1) end
+
+-- _0xF5622FA6ACFCA7DB  (0xF5622FA6ACFCA7DB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xF5622FA6ACFCA7DB(p0, p1) end
+
+-- _0xFC9806DA9A460093  (0xFC9806DA9A460093)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+function N_0xFC9806DA9A460093(x1, y1, z1, x2, y2, z2) end
+
+-- _PERSISTENCE_IS_SCENARIO_MARKED_AS_LOOTED  (0xFB7CF1DE938A3E22)
+-- min build: 1207
+---@param scenario number
+---@return boolean
+function _PersistenceIsScenarioMarkedAsLooted(scenario) end
+
+-- _PERSISTENCE_IS_SCENARIO_MARKED_AS_LOOTED_AT_COORDS  (0xB6E1A185C2B9319A)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function _PersistenceIsScenarioMarkedAsLootedAtCoords(x, y, z) end
+
+-- _PERSISTENCE_IS_SCENARIO_MARKED_AS_LOOTED_AT_COORDS_WITH_MODEL  (0x188313616D184213)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param model number
+---@return boolean
+function _PersistenceIsScenarioMarkedAsLootedAtCoordsWithModel(x, y, z, model) end
+
+-- _PERSISTENCE_REFRESH_TOWN_VOLUME  (0xEFB5F34CC0953B27)
+-- Only used in R* script long_update.ysc in script function REFRESH_CLOSEST_TOWN
+-- min build: 1207
+---@param volume number
+function _PersistenceRefreshTownVolume(volume) end
+
+-- PERSISTENCE_ADD_SCENARIO_LOOTED  (0x8245C1F3262F4AC2)
+-- min build: 1207
+---@param scenario number
+function PersistenceAddScenarioLooted(scenario) end
+
+-- PERSISTENCE_REMOVE_ALL_ENTITIES_IN_AREA  (0x9D16896F0DBE78A2)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+function PersistenceRemoveAllEntitiesInArea(x, y, z, radius) end

--- a/.luals/redm-natives/PHYSICS.lua
+++ b/.luals/redm-natives/PHYSICS.lua
@@ -1,0 +1,571 @@
+---@meta
+
+-- RDR3 namespace: PHYSICS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0CB16D05E03FB525  (0x0CB16D05E03FB525)
+-- min build: 1207
+---@param p0 any
+function N_0x0CB16D05E03FB525(p0) end
+
+-- _0x1D97DA8ACB5D2582  (0x1D97DA8ACB5D2582)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+function N_0x1D97DA8ACB5D2582(ropeId, p1) end
+
+-- _0x21D0890D88DFB0B0  (0x21D0890D88DFB0B0)
+-- min build: 1207
+---@param ropeId number
+---@param p1 boolean
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+function N_0x21D0890D88DFB0B0(ropeId, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- _0x31160EC47E7C9549  (0x31160EC47E7C9549)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x31160EC47E7C9549(p0, p1) end
+
+-- _0x32F4DBFDFCCCC735  (0x32F4DBFDFCCCC735)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x32F4DBFDFCCCC735(p0, p1, p2) end
+
+-- _0x3900491C0D61ED4B  (0x3900491C0D61ED4B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3900491C0D61ED4B(p0, p1) end
+
+-- _0x423C6B1F3786D28B  (0x423C6B1F3786D28B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x423C6B1F3786D28B(p0, p1) end
+
+-- _0x461FCBDEB4D06717  (0x461FCBDEB4D06717)
+-- min build: 1207
+---@param ropeId number
+---@param p1 boolean
+function N_0x461FCBDEB4D06717(ropeId, p1) end
+
+-- _0x483D4E917B0D35A9  (0x483D4E917B0D35A9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x483D4E917B0D35A9(p0, p1) end
+
+-- _0x522FA3F490E2F7AC  (0x522FA3F490E2F7AC)
+-- min build: 1207
+---@param ropeId number
+---@param p1 any
+---@param p2 any
+function N_0x522FA3F490E2F7AC(ropeId, p1, p2) end
+
+-- _0x5A989B7EE3672A56  (0x5A989B7EE3672A56)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x5A989B7EE3672A56(p0, p1) end
+
+-- _0x5BD7457221CC5FF4  (0x5BD7457221CC5FF4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x5BD7457221CC5FF4(p0, p1) end
+
+-- _0x5E981C764DF33117  (0x5E981C764DF33117)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x5E981C764DF33117(p0, p1) end
+
+-- _0x69C810B72291D831  (0x69C810B72291D831)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0x69C810B72291D831(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x6EA0E93CFFA472CC  (0x6EA0E93CFFA472CC)
+-- min build: 1207
+---@param p0 any
+function N_0x6EA0E93CFFA472CC(p0) end
+
+-- _0x751DF00EEFF122E3  (0x751DF00EEFF122E3)
+-- min build: 1207
+---@param p0 any
+function N_0x751DF00EEFF122E3(p0) end
+
+-- _0x76BAD9D538BCA1AA  (0x76BAD9D538BCA1AA)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+function N_0x76BAD9D538BCA1AA(ropeId, p1) end
+
+-- _0x814D453FCFDF119F  (0x814D453FCFDF119F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x814D453FCFDF119F(p0, p1, p2) end
+
+-- _0x8D59079C37C21D78  (0x8D59079C37C21D78)
+-- _ROPE_SET_*
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+function N_0x8D59079C37C21D78(ropeId, p1) end
+
+-- _0x8EEDFD8921389928  (0x8EEDFD8921389928)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function N_0x8EEDFD8921389928(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _0x9C24846D0A4A2776  (0x9C24846D0A4A2776)
+-- min build: 1207
+---@param p0 any
+function N_0x9C24846D0A4A2776(p0) end
+
+-- _0xB40EA9E0D2E2F7F3  (0xB40EA9E0D2E2F7F3)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+function N_0xB40EA9E0D2E2F7F3(ropeId, p1) end
+
+-- _0xB7469CB9AC3C0FD4  (0xB7469CB9AC3C0FD4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function N_0xB7469CB9AC3C0FD4(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0xBB3E9B073E66C3C9  (0xBB3E9B073E66C3C9)
+-- min build: 1207
+---@param ropeId number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+function N_0xBB3E9B073E66C3C9(ropeId, p1, p2, p3, p4) end
+
+-- _0xBDDA142759307528  (0xBDDA142759307528)
+-- min build: 1207
+---@param p0 any
+function N_0xBDDA142759307528(p0) end
+
+-- _0xC64E7A62632AD2FE  (0xC64E7A62632AD2FE)
+-- min build: 1207
+---@param ropeId number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function N_0xC64E7A62632AD2FE(ropeId, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0xC89E7410A93AC19A  (0xC89E7410A93AC19A)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+function N_0xC89E7410A93AC19A(ropeId, p1) end
+
+-- _0xD699E688B49C0FD2  (0xD699E688B49C0FD2)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+function N_0xD699E688B49C0FD2(ropeId, p1, p2, p3, p4) end
+
+-- _0xDEDE679ED29DD4E7  (0xDEDE679ED29DD4E7)
+-- min build: 1207
+---@param ropeId number
+---@param p1 boolean
+function N_0xDEDE679ED29DD4E7(ropeId, p1) end
+
+-- _0xE54BF2CE6C7D23A9  (0xE54BF2CE6C7D23A9)
+-- min build: 1207
+---@param ropeId number
+---@param p1 number
+---@param x number
+---@param y number
+---@param z number
+function N_0xE54BF2CE6C7D23A9(ropeId, p1, x, y, z) end
+
+-- _0xEAF529446488EB18  (0xEAF529446488EB18)
+-- min build: 1207
+---@param p0 any
+function N_0xEAF529446488EB18(p0) end
+
+-- _0xF1EA2A881EB7F2CD  (0xF1EA2A881EB7F2CD)
+-- min build: 1207
+---@param ropeId number
+---@param p1 boolean
+function N_0xF1EA2A881EB7F2CD(ropeId, p1) end
+
+-- _0xF27F1A8DE4F50A1B  (0xF27F1A8DE4F50A1B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0xF27F1A8DE4F50A1B(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xF8CA39D5C0D1D9A1  (0xF8CA39D5C0D1D9A1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xF8CA39D5C0D1D9A1(p0, p1) end
+
+-- _0xFB9153A54AC713E8  (0xFB9153A54AC713E8)
+-- min build: 1207
+---@param ropeId number
+---@param p1 boolean
+function N_0xFB9153A54AC713E8(ropeId, p1) end
+
+-- _ADD_ROPE_2  (0xE9C59F6809373A99)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param length number
+---@param ropeType number
+---@param isNetworked boolean
+---@param p9 number
+---@param p10 number
+---@return number
+function _AddRope2(x, y, z, rotX, rotY, rotZ, length, ropeType, isNetworked, p9, p10) end
+
+-- _ATTACH_ENTITES_TO_ROPE_3  (0xE9CD9A67834985A7)
+-- min build: 1207
+---@param ropeId number
+---@param entity1 number
+---@param entity2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 any
+---@param p10 any
+function _AttachEntitesToRope3(ropeId, entity1, entity2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- _ATTACH_ENTITIES_TO_ROPE_2  (0x462FF2A432733A44)
+-- Attaches a rope to two entities: binds two bones from two entities; one entity can be an object, i.e. a suspension point, the other an NPC bone
+-- min build: 1207
+---@param ropeId number
+---@param entity1 number
+---@param entity2 number
+---@param ent1X number
+---@param ent1Y number
+---@param ent1Z number
+---@param ent2X number
+---@param ent2Y number
+---@param ent2Z number
+---@param boneName1 string
+---@param boneName2 string
+function _AttachEntitiesToRope2(ropeId, entity1, entity2, ent1X, ent1Y, ent1Z, ent2X, ent2Y, ent2Z, boneName1, boneName2) end
+
+-- _BREAK_ROPE  (0x4CFA2B7FAE115ECB)
+-- ropeTop returns top half of rope, ropeBottom returns bottom half of rope
+-- min build: 1207
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param p6 number
+---@return number
+---@return number
+---@return number
+function _BreakRope(offsetX, offsetY, offsetZ, p6) end
+
+-- _CREATE_ROPE_WINDING_ABILITY  (0x3C6490D940FF5D0B)
+-- Combining this with ADD_ROPE enables winding
+-- p1: mostly empty (0)
+-- ropeModelType: RB_L_Wrist02, RB_R_Wrist02, ropeAttach, noose01x_Rope_03, SKEL_Neck0, SKEL_L_FOOT, SKEL_Neck1, Root_s_meatbit_Chunck_Xlarge01x
+-- _CREATE_*
+-- min build: 1207
+---@param ropeId number
+---@param p1 string
+---@param ropeModelType string
+---@param length number
+---@param p4 boolean
+function _CreateRopeWindingAbility(ropeId, p1, ropeModelType, length, p4) end
+
+-- _HITCH_HORSE  (0x06AADE17334F7A40)
+-- min build: 1207
+---@param horse number
+---@param x number
+---@param y number
+---@param z number
+function _HitchHorse(horse, x, y, z) end
+
+-- _IS_ROPE_ATTACHED_TO_ENTITY  (0x9B4F7E3E4F9C77B3)
+-- min build: 1207
+---@param ropeId number
+---@param entity number
+---@return boolean
+function _IsRopeAttachedToEntity(ropeId, entity) end
+
+-- _IS_ROPE_BROKEN  (0x79C2BEC82CFD7F7F)
+-- min build: 1207
+---@param ropeId number
+---@return boolean
+function _IsRopeBroken(ropeId) end
+
+-- _RELEASE_ROPE  (0x6076213101A47B3B)
+-- min build: 1207
+---@param ropeId number
+function _ReleaseRope(ropeId) end
+
+-- _ROPE_CHANGE_VISIBILITY  (0x7A54D82227A139DB)
+-- min build: 1207
+---@param visible boolean
+---@return number
+function _RopeChangeVisibility(visible) end
+
+-- _ROPE_GET_BREAKER_OF_ROPE  (0xEE360CFC80C8B2BC)
+-- min build: 1311
+---@param ropeId number
+---@return number
+function _RopeGetBreakerOfRope(ropeId) end
+
+-- _ROPE_GET_FORCED_LENGTH  (0x3D69537039F8D824)
+-- min build: 1207
+---@param ropeId number
+---@return number
+function _RopeGetForcedLength(ropeId) end
+
+-- _ROPE_SET_LENGTH_CHANGE_RATE  (0x1FC92BDBA1106BD2)
+-- Sets the rate used by START_ROPE_WINDING and START_ROPE_UNWINDING_FRONT to change the rope's forced length.
+-- ROPE_FORCE_LENGTH directly writes the forced length instead.
+-- min build: 1207
+---@param ropeId number
+---@param lengthChangeRate number
+function _RopeSetLengthChangeRate(ropeId, lengthChangeRate) end
+
+-- _START_ROPE_UNWINDING_BACK  (0x00F611A794A3C36E)
+-- min build: 1207
+---@param ropeId number
+function _StartRopeUnwindingBack(ropeId) end
+
+-- _STOP_ROPE_UNWINDING_BACK  (0x10DAA76CB8A201A1)
+-- min build: 1207
+---@param ropeId number
+function _StopRopeUnwindingBack(ropeId) end
+
+-- _UNHITCH_HORSE  (0x0348469DAA17576C)
+-- min build: 1207
+---@param horse number
+function _UnhitchHorse(horse) end
+
+-- ACTIVATE_PHYSICS  (0x710311ADF0E20730)
+-- min build: 1207
+---@param entity number
+function ActivatePhysics(entity) end
+
+-- ADD_ROPE  (0xE832D760399EB220)
+-- There are 19 types of rope, from type = 0 to type = 18
+-- Rope definitions are stored in ropedata.xml
+-- Rope types 0, 15 and 18 have proper physics for hanging objects (taut, do not sag, small to medium diameter, good aspect for a rope)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param length number
+---@param ropeType number
+---@param maxLength number
+---@param minLength number
+---@param p10 number
+---@param p11 boolean
+---@param p12 boolean
+---@param rigid boolean
+---@param p14 number
+---@param breakWhenShot boolean
+---@param p17 boolean
+---@return number
+---@return any
+function AddRope(x, y, z, rotX, rotY, rotZ, length, ropeType, maxLength, minLength, p10, p11, p12, rigid, p14, breakWhenShot, p17) end
+
+-- ATTACH_ENTITIES_TO_ROPE  (0x3D95EC8B6D940AC3)
+-- Attaches entity 1 to entity 2.
+-- If you use a boneName (p12/p13) make sure boneId (p15/p16) is set to -1.
+-- min build: 1207
+---@param ropeId number
+---@param entity1 number
+---@param entity2 number
+---@param ent1X number
+---@param ent1Y number
+---@param ent1Z number
+---@param ent2X number
+---@param ent2Y number
+---@param ent2Z number
+---@param length number
+---@param alwaysZero1 number
+---@param alwaysZero2 number
+---@param boneName1 string
+---@param boneName2 string
+---@param p14 boolean
+---@param boneId1 number
+---@param boneId2 number
+---@param alwaysZero3 number
+---@param alwaysZero4 number
+---@param p19 boolean
+---@param p20 boolean
+function AttachEntitiesToRope(ropeId, entity1, entity2, ent1X, ent1Y, ent1Z, ent2X, ent2Y, ent2Z, length, alwaysZero1, alwaysZero2, boneName1, boneName2, p14, boneId1, boneId2, alwaysZero3, alwaysZero4, p19, p20) end
+
+-- BREAK_ENTITY_GLASS  (0x2E648D16F6E308F3)
+-- min build: 1207
+---@param entity number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 any
+---@param p10 boolean
+function BreakEntityGlass(entity, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- DELETE_CHILD_ROPE  (0xAA5D6B1888E4DB20)
+-- min build: 1207
+---@param ropeId number
+function DeleteChildRope(ropeId) end
+
+-- DELETE_ROPE  (0x52B4829281364649)
+-- min build: 1207
+---@return number
+function DeleteRope() end
+
+-- DETACH_ROPE_FROM_ENTITY  (0xBCF3026912A8647D)
+-- min build: 1207
+---@param ropeId number
+---@param entity number
+function DetachRopeFromEntity(ropeId, entity) end
+
+-- DOES_ROPE_EXIST  (0xFD5448BE3111ED96)
+-- min build: 1207
+---@param ropeId number
+---@return boolean
+function DoesRopeExist(ropeId) end
+
+-- GET_ROPE_LAST_VERTEX_COORD  (0x21BB0FBD3E217C2D)
+-- min build: 1207
+---@param ropeId number
+---@return vector3
+function GetRopeLastVertexCoord(ropeId) end
+
+-- GET_ROPE_VERTEX_COORD  (0xEA61CA8E80F09E4D)
+-- min build: 1207
+---@param ropeId number
+---@param vertex number
+---@return vector3
+function GetRopeVertexCoord(ropeId, vertex) end
+
+-- GET_ROPE_VERTEX_COUNT  (0x3655F544CD30F0B5)
+-- min build: 1207
+---@param ropeId number
+---@return number
+function GetRopeVertexCount(ropeId) end
+
+-- ROPE_DRAW_SHADOW_ENABLED  (0xF159A63806BB5BA8)
+-- min build: 1207
+---@param toggle boolean
+---@return number
+function RopeDrawShadowEnabled(toggle) end
+
+-- ROPE_FORCE_LENGTH  (0xD009F759A723DB1B)
+-- Forces a rope to a certain length.
+-- min build: 1207
+---@param ropeId number
+---@param length number
+function RopeForceLength(ropeId, length) end
+
+-- ROPE_SET_UPDATE_ORDER  (0xDC57A637A20006ED)
+-- min build: 1207
+---@param ropeId number
+---@param p1 any
+function RopeSetUpdateOrder(ropeId, p1) end
+
+-- SET_DAMPING  (0xEEA3B200A6FEB65B)
+-- min build: 1207
+---@param entity number
+---@param vertex number
+---@param value number
+function SetDamping(entity, vertex, value) end
+
+-- SET_DISABLE_BREAKING  (0x5CEC1A84620E7D5B)
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function SetDisableBreaking(object, toggle) end
+
+-- SET_DISABLE_FRAG_DAMAGE  (0x01BA3AED21C16CFB)
+-- min build: 1207
+---@param object number
+---@param toggle boolean
+function SetDisableFragDamage(object, toggle) end
+
+-- START_ROPE_UNWINDING_FRONT  (0x538D1179EC1AA9A9)
+-- min build: 1207
+---@param ropeId number
+function StartRopeUnwindingFront(ropeId) end
+
+-- START_ROPE_WINDING  (0x1461C72C889E343E)
+-- min build: 1207
+---@param ropeId number
+function StartRopeWinding(ropeId) end
+
+-- STOP_ROPE_UNWINDING_FRONT  (0xFFF3A50779EFBBB3)
+-- min build: 1207
+---@param ropeId number
+function StopRopeUnwindingFront(ropeId) end
+
+-- STOP_ROPE_WINDING  (0xCB2D4AB84A19AA7C)
+-- min build: 1207
+---@param ropeId number
+function StopRopeWinding(ropeId) end

--- a/.luals/redm-natives/PLAYER.lua
+++ b/.luals/redm-natives/PLAYER.lua
@@ -1,0 +1,2864 @@
+---@meta
+
+-- RDR3 namespace: PLAYER -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x00B156AFEBCC5AE0  (0x00B156AFEBCC5AE0)
+-- min build: 1207
+---@param p0 any
+function N_0x00B156AFEBCC5AE0(p0) end
+
+-- _0x03B4B759A8990505  (0x03B4B759A8990505)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x03B4B759A8990505(p0) end
+
+-- _0x06E1FB78B1E59CA5  (0x06E1FB78B1E59CA5)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x06E1FB78B1E59CA5(ped, p1) end
+
+-- _0x086549F3B0381CB1  (0x086549F3B0381CB1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x086549F3B0381CB1(p0, p1) end
+
+-- _0x0869D499A7848309  (0x0869D499A7848309)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function N_0x0869D499A7848309(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0x08E22898A6AF4905  (0x08E22898A6AF4905)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x08E22898A6AF4905(p0, p1) end
+
+-- _0x0B7803F6F7BB43E0  (0x0B7803F6F7BB43E0)
+-- Hardcoded to return zero/false.
+-- min build: 1207
+---@return any
+function N_0x0B7803F6F7BB43E0() end
+
+-- _0x0F4EAF69DA41AF43  (0x0F4EAF69DA41AF43)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x0F4EAF69DA41AF43(p0) end
+
+-- _0x0F9CF06986300875  (0x0F9CF06986300875)
+-- min build: 1207
+---@param p0 any
+function N_0x0F9CF06986300875(p0) end
+
+-- _0x107F2A66E1C4C83A  (0x107F2A66E1C4C83A)
+-- min build: 1207
+---@param p0 any
+function N_0x107F2A66E1C4C83A(p0) end
+
+-- _0x113EF458AB6CDA67  (0x113EF458AB6CDA67)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x113EF458AB6CDA67(p0, p1) end
+
+-- _0x12E09E278C6C29B7  (0x12E09E278C6C29B7)
+-- min build: 1207
+---@param p0 any
+function N_0x12E09E278C6C29B7(p0) end
+
+-- _0x14E57F88BA0A07FC  (0x14E57F88BA0A07FC)
+-- min build: 1207
+---@param location number
+function N_0x14E57F88BA0A07FC(location) end
+
+-- _0x19B2C7A6C34FAD54  (0x19B2C7A6C34FAD54)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x19B2C7A6C34FAD54(p0, p1) end
+
+-- _0x1AD8AD999C27F44A  (0x1AD8AD999C27F44A)
+-- min build: 1311
+---@param p0 any
+function N_0x1AD8AD999C27F44A(p0) end
+
+-- _0x1D256EED194F5B58  (0x1D256EED194F5B58)
+-- min build: 1207
+---@param p0 any
+function N_0x1D256EED194F5B58(p0) end
+
+-- _0x1E8099F449ABB0BA  (0x1E8099F449ABB0BA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x1E8099F449ABB0BA(p0) end
+
+-- _0x1F488807BC8E0630  (0x1F488807BC8E0630)
+-- _RESET_PLAYER_A* - _RESET_PLAYER_I*
+-- min build: 1207
+---@param player number
+function N_0x1F488807BC8E0630(player) end
+
+-- _0x1FDA57E8908F2609  (0x1FDA57E8908F2609)
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param useSteerassist boolean
+function N_0x1FDA57E8908F2609(player, ped, useSteerassist) end
+
+-- _0x21091B4BEB6376EE  (0x21091B4BEB6376EE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x21091B4BEB6376EE(p0) end
+
+-- _0x216BC0D3D2E413D2  (0x216BC0D3D2E413D2)
+-- min build: 1207
+---@param player number
+---@param p1 any
+function N_0x216BC0D3D2E413D2(player, p1) end
+
+-- _0x22B3CABEDDB538B2  (0x22B3CABEDDB538B2)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function N_0x22B3CABEDDB538B2(player, p1) end
+
+-- _0x263D69767F76059C  (0x263D69767F76059C)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function N_0x263D69767F76059C(player, p1) end
+
+-- _0x2BB8D58E88777499  (0x2BB8D58E88777499)
+-- min build: 1207
+---@param p0 any
+function N_0x2BB8D58E88777499(p0) end
+
+-- _0x2BEED53B912537D0  (0x2BEED53B912537D0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x2BEED53B912537D0(p0, p1, p2) end
+
+-- _0x2C2D287748E8E9B7  (0x2C2D287748E8E9B7)
+-- min build: 1207
+---@param p0 boolean
+function N_0x2C2D287748E8E9B7(p0) end
+
+-- _0x2E1ABE627C95ED9B  (0x2E1ABE627C95ED9B)
+-- min build: 1207
+---@return any
+function N_0x2E1ABE627C95ED9B() end
+
+-- _0x2E67707BEC52CA4B  (0x2E67707BEC52CA4B)
+-- min build: 1207
+---@param p0 any
+function N_0x2E67707BEC52CA4B(p0) end
+
+-- _0x310CE349E0C0EC4B  (0x310CE349E0C0EC4B)
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param p2 number
+function N_0x310CE349E0C0EC4B(player, ped, p2) end
+
+-- _0x325434C68358D282  (0x325434C68358D282)
+-- Only used in script function UPDATE_PLAYER_JUST_DIED_STATE
+-- The value passed to this native in the scripts is whether a global UGC mission is active or not
+-- min build: 1207
+---@param toggle boolean
+function N_0x325434C68358D282(toggle) end
+
+-- _0x35A33783EC3C3448  (0x35A33783EC3C3448)
+-- min build: 1311
+---@param p0 any
+function N_0x35A33783EC3C3448(p0) end
+
+-- _0x3A8611BD7BDE84F7  (0x3A8611BD7BDE84F7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3A8611BD7BDE84F7(p0, p1) end
+
+-- _0x3ACAC8832E77BC93  (0x3ACAC8832E77BC93)
+-- Used in script function INIT_DEADEYE_SLOWDOWN
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function N_0x3ACAC8832E77BC93(player, p1) end
+
+-- _0x3AD212429E095EFB  (0x3AD212429E095EFB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3AD212429E095EFB(p0, p1) end
+
+-- _0x3B296934DB026873  (0x3B296934DB026873)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3B296934DB026873(p0, p1) end
+
+-- _0x3BB84F812E052C90  (0x3BB84F812E052C90)
+-- min build: 1207
+---@param p0 any
+function N_0x3BB84F812E052C90(p0) end
+
+-- _0x3C4AE8506638C7E2  (0x3C4AE8506638C7E2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3C4AE8506638C7E2(p0, p1) end
+
+-- _0x3D9DA5C9EFD20D88  (0x3D9DA5C9EFD20D88)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3D9DA5C9EFD20D88(p0, p1) end
+
+-- _0x3DAABE78A23694BC  (0x3DAABE78A23694BC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3DAABE78A23694BC(p0, p1) end
+
+-- _0x45EF176B532CA851  (0x45EF176B532CA851)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x45EF176B532CA851(p0, p1) end
+
+-- _0x497A18F8F88AA9D8  (0x497A18F8F88AA9D8)
+-- min build: 1207
+function N_0x497A18F8F88AA9D8() end
+
+-- _0x4D1699543B1C023C  (0x4D1699543B1C023C)
+-- _SET_SPECIAL_ABILITY_*
+-- min build: 1207
+---@param player number
+---@param p1 number
+function N_0x4D1699543B1C023C(player, p1) end
+
+-- _0x4DBC4873707E8FD6  (0x4DBC4873707E8FD6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x4DBC4873707E8FD6(p0, p1, p2, p3) end
+
+-- _0x4EC8BE63B8A5D4EF  (0x4EC8BE63B8A5D4EF)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function N_0x4EC8BE63B8A5D4EF(player, p1) end
+
+-- _0x4F0D2256AAE94EDA  (0x4F0D2256AAE94EDA)
+-- min build: 1207
+---@param p0 number
+function N_0x4F0D2256AAE94EDA(p0) end
+
+-- _0x51139D8C17B16FBC  (0x51139D8C17B16FBC)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x51139D8C17B16FBC(p0) end
+
+-- _0x57028FD99886F6F9  (0x57028FD99886F6F9)
+-- _IS_PLAYER_D* - _IS_PLAYER_F*
+-- min build: 1232
+---@return boolean
+function N_0x57028FD99886F6F9() end
+
+-- _0x570A13A4CA2799BB  (0x570A13A4CA2799BB)
+-- Used in script function INIT_DEADEYE_SLOWDOWN
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function N_0x570A13A4CA2799BB(player, p1) end
+
+-- _0x57D9991DC1334151  (0x57D9991DC1334151)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x57D9991DC1334151(p0) end
+
+-- _0x585CE159DB46FADB  (0x585CE159DB46FADB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x585CE159DB46FADB(p0, p1) end
+
+-- _0x5B7B97E99F84138B  (0x5B7B97E99F84138B)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x5B7B97E99F84138B(p0) end
+
+-- _0x5C2E5E3CAEEB1F58  (0x5C2E5E3CAEEB1F58)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x5C2E5E3CAEEB1F58(p0, p1, p2) end
+
+-- _0x621D1B289CAF5978  (0x621D1B289CAF5978)
+-- _IS_PLAYER_S* - _IS_PLAYER_T*
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x621D1B289CAF5978(player) end
+
+-- _0x628E742FE1F79C4A  (0x628E742FE1F79C4A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x628E742FE1F79C4A(p0, p1) end
+
+-- _0x65887EAC535A0B0C  (0x65887EAC535A0B0C)
+-- min build: 1207
+---@param p0 any
+function N_0x65887EAC535A0B0C(p0) end
+
+-- _0x67659A8F248E0141  (0x67659A8F248E0141)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x67659A8F248E0141(p0, p1) end
+
+-- _0x6852288340B43239  (0x6852288340B43239)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x6852288340B43239(p0, p1) end
+
+-- _0x694FFA4308060CD1  (0x694FFA4308060CD1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x694FFA4308060CD1(p0, p1) end
+
+-- _0x6C54E69516CC56BD  (0x6C54E69516CC56BD)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x6C54E69516CC56BD(p0) end
+
+-- _0x6EDB5D08CB03E763  (0x6EDB5D08CB03E763)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x6EDB5D08CB03E763(p0, p1) end
+
+-- _0x73EB2EF2E92D23BF  (0x73EB2EF2E92D23BF)
+-- min build: 1207
+---@return boolean
+function N_0x73EB2EF2E92D23BF() end
+
+-- _0x747257807B8721CE  (0x747257807B8721CE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x747257807B8721CE(p0, p1) end
+
+-- _0x76F7E1BCD623A429  (0x76F7E1BCD623A429)
+-- min build: 1207
+---@param p0 any
+function N_0x76F7E1BCD623A429(p0) end
+
+-- _0x77B0B6D17A3AC9AA  (0x77B0B6D17A3AC9AA)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x77B0B6D17A3AC9AA(p0, p1) end
+
+-- _0x77E83C315A3B31CA  (0x77E83C315A3B31CA)
+-- min build: 1207
+---@param p0 any
+function N_0x77E83C315A3B31CA(p0) end
+
+-- _0x818241B3EDA84191  (0x818241B3EDA84191)
+-- _SET_PLAYER_DAMAGE_* - _SET_PLAYER_DEFENSE_*
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+function N_0x818241B3EDA84191(player, p1) end
+
+-- _0x83C989D5B5B5B466  (0x83C989D5B5B5B466)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x83C989D5B5B5B466(p0, p1) end
+
+-- _0x84481018E668E1B8  (0x84481018E668E1B8)
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param p2 any
+function N_0x84481018E668E1B8(player, ped, p2) end
+
+-- _0x8591EE69CC3ED257  (0x8591EE69CC3ED257)
+-- SET_PLAYER_S/T*
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function N_0x8591EE69CC3ED257(player, toggle) end
+
+-- _0x8702D9150D9FBB3D  (0x8702D9150D9FBB3D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x8702D9150D9FBB3D(p0, p1) end
+
+-- _0x8F44EBB3BA8F6D44  (0x8F44EBB3BA8F6D44)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8F44EBB3BA8F6D44(p0, p1) end
+
+-- _0x9044835BE9D9DBFE  (0x9044835BE9D9DBFE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9044835BE9D9DBFE(p0, p1) end
+
+-- _0x9073EC5456651A90  (0x9073EC5456651A90)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9073EC5456651A90(p0, p1) end
+
+-- _0x908D4B72854C8F62  (0x908D4B72854C8F62)
+-- min build: 1207
+---@param p0 any
+function N_0x908D4B72854C8F62(p0) end
+
+-- _0x927861B2C08DBEA5  (0x927861B2C08DBEA5)
+-- _GET_A* - _GET_C*
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x927861B2C08DBEA5(player) end
+
+-- _0x929DDD5538F3DF1F  (0x929DDD5538F3DF1F)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+function N_0x929DDD5538F3DF1F(p0, p1) end
+
+-- _0x93624B36E8851B42  (0x93624B36E8851B42)
+-- min build: 1207
+---@param player number
+function N_0x93624B36E8851B42(player) end
+
+-- _0x9422743A5BA50E10  (0x9422743A5BA50E10)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x9422743A5BA50E10(p0) end
+
+-- _0x9461A8FAB0378E5B  (0x9461A8FAB0378E5B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9461A8FAB0378E5B(p0, p1) end
+
+-- _0x9AFCF9FE1884BF62  (0x9AFCF9FE1884BF62)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9AFCF9FE1884BF62(p0, p1) end
+
+-- _0x9FC5A003FB76EDBD  (0x9FC5A003FB76EDBD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9FC5A003FB76EDBD(p0, p1) end
+
+-- _0xA28056CD1B04B250  (0xA28056CD1B04B250)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function N_0xA28056CD1B04B250(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- _0xA342495F93B7B838  (0xA342495F93B7B838)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA342495F93B7B838(p0, p1) end
+
+-- _0xA54000D4BFD90BDE  (0xA54000D4BFD90BDE)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xA54000D4BFD90BDE(p0) end
+
+-- _0xAAED694CE814817F  (0xAAED694CE814817F)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xAAED694CE814817F(p0) end
+
+-- _0xB15CD2F9932C9AB5  (0xB15CD2F9932C9AB5)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xB15CD2F9932C9AB5(p0) end
+
+-- _0xB331D8A73F9D2BDF  (0xB331D8A73F9D2BDF)
+-- _IS_PLAYER_I* - _IS_PLAYER_P*
+-- min build: 1207
+---@param player number
+---@return boolean
+---@return any
+function N_0xB331D8A73F9D2BDF(player) end
+
+-- _0xBA5CA1FEB5DE0DF6  (0xBA5CA1FEB5DE0DF6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0xBA5CA1FEB5DE0DF6(p0, p1, p2, p3, p4, p5) end
+
+-- _0xBB6EA5D59E926095  (0xBB6EA5D59E926095)
+-- NPEW__ENUM__EMOTE_CATEGORY_INVALID = -1
+-- NPEW__ENUM__EMOTE_CATEGORY_ACTIONS
+-- NPEW__ENUM__EMOTE_CATEGORY_ANTAGONIZE
+-- NPEW__ENUM__EMOTE_CATEGORY_REACTIONS
+-- NPEW__ENUM__EMOTE_CATEGORY_GREET
+-- NPEW__ENUM__NUM_EMOTE_CATEGORIES
+-- NPEW__ENUM__NUM_DISPLAY_TEXTURES
+-- min build: 1207
+---@param category number
+---@param emote number
+function N_0xBB6EA5D59E926095(category, emote) end
+
+-- _0xBD96185264DDAAEA  (0xBD96185264DDAAEA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBD96185264DDAAEA(p0, p1) end
+
+-- _0xBED386157F65942C  (0xBED386157F65942C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBED386157F65942C(p0, p1) end
+
+-- _0xBEFED69CE8317F91  (0xBEFED69CE8317F91)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xBEFED69CE8317F91(p0) end
+
+-- _0xC177C827CEFC0AA4  (0xC177C827CEFC0AA4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xC177C827CEFC0AA4(p0, p1) end
+
+-- _0xC4873B053054C04B  (0xC4873B053054C04B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function N_0xC4873B053054C04B(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0xC58CE6824E604DEC  (0xC58CE6824E604DEC)
+-- min build: 1207
+---@param p0 any
+function N_0xC58CE6824E604DEC(p0) end
+
+-- _0xC71D07C96946E263  (0xC71D07C96946E263)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xC71D07C96946E263(p0, p1) end
+
+-- _0xC74EB3F2EC169F6B  (0xC74EB3F2EC169F6B)
+-- Hardcoded to return zero/false.
+-- min build: 1232
+---@param p0 any
+---@return any
+function N_0xC74EB3F2EC169F6B(p0) end
+
+-- _0xC900A465364A85D6  (0xC900A465364A85D6)
+-- min build: 1207
+---@param player number
+function N_0xC900A465364A85D6(player) end
+
+-- _0xC93A9A45430D484E  (0xC93A9A45430D484E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC93A9A45430D484E(p0) end
+
+-- _0xCA59808E51FD67C4  (0xCA59808E51FD67C4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCA59808E51FD67C4(p0, p1) end
+
+-- _0xCB0B9506BC91E441  (0xCB0B9506BC91E441)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCB0B9506BC91E441(p0, p1) end
+
+-- _0xCB61A63AA53D7D22  (0xCB61A63AA53D7D22)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCB61A63AA53D7D22(p0, p1) end
+
+-- _0xCD7CA3013FD12749  (0xCD7CA3013FD12749)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+function N_0xCD7CA3013FD12749(p0, p1) end
+
+-- _0xCDDD4B74660E2335  (0xCDDD4B74660E2335)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xCDDD4B74660E2335(p0, p1, p2) end
+
+-- _0xCEDC16930526F728  (0xCEDC16930526F728)
+-- min build: 1207
+---@param p0 any
+function N_0xCEDC16930526F728(p0) end
+
+-- _0xCFB2EED4FCB7BD77  (0xCFB2EED4FCB7BD77)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xCFB2EED4FCB7BD77(p0, p1, p2) end
+
+-- _0xD1F6B912785BFD35  (0xD1F6B912785BFD35)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xD1F6B912785BFD35(p0) end
+
+-- _0xD288E02E364972D2  (0xD288E02E364972D2)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD288E02E364972D2(p0, p1, p2) end
+
+-- _0xDA9D7BE231FE865F  (0xDA9D7BE231FE865F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xDA9D7BE231FE865F(p0, p1, p2) end
+
+-- _0xDAB6A2FC56B7DE65  (0xDAB6A2FC56B7DE65)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xDAB6A2FC56B7DE65(p0) end
+
+-- _0xDD33A82352C4652F  (0xDD33A82352C4652F)
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param p2 number
+function N_0xDD33A82352C4652F(player, ped, p2) end
+
+-- _0xE1D356F5A66D0FFA  (0xE1D356F5A66D0FFA)
+-- min build: 1232
+---@param emote number
+---@return boolean
+function N_0xE1D356F5A66D0FFA(emote) end
+
+-- _0xE50A67C33514A390  (0xE50A67C33514A390)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xE50A67C33514A390(p0, p1) end
+
+-- _0xE7F8707269544B29  (0xE7F8707269544B29)
+-- _IS_PLAYER_A* - _IS_PLAYER_BE*
+-- min build: 1207
+---@param player number
+---@param ped number
+---@return boolean
+function N_0xE7F8707269544B29(player, ped) end
+
+-- _0xE956C2340A76272E  (0xE956C2340A76272E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE956C2340A76272E(p0) end
+
+-- _0xEACEBAAE0A33FB3F  (0xEACEBAAE0A33FB3F)
+-- min build: 1207
+---@param p0 any
+function N_0xEACEBAAE0A33FB3F(p0) end
+
+-- _0xEBB6E27AC2FF32DA  (0xEBB6E27AC2FF32DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xEBB6E27AC2FF32DA(p0, p1, p2, p3, p4) end
+
+-- _0xEBFF94328FF7A18A  (0xEBFF94328FF7A18A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xEBFF94328FF7A18A(p0, p1) end
+
+-- _0xF21C7A3F3FFBA629  (0xF21C7A3F3FFBA629)
+-- _CLEAR_FACIAL_* - _CLEAR_PED_BLOOD*
+-- min build: 1207
+---@param player number
+function N_0xF21C7A3F3FFBA629(player) end
+
+-- _0xF4CB347D7B5EB0FD  (0xF4CB347D7B5EB0FD)
+-- min build: 1207
+---@return any
+function N_0xF4CB347D7B5EB0FD() end
+
+-- _0xF993373285053D77  (0xF993373285053D77)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xF993373285053D77(p0, p1, p2) end
+
+-- _0xFA437FA0738C370C  (0xFA437FA0738C370C)
+-- Params: p1, p2, p3, p4 = 1.f, 0, 0, 0 in R* Scripts
+-- _SPECIAL_ABILITY*
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function N_0xFA437FA0738C370C(player, p1, p2, p3, p4) end
+
+-- _0xFA7DAAE3959E6C7B  (0xFA7DAAE3959E6C7B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFA7DAAE3959E6C7B(p0, p1) end
+
+-- _ADD_AMBIENT_PLAYER_INTERACTIVE_FOCUS_PRESET  (0x3946FC742AC305CD)
+-- Associates a specific "interactive focus mode preset" between a player and a ped, with a specified location and target entity.
+-- To access all available presets, refer to the file located at:
+-- `\update_1.rpf\common\data\interactive_focus_mode_presets.meta`
+-- Video: https://imgur.com/gallery/0x3946fc742ac305cd-1uJIRNr
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param preset string
+---@param x number
+---@param y number
+---@param z number
+---@param targetEntity number
+---@param name string
+function _AddAmbientPlayerInteractiveFocusPreset(player, ped, preset, x, y, z, targetEntity, name) end
+
+-- _ADD_AMBIENT_PLAYER_INTERACTIVE_FOCUS_PRESET_AT_COORDS  (0xD48227263E3D06AE)
+-- Adds an "interactive focus mode preset" between a player and a specific set of coordinates with a target entity.
+-- To access all available presets, refer to the file located at:
+-- `\update_1.rpf\common\data\interactive_focus_mode_presets.meta`
+-- 
+-- Related function:
+-- - _DISABLE_PLAYER_INTERACTIVE_FOCUS_PRESET (0xC67A4910425F11F1)
+-- 
+-- Video: https://imgur.com/gallery/0xd48227263e3d06ae-SUJhMoA
+-- min build: 1232
+---@param player number
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param preset string
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param targetEntity number
+---@param name string
+function _AddAmbientPlayerInteractiveFocusPresetAtCoords(player, x1, y1, z1, preset, x2, y2, z2, targetEntity, name) end
+
+-- _ADD_PLAYER_AS_FOLLOW_TARGET  (0xAC22AA6DF4D1C1DE)
+-- Used in script function: NET_AUTO_FOLLOW_UPDATE_LEADER_VALUES
+-- followMode:
+-- HORSEFOLLOWMODE_AUTO = 0,
+-- HORSEFOLLOWMODE_SIDE_ONLY,
+-- HORSEFOLLOWMODE_BEHIND_ONLY,
+-- HORSEFOLLOWMODE_BEHIND_AND_SIDE,
+-- HORSEFOLLOWMODE_BEHIND_CLOSE
+-- followPriority:
+-- HORSEFOLLOWPRIORITY_STEER_ASSIST = 0,
+-- HORSEFOLLOWPRIORITY_AMBIENT,
+-- HORSEFOLLOWPRIORITY_NORMAL,
+-- HORSEFOLLOWPRIORITY_HIGH
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param p2 number
+---@param p3 number
+---@param followMode number
+---@param followPriority number
+---@param p6 boolean
+function _AddPlayerAsFollowTarget(player, ped, p2, p3, followMode, followPriority, p6) end
+
+-- _CLEAR_BOUNTY_TARGET  (0x8F2A81C09DA9124A)
+-- min build: 1207
+---@param player number
+function _ClearBountyTarget(player) end
+
+-- _CLEAR_DEADEYE_AURA_EFFECT_INTENSITY  (0x0E9057A9DA78D0F8)
+-- Clears the intensity of aura effects applied to entities for a specific player in Deadeye mode based on a flag parameter. This function is used to reset any intensity modifications set by `PLAYER::_SET_DEADEYE_ENTITY_AURA_EFFECT_INTENSITY` (0x131E294EF60160DF), restoring affected entities' aura intensity to their default state.
+-- 
+-- Example usage:
+-- PLAYER::_CLEAR_DEADEYE_AURA_EFFECT_INTENSITY(PLAYER::PLAYER_ID(),2);
+-- Clears all aura intensity adjustments for the player based on the specified flag, restoring entities' intensity to default values.
+-- 
+-- Video: https://imgur.com/gallery/0x0e9057a9da78d0f8-ctZPFmz
+-- min build: 1207
+---@param player number
+---@param flag number
+function _ClearDeadeyeAuraEffectIntensity(player, flag) end
+
+-- _CLEAR_PED_EAGLE_EYE_TRAILS_FOR_PLAYER  (0xE5D3EB37ABC1EB03)
+-- Clears all eagle eye trails that were registered for peds (maybe also other entities?) associated with specified player.
+-- Video: https://imgur.com/a/uvCTPei
+-- _CLEAR_FACIAL_* - _CLEAR_PED_BLOOD*
+-- min build: 1207
+---@param player number
+function _ClearPedEagleEyeTrailsForPlayer(player) end
+
+-- _DISABLE_PLAYER_INTERACTIVE_FOCUS_PRESET  (0xC67A4910425F11F1)
+-- Disables the previously set "interactive focus mode preset" for a given player.
+-- Example usage:
+-- PLAYER::_DISABLE_PLAYER_INTERACTIVE_FOCUS_PRESET(Player::PLAYER_ID(), "qadr_");
+-- 
+-- This example disables the preset named "qadr_" for the current player, effectively removing the previously established interactive focus mode.
+-- Refer to `_ADD_AMBIENT_PLAYER_INTERACTIVE_FOCUS_PRESET(0x3946FC742AC305CD)` to understand how presets are added.
+-- Video: https://imgur.com/gallery/0x3946fc742ac305cd-1uJIRNr
+-- min build: 1207
+---@param player number
+---@param name string
+function _DisablePlayerInteractiveFocusPreset(player, name) end
+
+-- _EAGLE_EYE_ADD_FOCUS_SKILL  (0xBC02B3D151D3859F)
+-- Enable/disable the focus skill on given entity in eagle eye mode, which makes the entity glow up.
+-- Video: https://imgur.com/a/e1ph146
+-- min build: 1207
+---@param entity number
+---@param enable boolean
+function _EagleEyeAddFocusSkill(entity, enable) end
+
+-- _EAGLE_EYE_ARE_ALL_TRAILS_HIDDEN  (0xA62BBAAE67A05BB0)
+-- Retrieves whether all trails are currently hidden during Eagle Eye mode for the specified player.
+-- Images:
+-- - https://imgur.com/gallery/0x330ca55a3647fa1c-0xa62bbaae67a05bb0-Lpzt2Yi
+-- - https://imgur.com/gallery/0x330ca55a3647fa1c-0xa62bbaae67a05bb0-yLA6GBk
+-- min build: 1207
+---@param player number
+---@return boolean
+function _EagleEyeAreAllTrailsHidden(player) end
+
+-- _EAGLE_EYE_CAN_PLAYER_FOCUS_ON_TRACK  (0x1DA5C5B0923E1B85)
+-- Checks if the player can focus on tracks while in Eagle Eye mode. Returns true if the player is able to focus on a track, otherwise false.
+-- Example usage:
+-- if (PLAYER::_EAGLE_EYE_CAN_PLAYER_FOCUS_ON_TRACK(PLAYER::PLAYER_ID())) {
+--     // Perform actions when the player is focusing on a track in Eagle Eye mode
+-- }
+-- Video: https://imgur.com/gallery/0x1da5c5b0923e1b85-M8AyOsu
+-- min build: 1207
+---@param player number
+---@return boolean
+function _EagleEyeCanPlayerFocusOnTrack(player) end
+
+-- _EAGLE_EYE_DISABLE_TRACKING_TRAIL  (0x40AB73092C95B5F5)
+-- min build: 1207
+---@param entity number
+---@param trail string
+---@param p2 any
+---@param p3 any
+function _EagleEyeDisableTrackingTrail(entity, trail, p2, p3) end
+
+-- _EAGLE_EYE_GET_TRACKED_PED_ID  (0x3813E11A378958A5)
+-- Retrieves the ID of the ped that the specified player is currently tracking while in Eagle Eye mode.
+-- Images:
+-- - https://imgur.com/gallery/0x3813e11a378958a5-CHoJVRu
+-- - https://imgur.com/gallery/0x3813e11a378958a5-reK5IXt
+-- min build: 1207
+---@param player number
+---@return number
+function _EagleEyeGetTrackedPedId(player) end
+
+-- _EAGLE_EYE_REMOVE_PARTICLE_FX_FROM_ENTITY  (0xDC5E09D012D759C4)
+-- Clears yellow indicator particle effects from given entity.
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param p2 number
+function _EagleEyeRemoveParticleFxFromEntity(entity1, entity2, p2) end
+
+-- _EAGLE_EYE_SET_COLOR  (0x2C41D93F550D5E37)
+-- false: default eagleeye color
+-- true: green eagleeye color
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+---@return any
+function _EagleEyeSetColor(player, p1) end
+
+-- _EAGLE_EYE_SET_CUSTOM_DISTANCE  (0x907B16B3834C69E2)
+-- min build: 1207
+---@param entity number
+---@param distance number
+function _EagleEyeSetCustomDistance(entity, distance) end
+
+-- _EAGLE_EYE_SET_DRAIN_RATE_MODIFIER  (0xE0D6C2A146A5C993)
+-- min build: 1207
+---@param player number
+---@param modifier number
+function _EagleEyeSetDrainRateModifier(player, modifier) end
+
+-- _EAGLE_EYE_SET_FOCUS_ON_ASSOCIATED_CLUE_TRAIL  (0x2AF423D6ECB2C485)
+-- min build: 1207
+---@param player number
+---@param linkedWaypointPed number
+function _EagleEyeSetFocusOnAssociatedClueTrail(player, linkedWaypointPed) end
+
+-- _EAGLE_EYE_SET_HIDE_ALL_TRAILS  (0x330CA55A3647FA1C)
+-- Sets whether all trails are hidden during Eagle Eye mode.
+-- Example usage:
+-- Hide all trails in Eagle Eye mode for the current player
+-- PLAYER::_EAGLE_EYE_SET_HIDE_ALL_TRAILS(PLAYER::PLAYER_ID(), true);
+-- 
+-- Show all trails in Eagle Eye mode
+-- PLAYER::_EAGLE_EYE_SET_HIDE_ALL_TRAILS(PLAYER::PLAYER_ID(), false);
+-- Images:
+-- - https://imgur.com/gallery/0x330ca55a3647fa1c-0xa62bbaae67a05bb0-Lpzt2Yi
+-- - https://imgur.com/gallery/0x330ca55a3647fa1c-0xa62bbaae67a05bb0-yLA6GBk
+-- min build: 1207
+---@param player number
+---@param hideTrails boolean
+function _EagleEyeSetHideAllTrails(player, hideTrails) end
+
+-- _EAGLE_EYE_SET_PARTICLE_FX_TO_ENTITY  (0x6ECFC621A168424C)
+-- Adds yellow indicator particle effects to given entity.
+-- Image: https://imgur.com/a/cbldo35
+-- min build: 1207
+---@param entity1 number
+---@param entity2 number
+---@param p2 number
+---@param heading number
+function _EagleEyeSetParticleFxToEntity(entity1, entity2, p2, heading) end
+
+-- _EAGLE_EYE_SET_PLUS_FLAG_DISABLED  (0xCE285A4413B00B7F)
+-- Sets the behavior of sprinting while the eagle eye feature is active, determining whether sprinting cancels the effect based on the specified parameter.
+-- disabled = true: sprinting will cancel the eagle eye effect when active. If the player starts sprinting, the Eagleeye feature will be deactivated.
+-- disabled = false: sprinting will not cancel the eagle eye effect. The player can sprint while keeping the Eagleeye feature active.
+-- min build: 1207
+---@param player number
+---@param disabled boolean
+function _EagleEyeSetPlusFlagDisabled(player, disabled) end
+
+-- _EAGLE_EYE_SET_RANGE  (0x22C8B10802301381)
+-- min build: 1207
+---@param player number
+---@param range number
+function _EagleEyeSetRange(player, range) end
+
+-- _EAGLE_EYE_SET_TRACKING_UPGRADE  (0xDFC85C5199045026)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function _EagleEyeSetTrackingUpgrade(player, p1) end
+
+-- _EAGLE_EYE_SET_TRACKING_UPGRADE_2  (0x6FA957D1B55941C1)
+-- min build: 1311
+---@param player number
+---@param p1 number
+function _EagleEyeSetTrackingUpgrade2(player, p1) end
+
+-- _ENABLE_CUSTOM_DEADEYE_ABILITY  (0x95EE1DEE1DCD9070)
+-- min build: 1207
+---@param player number
+---@param enable boolean
+function _EnableCustomDeadeyeAbility(player, enable) end
+
+-- _ENABLE_EAGLEEYE  (0xA63FCAD3A6FEC6D2)
+-- (Un)lock Eagle Eye functionality
+-- min build: 1207
+---@param player number
+---@param enable boolean
+function _EnableEagleeye(player, enable) end
+
+-- _FORCE_REST_SCENARIO  (0xE5A3DD2FF84E1A4B)
+-- min build: 1232
+---@param toggle boolean
+function _ForceRestScenario(toggle) end
+
+-- _FORMAT_PLAYER_NAME_STRING  (0x5B6193813E03E4E9)
+-- min build: 1207
+---@param string string
+---@return string
+function _FormatPlayerNameString(string) end
+
+-- _GET_ACTIVE_HORSE_FOR_PLAYER  (0x46FA0AE18F4C7FA9)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetActiveHorseForPlayer(player) end
+
+-- _GET_AI_PLAYER_DEFENSE_MODIFIER_AGAINST_AI  (0x2E78D822208E740A)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetAiPlayerDefenseModifierAgainstAi(player) end
+
+-- _GET_CONSTRUCTED_DISCOVERED_CHARACTER_NAME  (0x8E84119A23C16623)
+-- p0: mostly Ped Hashes
+-- min build: 1207
+---@param p0 number
+---@param model boolean
+---@param outfit boolean
+---@return number
+function _GetConstructedDiscoveredCharacterName(p0, model, outfit) end
+
+-- _GET_DEADEYE_ABILITY_DEPLETION_DELAY  (0xE92261BD28C0878F)
+-- Returns the depletion delay value for the Deadeye ability that was previously set using `PLAYER::_SET_DEADEYE_ABILITY_DEPLETION_DELAY` (0x870634493CB4372C). This function provides a float value representing the delay, allowing the game to retrieve the current Deadeye depletion setting for a specific player.
+-- 
+-- Example usage:
+-- 
+-- float depletionDelay = PLAYER::_GET_DEADEYE_ABILITY_DEPLETION_DELAY(PLAYER::PLAYER_ID());
+-- Video: https://imgur.com/gallery/0xe92261bd28c0878f-TAqX0fg
+-- min build: 1207
+---@param player number
+---@return number
+function _GetDeadeyeAbilityDepletionDelay(player) end
+
+-- _GET_DEADEYE_ABILITY_LEVEL  (0xCCE7C695C164C35F)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetDeadeyeAbilityLevel(player) end
+
+-- _GET_HAS_PLAYER_DISCOVERED_CHARACTER_NAME_SP  (0x0772F87D7B07719A)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param discoveryHash number
+---@return boolean
+function _GetHasPlayerDiscoveredCharacterNameSp(player, p1, discoveryHash) end
+
+-- _GET_IS_DEADEYE_TAGGING_ENABLED  (0x32348719DCED2969)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _GetIsDeadeyeTaggingEnabled(player) end
+
+-- _GET_NUM_DEADEYE_MARKS_ON_PED  (0x27AD7162D3FED01E)
+-- Retrieves the number of marks placed on a PED when Deadeye mode is active for the specified player.
+-- Example usage:
+-- int marksCount = PLAYER::_GET_NUM_DEADEYE_MARKS_ON_PED(PLAYER::PLAYER_ID(), pedHandle);
+-- Video: https://imgur.com/gallery/0x27ad7162d3fed01e-XvMXq2d
+-- min build: 1207
+---@param player number
+---@param ped number
+---@return number
+function _GetNumDeadeyeMarksOnPed(player, ped) end
+
+-- _GET_NUM_MARKED_DEADEYE_TARGETS  (0xCCD9B77F70D31C9D)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetNumMarkedDeadeyeTargets(player) end
+
+-- _GET_PEDS_IN_COMBAT_WITH_RECENTLY  (0x1A6E84F13C952094)
+-- Alternate name: _GET_PEDS_DAMAGED_BY_PLAYER
+-- Returns an array of peds the player has recently attacked in a combo, tracking up to three consecutive peds.
+-- Video: https://imgur.com/gallery/0x1a6e84f13c952094-USZqpAJ
+-- min build: 1207
+---@param player number
+---@param recentlyMs number
+---@return boolean
+---@return any
+function _GetPedsInCombatWithRecently(player, recentlyMs) end
+
+-- _GET_PLAYER_CACHED_DEAD_EYE_AMOUNT  (0xDF66A37936D5F3D9)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerCachedDeadEyeAmount(player) end
+
+-- _GET_PLAYER_DEAD_EYE  (0xA81D24AE0AF99A5E)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerDeadEye(player) end
+
+-- _GET_PLAYER_DEAD_EYE_METER_LEVEL  (0x3A6AE4EEE30370FE)
+-- min build: 1207
+---@param player number
+---@param p1 boolean
+---@return number
+function _GetPlayerDeadEyeMeterLevel(player, p1) end
+
+-- _GET_PLAYER_FREE_AIM_CLOSEST_ENTITY  (0x7AE93C45EC14A166)
+-- Returns true if any entity have been found closest to where the player is aiming at (like 5m max far). Seems to only work on human peds
+-- 
+-- Parameters:
+-- - entity: Entity* - Pointer of closest entity.
+-- 
+-- Returns:
+-- - success: bool - True if entity found, false otherwise.
+-- 
+-- Example video:
+-- - https://imgur.com/a/JiqTmYl
+-- min build: 1207
+---@param player number
+---@return boolean
+---@return number
+function _GetPlayerFreeAimClosestEntity(player) end
+
+-- _GET_PLAYER_HEALTH  (0x0317C947D062854E)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerHealth(player) end
+
+-- _GET_PLAYER_HEALTH_RECHARGE_MULTIPLIER  (0x22CD23BB0C45E0CD)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerHealthRechargeMultiplier(player) end
+
+-- _GET_PLAYER_HUNTING_WAGON  (0x5CA6BBD4A7D8145E)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerHuntingWagon(player) end
+
+-- _GET_PLAYER_INTERACTION_AIM_ENTITY  (0xBEA3A6E5F5F79A6F)
+-- Get the entity the player is aiming at with/without weapon.
+-- min build: 1207
+---@param player number
+---@return boolean
+---@return number
+function _GetPlayerInteractionAimEntity(player) end
+
+-- _GET_PLAYER_MAX_DEAD_EYE  (0x592F58BC4D2A2CF3)
+-- min build: 1207
+---@param player number
+---@param p1 any
+---@return number
+function _GetPlayerMaxDeadEye(player, p1) end
+
+-- _GET_PLAYER_MOOD  (0x054473164C012699)
+-- See _SET_PLAYER_MOOD
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerMood(player) end
+
+-- _GET_PLAYER_MOUNT_IS_SPRINTING_ON_ROAD  (0xE631EAF35828FA67)
+-- Checks if the player is sprinting on a road while riding a horse.
+-- This function only checks sprinting status when the player is on a road.
+-- 
+-- Video: https://youtu.be/cGyh0AXPu1E
+-- min build: 1207
+---@param player number
+---@return boolean
+function _GetPlayerMountIsSprintingOnRoad(player) end
+
+-- _GET_PLAYER_OWNER_OF_MOUNT  (0xAD03B03737CE6810)
+-- min build: 1207
+---@param mount number
+---@return number
+function _GetPlayerOwnerOfMount(mount) end
+
+-- _GET_PLAYER_OWNER_OF_VEHICLE  (0x7C803BDC8343228D)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetPlayerOwnerOfVehicle(vehicle) end
+
+-- _GET_PLAYER_PED_2  (0x5EBE38A20BC51C27)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerPed2(player) end
+
+-- _GET_PLAYER_REQUIRED_DEAD_EYE_AMOUNT  (0x811A748B1BE231BA)
+-- If player has less Dead Eye than required, Dead Eye cant be triggered.
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerRequiredDeadEyeAmount(player) end
+
+-- _GET_PLAYER_RESET_FLAG  (0xFE691E89C08937B6)
+-- playerResetFlag: See 0x9F9A829C6751F3C7
+-- min build: 1207
+---@param player number
+---@param playerResetFlag number
+---@return boolean
+function _GetPlayerResetFlag(player, playerResetFlag) end
+
+-- _GET_PLAYER_SPECIAL_ABILITY_MULTIPLIER  (0xAB3773E7AA1E9DCC)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerSpecialAbilityMultiplier(player) end
+
+-- _GET_PLAYER_STAMINA  (0x0FF421E467373FCF)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerStamina(player) end
+
+-- _GET_PLAYER_STAMINA_DEPLETION_MULTIPLIER  (0x68A0389E0718AC8F)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerStaminaDepletionMultiplier(player) end
+
+-- _GET_PLAYER_STAMINA_RECHARGE_MULTIPLIER  (0x617D3494AD58200F)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetPlayerStaminaRechargeMultiplier(player) end
+
+-- _GET_PLAYER_UI_PROMPT_FOR_PED_IS_ENABLED  (0xEA8F168A76A0B9BC)
+-- Returns true if PromptType is enabled for ped (mount)
+-- Params: See 0x0751D461F06E41CE
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param promptType number
+---@param promptMode number
+---@return boolean
+function _GetPlayerUiPromptForPedIsEnabled(player, ped, promptType, promptMode) end
+
+-- _GET_PLAYER_UI_PROMPT_IS_DISABLED  (0x6614F9039BD31931)
+-- Returns false if PromptType is enabled
+-- Params: See 0x0751D461F06E41CE
+-- min build: 1207
+---@param player number
+---@param promptType number
+---@param promptMode number
+---@return boolean
+function _GetPlayerUiPromptIsDisabled(player, promptType, promptMode) end
+
+-- _GET_PLAYER_WEAPON_DAMAGE  (0xFE0304050261442C)
+-- min build: 1207
+---@param player number
+---@param weaponHash number
+---@return number
+function _GetPlayerWeaponDamage(player, weaponHash) end
+
+-- _GET_SADDLE_HORSE_FOR_PLAYER  (0xB48050D326E9A2F3)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetSaddleHorseForPlayer(player) end
+
+-- _GET_TEMP_PLAYER_HORSE  (0xD3F7445CEA2E5035)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetTempPlayerHorse(player) end
+
+-- _GET_VEHICLE_OWNED_BY_PLAYER  (0xB9050A97594C8832)
+-- min build: 1207
+---@param player number
+---@return number
+function _GetVehicleOwnedByPlayer(player) end
+
+-- _GET_WANTED_LEVEL_MULTIPLIER  (0xA82964B9D8D6A983)
+-- Returns -1.0f if no multiplier has been set
+-- min build: 1207
+---@return number
+function _GetWantedLevelMultiplier() end
+
+-- _HAS_PLAYER_DAMAGED_RECENTLY_ATTACKED_PED  (0x72AD59F7B7FB6E24)
+-- Checks if the player has damaged the ped they recently attacked. Useful for determining if the player's recent attack on a ped resulted in damage.
+-- min build: 1207
+---@param player number
+---@param recentlyMs number
+---@return boolean
+function _HasPlayerDamagedRecentlyAttackedPed(player, recentlyMs) end
+
+-- _IS_DEADEYE_ABILITY_LOCKED  (0x8A0643B0B4CA276B)
+-- min build: 1207
+---@param player number
+---@param abilityType number
+---@return boolean
+function _IsDeadeyeAbilityLocked(player, abilityType) end
+
+-- _IS_EAGLE_EYE_REGISTERED_FOR_ENTITY  (0x0E6846476906C9DD)
+-- min build: 1207
+---@param player number
+---@param entity number
+---@return boolean
+function _IsEagleEyeRegisteredForEntity(player, entity) end
+
+-- _IS_PLAYER_FOLLOWING_TARGET  (0xE24C64D9ADED2EF5)
+-- min build: 1207
+---@param player number
+---@param ped number
+---@return boolean
+function _IsPlayerFollowingTarget(player, ped) end
+
+-- _IS_PLAYER_FREE_FOCUSING  (0x1A51BFE60708E482)
+-- Checks if player is focused on any entity
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsPlayerFreeFocusing(player) end
+
+-- _IS_PLAYER_IN_SCOPE  (0x04D7F33640662FA2)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsPlayerInScope(player) end
+
+-- _IS_PLAYER_LOCKED_ON_ENTITY_ON_HORSE  (0x2009F8AB7A5E9D6D)
+-- Checks if the player has locked onto an entity while on horseback.
+-- This function checks only the lock-on status and does not trigger any additional behavior.
+-- Images: https://imgur.com/gallery/0x2009f8ab7a5e9d6d-0xWIXcK
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsPlayerLockedOnEntityOnHorse(player) end
+
+-- _IS_SECONDARY_SPECIAL_ABILITY_ACTIVE  (0x45AB66D02B601FA7)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsSecondarySpecialAbilityActive(player) end
+
+-- _IS_SECONDARY_SPECIAL_ABILITY_ENABLED  (0xE022CC1B545F1D9F)
+-- Returns true if eagle eye is enabled for the player
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsSecondarySpecialAbilityEnabled(player) end
+
+-- _IS_SPECIAL_ABILITY_ACTIVE  (0xB16223CB7DA965F0)
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsSpecialAbilityActive(player) end
+
+-- _IS_SPECIAL_ABILITY_ENABLED  (0xDE6C85975F9D4894)
+-- Checks if the player's Deadeye ability is enabled.
+-- 
+-- Example usage:
+-- 
+-- if (PLAYER::_IS_SPECIAL_ABILITY_ENABLED(PLAYER::PLAYER_ID())) {
+--     // Execute logic when Deadeye is enabled
+-- }
+-- 
+-- This function does not activate or modify the Deadeye ability but simply checks its status.
+-- 
+-- Image : https://imgur.com/gallery/0xde6c85975f9d4894-MS4KeUL
+-- min build: 1207
+---@param player number
+---@return boolean
+function _IsSpecialAbilityEnabled(player) end
+
+-- _MODIFY_INFINITE_TRAIL_VISION  (0x28A13BF6B05C3D83)
+-- Toggle handles wether Deadeye and Eagleeye are infinite or not.
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function _ModifyInfiniteTrailVision(player, toggle) end
+
+-- _MODIFY_PLAYER_DISCOVERED_CHARACTER_NAME_MP_SET_UNDISCOVERED  (0xFB0E622B401884D3)
+-- min build: 1207
+---@param discoveryHash number
+function _ModifyPlayerDiscoveredCharacterNameMpSetUndiscovered(discoveryHash) end
+
+-- _MODIFY_PLAYER_UI_PROMPT  (0x0751D461F06E41CE)
+-- Params: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ePromptType
+-- promptType is mostly 34 (PP_TRACK_ANIMAL), promptMode = 0 (PP_MODE_BLOCK) in R* Scripts
+-- min build: 1207
+---@param player number
+---@param promptType number
+---@param promptMode number
+---@param disabled boolean
+function _ModifyPlayerUiPrompt(player, promptType, promptMode, disabled) end
+
+-- _MODIFY_PLAYER_UI_PROMPT_FOR_PED  (0xA3DB37EDF9A74635)
+-- Params: See 0x0751D461F06E41CE
+-- min build: 1207
+---@param player number
+---@param ped number
+---@param promptType number
+---@param promptMode number
+---@param enabled boolean
+function _ModifyPlayerUiPromptForPed(player, ped, promptType, promptMode, enabled) end
+
+-- _NETWORK_HAS_PLAYER_VALID_PED  (0x0760D6F70EBCC05C)
+-- Returns true if the given player has a valid ped.
+-- min build: 1207
+---@param player number
+---@return boolean
+function _NetworkHasPlayerValidPed(player) end
+
+-- _REGISTER_EAGLE_EYE_FOR_ENTITY  (0x543DFE14BE720027)
+-- Used for setting up eagle eye for entity
+-- Params: p2 = re-register or not?
+-- min build: 1207
+---@param player number
+---@param entity number
+---@param p2 boolean
+function _RegisterEagleEyeForEntity(player, entity, p2) end
+
+-- _REGISTER_EAGLE_EYE_TRAILS_FOR_ENTITY  (0xAC67098A1E54ABB0)
+-- min build: 1207
+---@param player number
+---@param entity number
+---@param p2 any
+function _RegisterEagleEyeTrailsForEntity(player, entity, p2) end
+
+-- _REMOVE_PLAYER_AS_FOLLOW_TARGET  (0x0C6B89876262A99D)
+-- min build: 1207
+---@param player number
+---@param ped number
+function _RemovePlayerAsFollowTarget(player, ped) end
+
+-- _RESET_DEADEYE_AURA_EFFECT  (0xE910932F4B30BE23)
+-- Resets any aura effects applied to entities for a specific player in Deadeye mode, returning all aura-related visuals to their default state. This function is primarily used to remove any highlighting or aura effects set by `PLAYER::_SET_DEADEYE_ENTITY_AURA_EFFECT` (0x2B12B6FC8B8772AB) and `PLAYER::_SET_DEADEYE_ENTITY_AURA_EFFECT_INTENSITY` (0x131E294EF60160DF).
+-- 
+-- Example usage:
+-- PLAYER::_RESET_DEADEYE_AURA_EFFECT(PLAYER::PLAYER_ID());
+-- Resets all aura effects and intensity changes for the player, removing entity highlights and restoring default visuals after Deadeye.
+-- 
+-- Video: https://imgur.com/gallery/0xe910932f4b30be23-tjviTeU
+-- min build: 1207
+---@param player number
+function _ResetDeadeyeAuraEffect(player) end
+
+-- _SECONDARY_SPECIAL_ABILITY_SET_ACTIVE  (0x1710BC33CFB83634)
+-- Activates EagleEye, called together with 0x28A13BF6B05C3D83
+-- min build: 1207
+---@param player number
+function _SecondarySpecialAbilitySetActive(player) end
+
+-- _SECONDARY_SPECIAL_ABILITY_SET_DISABLED  (0x64FF4BF9AF59E139)
+-- Deactivates EagleEye, called together with 0xC0B21F235C02139C
+-- min build: 1207
+---@param player number
+---@param disabled boolean
+function _SecondarySpecialAbilitySetDisabled(player, disabled) end
+
+-- _SET_AI_PLAYER_DEFENSE_MODIFIER_AGAINST_AI  (0x914071FF93AF2692)
+-- Sets Player's Defense against AI modifier
+-- min build: 1207
+---@param player number
+---@param modifier number
+function _SetAiPlayerDefenseModifierAgainstAi(player, modifier) end
+
+-- _SET_BOUNTY_TARGET  (0x6ADF821FBF21920E)
+-- min build: 1207
+---@param player number
+---@param target number
+function _SetBountyTarget(player, target) end
+
+-- _SET_BOW_DRAW_REDUCTION_TIME_IN_DEADEYE  (0xBE0C524970892D41)
+-- min build: 1207
+---@param player number
+---@param drawReductionTime number
+function _SetBowDrawReductionTimeInDeadeye(player, drawReductionTime) end
+
+-- _SET_BOW_STAMINA_DRAIN_SPEED  (0xFE7C9CF376D23342)
+-- Decreases Stamina bar drain speed by % when drawing a bow.
+-- min build: 1207
+---@param player number
+---@param staminaDrain number
+function _SetBowStaminaDrainSpeed(player, staminaDrain) end
+
+-- _SET_DAMAGE_CLOSE_DISTANCE_BONUS  (0x7761A30432C91297)
+-- min build: 1207
+---@param player number
+---@param closeRangeLowerBound number
+---@param closeRangeUpperBound number
+function _SetDamageCloseDistanceBonus(player, closeRangeLowerBound, closeRangeUpperBound) end
+
+-- _SET_DAMAGE_CLOSE_DISTANCE_BONUS_TOTAL  (0x5006C36652D6EC56)
+-- min build: 1207
+---@param player number
+---@param closeDamageBonus number
+function _SetDamageCloseDistanceBonusTotal(player, closeDamageBonus) end
+
+-- _SET_DAMAGE_FAR_DISTANCE_BONUS  (0xED591CB17C8BA216)
+-- min build: 1207
+---@param player number
+---@param farRangeLowerBound number
+---@param farRangeUpperBound number
+function _SetDamageFarDistanceBonus(player, farRangeLowerBound, farRangeUpperBound) end
+
+-- _SET_DAMAGE_FAR_DISTANCE_BONUS_TOTAL  (0x1F0E3A4434565F8F)
+-- min build: 1207
+---@param player number
+---@param farDamageBonus number
+function _SetDamageFarDistanceBonusTotal(player, farDamageBonus) end
+
+-- _SET_DEADEYE_ABILITY_DEPLETION_DELAY  (0x870634493CB4372C)
+-- Only used in R* SP Script short_update
+-- min build: 1207
+---@param player number
+---@param delay number
+function _SetDeadeyeAbilityDepletionDelay(player, delay) end
+
+-- _SET_DEADEYE_ABILITY_LEVEL  (0xF0FE8E790BFEB5BB)
+-- Max level is 5.
+-- min build: 1207
+---@param player number
+---@param level number
+function _SetDeadeyeAbilityLevel(player, level) end
+
+-- _SET_DEADEYE_ABILITY_LOCKED  (0x2797B8D66DD0EBB8)
+-- min build: 1207
+---@param player number
+---@param abilityType number
+---@param toggle boolean
+function _SetDeadeyeAbilityLocked(player, abilityType, toggle) end
+
+-- _SET_DEADEYE_ENTITY_AURA_EFFECT  (0x2B12B6FC8B8772AB)
+-- Applies an aura effect to nearby entities when Deadeye is active, based on a flag parameter. This includes humans, animals, vehicles, and horses pulling those vehicles. Additionally, depending on the flag value, the player's appearance may change (e.g., turning gray).
+-- 
+-- Example usage:
+-- PLAYER::_SET_DEADEYE_ENTITY_AURA_EFFECT(PLAYER::PLAYER_ID(), 3);
+-- Applies an aura effect to nearby entities, and the player turns gray by default when flag is set to 8.
+-- 
+-- Video: https://youtu.be/Mgb1N9_6Htc
+-- min build: 1207
+---@param player number
+---@param flag number
+function _SetDeadeyeEntityAuraEffect(player, flag) end
+
+-- _SET_DEADEYE_ENTITY_AURA_EFFECT_INTENSITY  (0x131E294EF60160DF)
+-- Applies a customizable aura effect to nearby entities when Deadeye is active, with control over aura intensity and additional behavior based on a flag parameter.
+-- 
+-- auraIntensity: maximum value of 1.0. Represents how strong the aura appears on nearby entities.
+-- flag: 2: Applies aura to humans, 4: Applies aura to animals
+-- 
+-- Example usage:
+-- PLAYER::_SET_DEADEYE_ENTITY_AURA_EFFECT_INTENSITY(PLAYER::PLAYER_ID(), 0.0, 0.0, 0.0, 1.0, 8);
+-- Applies a maximum intensity aura effect to all nearby entities while Deadeye is active.
+-- 
+-- Screenshot: https://imgur.com/gallery/0x131e294ef60160df-zNQ6Pc0
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param auraIntensity number
+---@param flag number
+function _SetDeadeyeEntityAuraEffectIntensity(player, p1, p2, p3, auraIntensity, flag) end
+
+-- _SET_DEADEYE_TAGGING_CONFIG  (0x83FCD6921FC8FD05)
+-- min build: 1207
+---@param player number
+---@param filter number
+function _SetDeadeyeTaggingConfig(player, filter) end
+
+-- _SET_DEADEYE_TAGGING_ENABLED  (0x6B5DDFB967E5073D)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function _SetDeadeyeTaggingEnabled(player, toggle) end
+
+-- _SET_DISABLE_PLAYER_WANTED_LEVEL  (0x8674D138391FFB1B)
+-- Disables the players ability to be wanted by lawmen
+-- min build: 1207
+---@param player number
+---@param disable boolean
+function _SetDisablePlayerWantedLevel(player, disable) end
+
+-- _SET_LOCAL_PLAYER_PERSONA_ABILITY_FLAG  (0x7146CF430965927C)
+-- see personaabilities.meta
+-- enum ePersonaAbilityFlag
+-- {
+-- 	PERSONA_CAN_AUTOESCAPE_FROM_LASSO,
+-- 	PERSONA_HAT_BLOCKS_FIRST_HEADSHOT,
+-- 	PERSONA_FULL_AUTO_FOR_ALL_WEAPONS,
+-- 	PERSONA_MIGHT_LIVE_AFTER_DEADLY_DAMAGE,
+-- 	PERSONA_IGNORE_AIM_BEFORE_FIRING_RESTRICTIONS,
+-- 	PERSONA_DEADEYE_INSTANT_RELOAD,
+-- 	PERSONA_USE_PHOSPHOROUS_ROUNDS,
+-- 	PERSONA_CONT_DEADEYE_ON_TAKING_COVER,
+-- 	PERSONA_CONT_DEADEYE_ON_RELOAD,
+-- 	PERSONA_CONT_DEADEYE_ON_SHOOTING,
+-- 	PERSONA_CONT_DEADEYE_ON_EXITING_AIM,
+-- 	PERSONA_DISABLE_PLAYER_CANCELLING_DEADEYE,
+-- 	PERSONA_CONT_DEADEYE_ON_RAGDOLL,
+-- 	PERSONA_USE_EXPLOSIVE_ROUNDS,
+-- 	PERSONA_EXIT_DEADEYE_ON_TAKING_DAMAGE,
+-- 	PERSONA_CARRY_TWO_MONEYBAGS,
+-- 	PERSONA_ABILITY_LONG_PICK_HERBS,
+-- 	PERSONA_ABILITY_UNBREAKABLE_LASSO,
+-- 	PERSONA_CONT_DEADEYE_ON_SPRINTING,
+-- 	PERSONA_CANT_DEAL_HEADSHOTS,
+-- 	PERSONA_HANGMAN,
+-- 	PERSONA_ALLOW_DEADEYE_WITH_MELEE_WEAPONS,
+-- 	PERSONA_ALLOW_DEADEYE_WHILE_UNARMED,
+-- 	PERSONA_DISABLE_DEADEYE_PERFECT_ACCURACY,
+-- 	PERSONA_CANT_DEAL_HEADSHOTS_TO_PLAYERS,
+-- 	PERSONA_CANT_DEAL_CRITICAL_DAMAGE,
+-- 	PERSONA_CANT_DEAL_CRITICAL_DAMAGE_TO_PLAYERS,
+-- 	PERSONA_ALLOW_EAGLEEYE_IN_COMBAT,
+-- 	PERSONA_CONT_EAGLEEYE_ON_SPRINT,
+-- 	PERSONA_SUPPRESS_LENGENDARY_EAGLEEYE_TRAIL_COLOR
+-- };
+-- min build: 1207
+---@param flagId number
+---@param toggle boolean
+function _SetLocalPlayerPersonaAbilityFlag(flagId, toggle) end
+
+-- _SET_LOCKON_FOCUS_FIRE_VFX  (0x5F8E0303C229C84B)
+-- Focus Fire VFX start for player: p1 = focusfire
+-- min build: 1207
+---@param player number
+---@param p1 string
+function _SetLockonFocusFireVfx(player, p1) end
+
+-- _SET_MAX_WANTED_LEVEL_2  (0xEA6DE0CD15AECBE2)
+-- min build: 1207
+---@param maxWantedLevel number
+function _SetMaxWantedLevel2(maxWantedLevel) end
+
+-- _SET_MOUNT_PROMPT_DISABLED  (0x5B9813ECF7633FE8)
+-- min build: 1207
+---@param disabled boolean
+function _SetMountPromptDisabled(disabled) end
+
+-- _SET_PED_ACTIVE_PLAYER_HORSE  (0x8FBF9EDB378CCB8C)
+-- Seems to work similar to 0xD2CB0FB0FDCB473D
+-- min build: 1207
+---@param player number
+---@param horse number
+function _SetPedActivePlayerHorse(player, horse) end
+
+-- _SET_PED_AS_SADDLE_HORSE_FOR_PLAYER  (0xD2CB0FB0FDCB473D)
+-- min build: 1207
+---@param player number
+---@param mount number
+function _SetPedAsSaddleHorseForPlayer(player, mount) end
+
+-- _SET_PLAYER_AIM_WEAPON  (0xCFFC3ECCD7A5CCEB)
+-- Sets the weapon that the specified player will aim with. The weapon must already be assigned to the PED. This also determines the weapon order, specifying which weapon the player will automatically switch to when the current weapon runs out of ammo.
+-- Example usage:
+-- 
+-- Set the player's aim weapon to the specified weapon hash in slot 0
+-- PLAYER::_SET_PLAYER_AIM_WEAPON(PLAYER::PLAYER_ID(), GetHashKey("WEAPON_RIFLE_VARMINT"), 0);
+-- 
+-- Video: https://youtu.be/-fUMrLIm9ng
+-- min build: 1207
+---@param player number
+---@param weapon number
+---@param weaponDrawOrder number
+function _SetPlayerAimWeapon(player, weapon, weaponDrawOrder) end
+
+-- _SET_PLAYER_CAN_MERCY_KILL  (0x39363DFD04E91496)
+-- min build: 1311
+---@param player number
+---@param toggle boolean
+function _SetPlayerCanMercyKill(player, toggle) end
+
+-- _SET_PLAYER_CAN_PICKUP_ABILITY  (0xD1A70C1E8D1031FE)
+-- Shows or hides all "Pick Up" prompts for the specified player, including the prompt for picking up hats from the ground. When set to true, the player will see "Pick Up" prompts for all nearby items. If set to false, all "Pick Up" prompts will be hidden.
+-- Video: https://imgur.com/gallery/0xd1a70c1e8d1031fe-ifgUnmV
+-- min build: 1207
+---@param player number
+---@param isVisible boolean
+function _SetPlayerCanPickupAbility(player, isVisible) end
+
+-- _SET_PLAYER_CAN_PICKUP_HAT  (0xACA45DDCEF6071C4)
+-- Enables or disables the "Pick Up" prompt for a hat on the ground for the specified player. When set to true, the player will see a prompt to pick up the hat if they are near it.
+-- Video: https://imgur.com/gallery/0xaca45ddcef6071c4-dzlnm8Z
+-- min build: 1207
+---@param player number
+---@param enable boolean
+function _SetPlayerCanPickupHat(player, enable) end
+
+-- _SET_PLAYER_COOPERATE_PROMPT_THIS_FRAME  (0xCBB54CC7FFFFAB86)
+-- Activates the "Surrender" prompt for the specified player in the current frame.
+-- Notes:
+-- - Continuous Activation: Must be called every frame to keep the "Surrender" prompt active.
+-- - Prompt Grouping: Setting `promptOrder` to `1` ties the prompt to the `targetPed`'s prompt group.
+-- - Enemy Behavior: Stops enemies from continuing their attack when activated.
+-- Video: https://youtu.be/AfHdJ0Nrs7Q
+-- min build: 1207
+---@param player number
+---@param targetPed number
+---@param promptOrder number
+---@param unknownFlag boolean
+function _SetPlayerCooperatePromptThisFrame(player, targetPed, promptOrder, unknownFlag) end
+
+-- _SET_PLAYER_DAMAGE_INFO_OVERRIDE  (0x78B3D19AF6391A55)
+-- damageInfo: STANDARD_PED_DAMAGE, STANDARD_FEMALE_PED_DAMAGE, STANDARD_PLAYER_PED_DAMAGE_MP, STANDARD_FEMALE_PLAYER_PED_DAMAGE_MP
+-- min build: 1207
+---@param player number
+---@param damageInfo string
+function _SetPlayerDamageInfoOverride(player, damageInfo) end
+
+-- _SET_PLAYER_DEAD_EYE_AURA_BY_HASH  (0x768E81AE285A4B67)
+-- Sets the aura color for entities that the player can target in Deadeye mode, based on a specific hash value.
+-- Known hash : 
+-- - 1014693585 
+-- - 1936842089 
+-- - 1979474018
+-- Example usage:
+-- PLAYER::_SET_PLAYER_DEAD_EYE_AURA_BY_HASH(PLAYER::PLAYER_ID(), 1014693585);
+-- Video: https://imgur.com/gallery/0x768e81ae285a4b67-LzWAwBc 
+-- Previous name: _SET_PLAYER_STAT_FLAG_HASH
+-- _N*, _O* or _PE*
+-- min build: 1207
+---@param player number
+---@param auraHash number
+function _SetPlayerDeadEyeAuraByHash(player, auraHash) end
+
+-- _SET_PLAYER_DEFENSE_MODIFIER  (0x497A6539BB0E8787)
+-- Sets stamina core drains peed using ranged damage scale and melee damage scale
+-- min build: 1207
+---@param player number
+---@param weaponDefenseMod number
+---@param meleeDefenseMod number
+function _SetPlayerDefenseModifier(player, weaponDefenseMod, meleeDefenseMod) end
+
+-- _SET_PLAYER_DEFENSE_TYPE_MODIFIER  (0x93F499CAE53FCD05)
+-- bullet damage modifier: type = 4
+-- explosive damage Defense mod: type = 7
+-- fire damage Defense mod: type = 8, 15
+-- min build: 1207
+---@param player number
+---@param type number
+---@param defenseModifier number
+function _SetPlayerDefenseTypeModifier(player, type, defenseModifier) end
+
+-- _SET_PLAYER_EXPLOSIVE_WEAPON_DAMAGE_MODIFIER  (0x2D3ACE3DE0A2B622)
+-- min build: 1207
+---@param player number
+---@param modifier number
+function _SetPlayerExplosiveWeaponDamageModifier(player, modifier) end
+
+-- _SET_PLAYER_HAS_DISCOVERED_CHARACTER_NAME_MP  (0x7C32191D9FB2BDEA)
+-- min build: 1207
+---@param discoveryHash number
+function _SetPlayerHasDiscoveredCharacterNameMp(discoveryHash) end
+
+-- _SET_PLAYER_HAS_DISCOVERED_CHARACTER_NAME_SP  (0x946D46CD6DFB9742)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param discoveryHash number
+function _SetPlayerHasDiscoveredCharacterNameSp(player, p1, discoveryHash) end
+
+-- _SET_PLAYER_HAT_ACCESS  (0xA0C683284DF027C7)
+-- Sets the player's ability to wear hats based on the specified flag. The flag value determines whether the player can wear all hats or only the ones they own.
+-- 
+-- If the flag is set to 15 and `allow` is true, the player can wear all available hats. To restrict the player to wearing only owned hats (flag 1), you must first disable flag 15 by setting it to false, then set flag 1 to true.
+-- 
+-- Example usage:
+-- 
+-- Allow the player to wear all hats
+-- PLAYER::_SET_PLAYER_HAT_ACCESS(PLAYER::PLAYER_ID(), 15, true);
+-- 
+-- Restrict the player to only wearing owned hats
+-- PLAYER::_SET_PLAYER_HAT_ACCESS(PLAYER::PLAYER_ID(), 15, false);
+-- PLAYER::_SET_PLAYER_HAT_ACCESS(PLAYER::PLAYER_ID(), 1, true);
+-- 
+-- Video: https://imgur.com/gallery/0xa0c683284df027c7-dhV5NAL
+-- min build: 1207
+---@param player number
+---@param flag number
+---@param enable boolean
+function _SetPlayerHatAccess(player, flag, enable) end
+
+-- _SET_PLAYER_HEALTH_RECHARGE_TIME_MODIFIER  (0x535ED4605F89AB6E)
+-- Setting player's Health recharge time to zero forces immediate health regen
+-- min build: 1207
+---@param player number
+---@param modifier number
+function _SetPlayerHealthRechargeTimeModifier(player, modifier) end
+
+-- _SET_PLAYER_HUNTING_WAGON  (0x6A4404BDFA62CE2C)
+-- Only applies to HUNTERCART01
+-- min build: 1207
+---@param player number
+---@param wagon number
+function _SetPlayerHuntingWagon(player, wagon) end
+
+-- _SET_PLAYER_IN_VEHICLE_TARGETING_MODE  (0x19B4F71703902238)
+-- Sets your targeting mode for when you're in a vehicle (perhaps a mount/horse).
+-- see SET_PLAYER_TARGETING_MODE for eTargetingMode
+-- min build: 1207
+---@param targetMode number
+function _SetPlayerInVehicleTargetingMode(targetMode) end
+
+-- _SET_PLAYER_INTERACTION_NEGATIVE_RESPONSE  (0x98CD760DE43B612E)
+-- min build: 1207
+---@param player number
+---@param speech string
+function _SetPlayerInteractionNegativeResponse(player, speech) end
+
+-- _SET_PLAYER_INTERACTION_POSITIVE_RESPONSE  (0xC6366A585659D15C)
+-- min build: 1207
+---@param player number
+---@param speech string
+function _SetPlayerInteractionPositiveResponse(player, speech) end
+
+-- _SET_PLAYER_LASSO_DAMAGE_PER_SECOND  (0x43F50A7CD2482156)
+-- _SET_PLAYER_A* - _SET_PLAYER_C*
+-- min build: 1207
+---@param player number
+---@param damage number
+function _SetPlayerLassoDamagePerSecond(player, damage) end
+
+-- _SET_PLAYER_LOCAL_ACCURACY_FLOOR_MODIFIER  (0x4EA69188FBCE6A7D)
+-- min build: 1207
+---@param player number
+---@param accuracy number
+function _SetPlayerLocalAccuracyFloorModifier(player, accuracy) end
+
+-- _SET_PLAYER_MANAGE_BUFF_SUPER_JUMP  (0x292F0B6EDC82E3A4)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function _SetPlayerManageBuffSuperJump(player, p1) end
+
+-- _SET_PLAYER_MAX_AMMO_OVERRIDE_FOR_AMMO_TYPE  (0xE133C1EC5300F740)
+-- min build: 1207
+---@param player number
+---@param ammoType number
+---@param amount number
+function _SetPlayerMaxAmmoOverrideForAmmoType(player, ammoType, amount) end
+
+-- _SET_PLAYER_MOOD  (0x39BED552DB46FFA9)
+-- mood: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ePedMood
+-- min build: 1207
+---@param player number
+---@param mood number
+function _SetPlayerMood(player, mood) end
+
+-- _SET_PLAYER_MOUNT_STATE_ACTIVE  (0xDF93973251FB2CA5)
+-- Name could potentially be inaccurate.
+-- Used in Script Function HORSE_SETUP_PLAYER_HORSE_ATTRIBUTES (p1 = true)
+-- _SET_PLAYER_L* - _SET_PLAYER_M*
+-- min build: 1207
+---@param player number
+---@param active boolean
+function _SetPlayerMountStateActive(player, active) end
+
+-- _SET_PLAYER_OWNS_MOUNT  (0xE6D4E435B56D5BD0)
+-- Seems to enable active horse equipment prompt when being near it and enables the control that opens the inventory as well
+-- min build: 1207
+---@param player number
+---@param mount number
+function _SetPlayerOwnsMount(player, mount) end
+
+-- _SET_PLAYER_OWNS_VEHICLE  (0xD0E02AA618020D17)
+-- min build: 1207
+---@param player number
+---@param vehicle number
+function _SetPlayerOwnsVehicle(player, vehicle) end
+
+-- _SET_PLAYER_PROMPT_LEAVE_TEXT  (0x06C3DB00B69D5435)
+-- Sets the stand prompt for a specific player using a predefined text entry.
+-- Example usage:
+-- PLAYER::_SET_PLAYER_PROMPT_LEAVE_TEXT(PLAYER::PLAYER_ID(), MISC::VAR_STRING(10, "LITERAL_STRING", "Get on your feet"));
+-- The prompt for player to stand uses this text.
+-- Screenshot: https://imgur.com/gallery/rdrnative-kscnRlF
+-- min build: 1232
+---@param player number
+---@param promptTextKey string
+function _SetPlayerPromptLeaveText(player, promptTextKey) end
+
+-- _SET_PLAYER_PROMPT_MELEE_TEXT  (0x0FAF95D71ED67ADE)
+-- Sets the melee combat prompt for a specific player using a predefined text entry.
+-- Example usage:
+-- PLAYER::_SET_PLAYER_PROMPT_MELEE_TEXT(PLAYER::PLAYER_ID(), MISC::VAR_STRING(10, "LITERAL_STRING", "Throw Punch"));
+-- The prompt for player during melee combat uses this text.
+-- Screenshot: https://imgur.com/gallery/0x0faf95d71ed67ade-GDYsE9L
+-- min build: 1207
+---@param player number
+---@param promptTextKey string
+function _SetPlayerPromptMeleeText(player, promptTextKey) end
+
+-- _SET_PLAYER_PROMPT_SIT_TEXT  (0x988C9045531B9FCE)
+-- Sets the sit prompt for a specific player using a predefined text entry.
+-- Example usage:
+-- PLAYER::_SET_PLAYER_PROMPT_SIT_TEXT(PLAYER::PLAYER_ID(), MISC::VAR_STRING(10, "LITERAL_STRING", "Take a Seat"));
+-- The prompt for player to sit uses this text.
+-- Screenshot: https://imgur.com/gallery/0x988c9045531b9fce-9bTHgkv
+-- min build: 1232
+---@param player number
+---@param promptTextKey string
+function _SetPlayerPromptSitText(player, promptTextKey) end
+
+-- _SET_PLAYER_REMOTE_ACCURACY_FLOOR_MODIFIER  (0xDEE80FEDFDD43C9B)
+-- min build: 1207
+---@param player number
+---@param accuracy number
+function _SetPlayerRemoteAccuracyFloorModifier(player, accuracy) end
+
+-- _SET_PLAYER_RESET_FLAG  (0x9F9A829C6751F3C7)
+-- https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/ePlayerResetFlags
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/PLAYER_RESET_FLAGS
+-- min build: 1207
+---@param player number
+---@param playerResetFlag number
+---@param p2 boolean
+function _SetPlayerResetFlag(player, playerResetFlag, p2) end
+
+-- _SET_PLAYER_STAMINA_SPRINT_DEPLETION_MULTIPLIER  (0xBBADFB5E5E5766FB)
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function _SetPlayerStaminaSprintDepletionMultiplier(player, multiplier) end
+
+-- _SET_PLAYER_TOTAL_ACCURACY_MODIFIER  (0x967FF5BC0CFE6D26)
+-- min build: 1207
+---@param player number
+---@param accuracy number
+function _SetPlayerTotalAccuracyModifier(player, accuracy) end
+
+-- _SET_PLAYER_TRAMPLE_DAMAGE_MODIFIER  (0xAF341032E97FB061)
+-- min build: 1207
+---@param player number
+---@param modifier number
+function _SetPlayerTrampleDamageModifier(player, modifier) end
+
+-- _SET_PLAYER_WEAPON_GROUP_AS_INSTANT_KILL  (0x59F0AFF3E0A1B019)
+-- min build: 1207
+---@param player number
+---@param weaponGroup number
+---@param toggle boolean
+function _SetPlayerWeaponGroupAsInstantKill(player, weaponGroup, toggle) end
+
+-- _SET_PLAYER_WEAPON_GROUP_DAMAGE_MODIFIER  (0xFC79DCC94D0A5897)
+-- min build: 1207
+---@param player number
+---@param weaponGroup number
+---@param modifier number
+function _SetPlayerWeaponGroupDamageModifier(player, weaponGroup, modifier) end
+
+-- _SET_RECEIVED_DAMAGE_TAKEN_ON_HORSEBACK_MODIFIER  (0xB427911EA6DFFEF3)
+-- Decreases the damage the player receives while on horseback
+-- Previous name: _SET_RECEIVED_HORSEBACK_DAMAGE_DECREASE
+-- min build: 1207
+---@param player number
+---@param damageDecrease number
+function _SetReceivedDamageTakenOnHorsebackModifier(player, damageDecrease) end
+
+-- _SET_SHOW_INFO_CARD  (0xDC68829BB3F37023)
+-- min build: 1207
+---@param player number
+---@param showingInfoCard boolean
+function _SetShowInfoCard(player, showingInfoCard) end
+
+-- _SET_SPECIAL_ABILITY_ACTIVATION_COST  (0xAE4BCC79C587EBBF)
+-- min build: 1207
+---@param player number
+---@param activationCost number
+---@param p2 number
+function _SetSpecialAbilityActivationCost(player, activationCost, p2) end
+
+-- _SET_SPECIAL_ABILITY_DISABLE_TIMER  (0xC0B1C05B313693D1)
+-- Only used in R* SP Script short_update
+-- min build: 1207
+---@param player number
+---@param timer number
+function _SetSpecialAbilityDisableTimer(player, timer) end
+
+-- _SET_SPECIAL_ABILITY_DURATION_COST  (0xB783F75940B23014)
+-- durationCost: per second
+-- min build: 1207
+---@param player number
+---@param durationCost number
+function _SetSpecialAbilityDurationCost(player, durationCost) end
+
+-- _SET_SPECIAL_ABILITY_MULTIPLIER  (0x5A498FCA232F71E1)
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function _SetSpecialAbilityMultiplier(player, multiplier) end
+
+-- _SET_SPECIAL_ABILITY_TYPE  (0x00BA333DA05ADC23)
+-- SPECIAL_ABILITY_NONE = -1,
+-- SPECIAL_ABILITY_CAR_SLOWDOWN,
+-- SPECIAL_ABILITY_RAGE,
+-- SPECIAL_ABILITY_BULLET_TIME,
+-- SPECIAL_ABILITY_SNAPSHOT,
+-- SPECIAL_ABILITY_INSULT,
+-- SPECIAL_ABILITY_DEADEYE,
+-- SPECIAL_ABILITY_REVIVE
+-- min build: 1207
+---@param player number
+---@param type number
+function _SetSpecialAbilityType(player, type) end
+
+-- _SET_USED_ITEM_EFFECT  (0x0E1DB1F8F5B561DC)
+-- min build: 1207
+---@param health number
+---@param stamina number
+---@param deadeye number
+---@param healthCore number
+---@param staminaCore number
+---@param deadeyeCore number
+function _SetUsedItemEffect(health, stamina, deadeye, healthCore, staminaCore, deadeyeCore) end
+
+-- _SET_WANTED_COOLDOWN  (0x39D8D7082BC34B72)
+-- Sets the current player's wanted evasion cooldown timer.
+-- Observed values: 10000 = short cooldown, 35000 = long cooldown. The wanted UI only exposes short/long states and must be cleared manually after the cooldown ends.
+-- min build: 1311
+---@param ms number
+function _SetWantedCooldown(ms) end
+
+-- _SET_WEAPON_DEGRADATION_MODIFIER  (0x11A7FF918EF6BC66)
+-- min build: 1207
+---@param player number
+---@param modifier number
+function _SetWeaponDegradationModifier(player, modifier) end
+
+-- _SET_WEAPON_DRAW_SPEED  (0x00EB5A760638DB55)
+-- min build: 1207
+---@param player number
+---@param weaponHash number
+---@param modifier number
+function _SetWeaponDrawSpeed(player, weaponHash, modifier) end
+
+-- _SPECIAL_ABILITY_DRAIN_BY_AMOUNT  (0x200114E99552462B)
+-- Drains Deadeye by given amount.
+-- min build: 1207
+---@param player number
+---@param amount number
+---@param p2 any
+function _SpecialAbilityDrainByAmount(player, amount, p2) end
+
+-- _SPECIAL_ABILITY_GET_AMOUNT_CACHED  (0x029884FB65821B07)
+-- Returns Deadeye value from player
+-- min build: 1207
+---@param player number
+---@return number
+function _SpecialAbilityGetAmountCached(player) end
+
+-- _SPECIAL_ABILITY_RESTORE_BY_AMOUNT  (0x51345AE20F22C261)
+-- Restores Deadeye by given amount.
+-- Params: p2, p3, p4 = 0, 0, 1 in R* Scripts
+-- min build: 1207
+---@param player number
+---@param amount number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function _SpecialAbilityRestoreByAmount(player, amount, p2, p3, p4) end
+
+-- _SPECIAL_ABILITY_RESTORE_OUTER_RING  (0x2498035289B5688F)
+-- Only used in R* SP Script short_update
+-- Restores Deadeye Outer Ring
+-- min build: 1207
+---@param player number
+---@param amount number
+function _SpecialAbilityRestoreOuterRing(player, amount) end
+
+-- _SPECIAL_ABILITY_SET_ACTIVATE  (0xBBA140062B15A8AC)
+-- Activates the special ability for the specified player.
+-- Example usage:
+-- 
+-- Activate the special ability for the current player
+-- PLAYER::_SPECIAL_ABILITY_SET_ACTIVATE(PLAYER::PLAYER_ID());
+-- 
+-- Video: https://imgur.com/gallery/0xbba140062b15a8ac-P8jniMu
+-- min build: 1207
+---@param player number
+function _SpecialAbilitySetActivate(player) end
+
+-- _SPECIAL_ABILITY_SET_DISABLED  (0xAE637BB8EF017875)
+-- min build: 1207
+---@param player number
+---@param disabled boolean
+function _SpecialAbilitySetDisabled(player, disabled) end
+
+-- _SPECIAL_ABILITY_SET_EAGLE_EYE_DISABLED  (0xC0B21F235C02139C)
+-- min build: 1207
+---@param player number
+function _SpecialAbilitySetEagleEyeDisabled(player) end
+
+-- _SPECIAL_ABILITY_START_RESTORE  (0x1D77B47AFA584E90)
+-- Params: p1 = -1 in R* Scripts
+-- min build: 1207
+---@param player number
+---@param abilityType number
+---@param p2 boolean
+function _SpecialAbilityStartRestore(player, abilityType, p2) end
+
+-- _UNREGISTER_EAGLE_EYE_FOR_ENTITY  (0x9DAE1380CC5C6451)
+-- min build: 1207
+---@param player number
+---@param entity number
+function _UnregisterEagleEyeForEntity(player, entity) end
+
+-- _UNREGISTER_EAGLE_EYE_TRAILS_FOR_ENTITY  (0x9A957912CE2EABD1)
+-- min build: 1207
+---@param player number
+---@param entity number
+---@param p2 any
+function _UnregisterEagleEyeTrailsForEntity(player, entity, p2) end
+
+-- BOOST_PLAYER_HORSE_SPEED_FOR_TIME  (0x09C28F828EE674FA)
+-- min build: 1207
+---@param player number
+---@param speedBoost number
+---@param duration number
+function BoostPlayerHorseSpeedForTime(player, speedBoost, duration) end
+
+-- CAN_PLAYER_START_MISSION  (0x2DF170B1185AF777)
+-- min build: 1207
+---@param player number
+---@return boolean
+function CanPlayerStartMission(player) end
+
+-- CLEAR_PLAYER_HAS_DAMAGED_AT_LEAST_ONE_NON_ANIMAL_PED  (0x0361096D6CE4372C)
+-- min build: 1207
+---@param player number
+function ClearPlayerHasDamagedAtLeastOneNonAnimalPed(player) end
+
+-- CLEAR_PLAYER_HAS_DAMAGED_AT_LEAST_ONE_PED  (0x270B63A641BE32F2)
+-- min build: 1207
+---@param player number
+function ClearPlayerHasDamagedAtLeastOnePed(player) end
+
+-- CLEAR_PLAYER_WANTED_LEVEL  (0x4E4B996C928C7AA6)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param player number
+function ClearPlayerWantedLevel(player) end
+
+-- DISABLE_PLAYER_FIRING  (0x2970929FD5F9FC89)
+-- Inhibits the player from using any method of combat including melee and firearms.
+-- 
+-- NOTE: Only disables the firing for one frame
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function DisablePlayerFiring(player, toggle) end
+
+-- EAGLE_EYE_SET_CUSTOM_ENTITY_TINT  (0x62ED71E133B6C9F1)
+-- min build: 1207
+---@param entity number
+---@param red number
+---@param green number
+---@param blue number
+function EagleEyeSetCustomEntityTint(entity, red, green, blue) end
+
+-- FORCE_CLEANUP  (0x768C017FB878E4F4)
+-- min build: 1207
+---@param cleanupFlags number
+function ForceCleanup(cleanupFlags) end
+
+-- FORCE_CLEANUP_FOR_ALL_THREADS_WITH_THIS_NAME  (0xDAACAF8B687F2353)
+-- min build: 1207
+---@param name string
+---@param cleanupFlags number
+function ForceCleanupForAllThreadsWithThisName(name, cleanupFlags) end
+
+-- FORCE_CLEANUP_FOR_THREAD_WITH_THIS_ID  (0xF4C9512A2F0A3031)
+-- min build: 1207
+---@param id number
+---@param cleanupFlags number
+function ForceCleanupForThreadWithThisId(id, cleanupFlags) end
+
+-- GET_CAUSE_OF_MOST_RECENT_FORCE_CLEANUP  (0x84E8E29EBD4A46D2)
+-- min build: 1207
+---@return number
+function GetCauseOfMostRecentForceCleanup() end
+
+-- GET_DISCOVERABLE_NAME_HASH_AND_TYPE_FOR_ENTITY  (0x0139637A3BFF8B6D)
+-- Returns name hash (name) and outHash includes the type.
+-- min build: 1207
+---@param entity number
+---@return number
+---@return number
+function GetDiscoverableNameHashAndTypeForEntity(entity) end
+
+-- GET_ENTITY_PLAYER_IS_FREE_AIMING_AT  (0xA6817C110B830EAD)
+-- min build: 1207
+---@param player number
+---@return boolean
+---@return number
+function GetEntityPlayerIsFreeAimingAt(player) end
+
+-- GET_HAS_PLAYER_DISCOVERED_CHARACTER_NAME_MP  (0x354F689C4FFAAB37)
+-- min build: 1207
+---@param discoveryHash number
+---@return boolean
+function GetHasPlayerDiscoveredCharacterNameMp(discoveryHash) end
+
+-- GET_IS_PLAYER_UI_PROMPT_ACTIVE  (0x51BEA356B1C60225)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@return boolean
+function GetIsPlayerUiPromptActive(player, p1) end
+
+-- GET_MAX_WANTED_LEVEL  (0xD04CFAD1E2B7984A)
+-- Gets the maximum wanted level the player can get.
+-- Ranges from 0 to 5.
+-- min build: 1207
+---@return number
+function GetMaxWantedLevel() end
+
+-- GET_MOUNT_OWNED_BY_PLAYER  (0xF49F14462F0AE27C)
+-- min build: 1207
+---@param player number
+---@return number
+function GetMountOwnedByPlayer(player) end
+
+-- GET_PLAYER_CURRENT_STEALTH_NOISE  (0xD7ECC25E176ECBA5)
+-- min build: 1207
+---@param player number
+---@return number
+function GetPlayerCurrentStealthNoise(player) end
+
+-- GET_PLAYER_GROUP  (0x9BAB31815159ABCF)
+-- Returns the group ID the player is member of.
+-- min build: 1207
+---@param player number
+---@return number
+function GetPlayerGroup(player) end
+
+-- GET_PLAYER_INDEX  (0x47E385B0D957C8D4)
+-- Returns the same as PLAYER_ID and NETWORK_PLAYER_ID_TO_INT
+-- min build: 1207
+---@return number
+function GetPlayerIndex() end
+
+-- GET_PLAYER_INTERACTION_TARGET_ENTITY  (0x3EE1F7A8C32F24E1)
+-- min build: 1207
+---@param player number
+---@param p2 boolean
+---@param p3 boolean
+---@return boolean
+---@return number
+function GetPlayerInteractionTargetEntity(player, p2, p3) end
+
+-- GET_PLAYER_INVINCIBLE  (0x0CBBCB2CCFA7DC4E)
+-- Returns the player's invincibility status.
+-- min build: 1207
+---@param player number
+---@return boolean
+function GetPlayerInvincible(player) end
+
+-- GET_PLAYER_NAME  (0x7124FD9AC0E01BA0)
+-- min build: 1207
+---@param player number
+---@return string
+function GetPlayerName(player) end
+
+-- GET_PLAYER_PED  (0x275F255ED201B937)
+-- min build: 1207
+---@param player number
+---@return number
+function GetPlayerPed(player) end
+
+-- GET_PLAYER_PED_SCRIPT_INDEX  (0x5C880F9056D784C8)
+-- Does the same like PLAYER::GET_PLAYER_PED
+-- min build: 1207
+---@param player number
+---@return number
+function GetPlayerPedScriptIndex(player) end
+
+-- GET_PLAYER_RECEIVED_BATTLE_EVENT_RECENTLY  (0xFB6EB8785F808551)
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param p2 boolean
+---@return boolean
+function GetPlayerReceivedBattleEventRecently(player, p1, p2) end
+
+-- GET_PLAYER_TARGET_ENTITY  (0xAE663DDD99C8A670)
+-- min build: 1207
+---@param player number
+---@return boolean
+---@return number
+function GetPlayerTargetEntity(player) end
+
+-- GET_PLAYER_TEAM  (0xB464EB6A40C7975B)
+-- Gets the player's team.
+-- Returns -1 in singleplayer.
+-- min build: 1207
+---@param player number
+---@return number
+function GetPlayerTeam(player) end
+
+-- GET_PLAYER_WANTED_LEVEL  (0xABC532F9098BFD9D)
+-- min build: 1207
+---@param player number
+---@return number
+function GetPlayerWantedLevel(player) end
+
+-- GET_PLAYERS_LAST_VEHICLE  (0x2F96E7720B0B19EA)
+-- min build: 1207
+---@return number
+function GetPlayersLastVehicle() end
+
+-- GET_TARGET_CHARACTER_NAME_FOR_LOCAL_PLAYER  (0x36E3D8B5A6552FE8)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetTargetCharacterNameForLocalPlayer(ped) end
+
+-- GET_TARGET_CHARACTER_NAME_SCRIPT_OVERRIDE_HASH  (0x0335106F3ACABBED)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetTargetCharacterNameScriptOverrideHash(ped) end
+
+-- GET_TARGET_CHARACTER_NAME_SCRIPT_OVERRIDE_RAW_STRING  (0x755E08680F21EF30)
+-- min build: 1207
+---@param ped number
+---@return string
+function GetTargetCharacterNameScriptOverrideRawString(ped) end
+
+-- GET_WANTED_LEVEL_RADIUS  (0x80B00EB26D9521C7)
+-- Returns the radius for a wanted level, likely used for wanted blip/search volumes.
+-- Observed values: level 0 = 60.0, level 1 = 75.0, level 2 = 90.0, level 5 = 200.0.
+-- min build: 1207
+---@param wantedLevel number
+---@return number
+function GetWantedLevelRadius(wantedLevel) end
+
+-- GET_WANTED_LEVEL_THRESHOLD  (0x1B1A3B358F7D8F07)
+-- min build: 1207
+---@param wantedLevel number
+---@return number
+function GetWantedLevelThreshold(wantedLevel) end
+
+-- HAS_FORCE_CLEANUP_OCCURRED  (0xC11469DCA6FC3BB5)
+-- min build: 1207
+---@param cleanupFlags number
+---@return boolean
+function HasForceCleanupOccurred(cleanupFlags) end
+
+-- HAS_PLAYER_BEEN_SPOTTED_IN_STOLEN_VEHICLE  (0xC932F57F31EA9152)
+-- min build: 1207
+---@param player number
+---@return boolean
+function HasPlayerBeenSpottedInStolenVehicle(player) end
+
+-- HAS_PLAYER_DAMAGED_AT_LEAST_ONE_NON_ANIMAL_PED  (0x16C8D205DD5A2E90)
+-- min build: 1207
+---@param player number
+---@return boolean
+function HasPlayerDamagedAtLeastOneNonAnimalPed(player) end
+
+-- HAS_PLAYER_DAMAGED_AT_LEAST_ONE_PED  (0xDA4A4B9B96E20092)
+-- min build: 1207
+---@param player number
+---@return boolean
+function HasPlayerDamagedAtLeastOnePed(player) end
+
+-- INT_TO_PARTICIPANTINDEX  (0x58FF971FC8F2702C)
+-- Simply returns whatever is passed to it (Regardless of whether the handle is valid or not).
+-- min build: 1207
+---@param value number
+---@return number
+function IntToParticipantindex(value) end
+
+-- INT_TO_PLAYERINDEX  (0x748B3A65C2604C33)
+-- Simply returns whatever is passed to it (Regardless of whether the handle is valid or not).
+-- min build: 1207
+---@param value number
+---@return number
+function IntToPlayerindex(value) end
+
+-- IS_PLAYER_BEING_ARRESTED  (0xC8183AE963C58374)
+-- Return true while player is being arrested / busted.
+-- 
+-- If atArresting is set to 1, this function will return 1 when player is being arrested (while player is putting his hand up, but still have control)
+-- 
+-- If atArresting is set to 0, this function will return 1 only when the busted screen is shown.
+-- min build: 1207
+---@param player number
+---@param atArresting boolean
+---@return boolean
+function IsPlayerBeingArrested(player, atArresting) end
+
+-- IS_PLAYER_CLIMBING  (0xB8A70C22FD48197A)
+-- Returns TRUE if the player ('s ped) is climbing at the moment.
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerClimbing(player) end
+
+-- IS_PLAYER_CONTROL_ON  (0x7964097FCE4C244B)
+-- Returns whether the player can control himself.
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerControlOn(player) end
+
+-- IS_PLAYER_DEAD  (0x2E9C3FCB6798F397)
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerDead(player) end
+
+-- IS_PLAYER_FREE_AIMING  (0x936F967D4BE1CE9D)
+-- Gets a value indicating whether the specified player is currently aiming freely.
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerFreeAiming(player) end
+
+-- IS_PLAYER_FREE_AIMING_AT_ENTITY  (0x8C67C11C68713D25)
+-- Gets a value indicating whether the specified player is currently aiming freely at the specified entity.
+-- min build: 1207
+---@param player number
+---@param entity number
+---@return boolean
+function IsPlayerFreeAimingAtEntity(player, entity) end
+
+-- IS_PLAYER_PLAYING  (0xBFFB35986CAAE58C)
+-- Checks whether the specified player has a Ped, the Ped is not dead, is not injured and is not arrested.
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerPlaying(player) end
+
+-- IS_PLAYER_READY_FOR_CUTSCENE  (0xAA67BCB0097F2FA3)
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerReadyForCutscene(player) end
+
+-- IS_PLAYER_RIDING_TRAIN  (0x2FB0ACADA6A238DD)
+-- Returns true if the player is riding a train.
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerRidingTrain(player) end
+
+-- IS_PLAYER_SCRIPT_CONTROL_ON  (0xB78350754157C00F)
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerScriptControlOn(player) end
+
+-- IS_PLAYER_TARGETTING_ANYTHING  (0x4605C66E0F935F83)
+-- min build: 1207
+---@param player number
+---@return boolean
+function IsPlayerTargettingAnything(player) end
+
+-- IS_PLAYER_TARGETTING_ENTITY  (0x27F89FDC16688A7A)
+-- min build: 1207
+---@param player number
+---@param entity number
+---@param p2 boolean
+---@return boolean
+function IsPlayerTargettingEntity(player, entity, p2) end
+
+-- IS_PLAYER_TELEPORT_ACTIVE  (0x085EEAEB8783FEB5)
+-- min build: 1207
+---@return boolean
+function IsPlayerTeleportActive() end
+
+-- IS_PLAYER_WANTED_LEVEL_GREATER  (0xE1C0AD4C24324C36)
+-- min build: 1207
+---@param player number
+---@param wantedLevel number
+---@return boolean
+function IsPlayerWantedLevelGreater(player, wantedLevel) end
+
+-- IS_SYSTEM_UI_BEING_DISPLAYED  (0x908258B6209E71F7)
+-- min build: 1207
+---@return boolean
+function IsSystemUiBeingDisplayed() end
+
+-- NETWORK_PLAYER_ID_TO_INT  (0x8A9386F0749A17FA)
+-- Does exactly the same thing as PLAYER_ID()
+-- min build: 1207
+---@return number
+function NetworkPlayerIdToInt() end
+
+-- PLAYER_ID  (0x217E9DC48139933D)
+-- This returns YOUR 'identity' as a Player type.
+-- 
+-- Always returns 0 in story mode.
+-- min build: 1207
+---@return number
+function PlayerId() end
+
+-- PLAYER_PED_ID  (0x096275889B8E0EE0)
+-- Returns current player ped
+-- min build: 1207
+---@return number
+function PlayerPedId() end
+
+-- REPORT_POLICE_SPOTTED_PLAYER  (0xCBCCF73FFA69CC6B)
+-- min build: 1207
+---@param player number
+function ReportPoliceSpottedPlayer(player) end
+
+-- RESET_LAW_RESPONSE_DELAY_OVERRIDE  (0x5CE5CACC01D0F985)
+-- min build: 1207
+function ResetLawResponseDelayOverride() end
+
+-- RESET_PLAYER_ARREST_STATE  (0x12917931C31F1750)
+-- min build: 1207
+---@param player number
+function ResetPlayerArrestState(player) end
+
+-- RESET_PLAYER_INPUT_GAIT  (0x61A2EECAB274829B)
+-- min build: 1207
+---@param player number
+function ResetPlayerInputGait(player) end
+
+-- RESET_WANTED_LEVEL_DIFFICULTY  (0x062D14F18E8B0CAE)
+-- min build: 1207
+---@param player number
+function ResetWantedLevelDifficulty(player) end
+
+-- RESTORE_PLAYER_STAMINA  (0xC41F4B6E23FE6A4A)
+-- min build: 1207
+---@param player number
+---@param p1 number
+function RestorePlayerStamina(player, p1) end
+
+-- SET_AIR_DRAG_MULTIPLIER_FOR_PLAYERS_VEHICLE  (0x5DA6500FE849DA16)
+-- This can be between 1.0f - 50.0f
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function SetAirDragMultiplierForPlayersVehicle(player, multiplier) end
+
+-- SET_ALL_NEUTRAL_RANDOM_PEDS_FLEE_THIS_FRAME  (0x16752DAA7E6D3F72)
+-- min build: 1207
+---@param player number
+function SetAllNeutralRandomPedsFleeThisFrame(player) end
+
+-- SET_ALL_RANDOM_PEDS_FLEE  (0xE705309B8C6445A4)
+-- Sets whether all random peds will run away from player if they are agitated (threatened) (bool=true), or some peds can stand up for themselves (bool=false).
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetAllRandomPedsFlee(player, toggle) end
+
+-- SET_ALL_RANDOM_PEDS_FLEE_THIS_FRAME  (0xD5C198A62F1DEB0A)
+-- min build: 1207
+---@param player number
+function SetAllRandomPedsFleeThisFrame(player) end
+
+-- SET_EVERYONE_IGNORE_PLAYER  (0x34630A768925B852)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetEveryoneIgnorePlayer(player, toggle) end
+
+-- SET_LAW_RESPONSE_DELAY_OVERRIDE  (0xD2DFC9CCA5596A11)
+-- min build: 1207
+---@param p0 number
+function SetLawResponseDelayOverride(p0) end
+
+-- SET_LOCKON_TO_FRIENDLY_PLAYERS  (0x4A056257802DD3E5)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetLockonToFriendlyPlayers(player, toggle) end
+
+-- SET_MAX_WANTED_LEVEL  (0x28A4BD2CEE236E19)
+-- min build: 1207
+---@param maxWantedLevel number
+function SetMaxWantedLevel(maxWantedLevel) end
+
+-- SET_MIN_TIME_BEFORE_HORSE_BUCKING  (0x506CE71FB6E8CF5E)
+-- min build: 1207
+---@param mount number
+---@param iMinBuckTime number
+function SetMinTimeBeforeHorseBucking(mount, iMinBuckTime) end
+
+-- SET_PED_AS_TEMP_PLAYER_HORSE  (0x227B06324234FB09)
+-- min build: 1207
+---@param player number
+---@param horse number
+---@return boolean
+function SetPedAsTempPlayerHorse(player, horse) end
+
+-- SET_PLAYER_CAN_BE_HASSLED_BY_GANGS  (0xC7FE774412046825)
+-- Sets whether this player can be hassled by gangs.
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerCanBeHassledByGangs(player, toggle) end
+
+-- SET_PLAYER_CAN_USE_COVER  (0x5EDA520F7A3BAF4E)
+-- Sets whether this player can take cover.
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerCanUseCover(player, toggle) end
+
+-- SET_PLAYER_CLOTH_PIN_FRAMES  (0xD0D9317DFEEF9A66)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function SetPlayerClothPinFrames(ped, p1) end
+
+-- SET_PLAYER_CONTROL  (0x4D51E59243281D80)
+-- flags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eSetPlayerControlFlags
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+---@param flags number
+---@param bPreventHeadingChange boolean
+function SetPlayerControl(player, toggle, flags, bPreventHeadingChange) end
+
+-- SET_PLAYER_FORCED_AIM  (0xD5FCC166AEB2FD0F)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+---@param ped number
+---@param p3 number
+---@param p4 boolean
+function SetPlayerForcedAim(player, toggle, ped, p3, p4) end
+
+-- SET_PLAYER_HEALTH_RECHARGE_MULTIPLIER  (0x8899C244EBCF70DE)
+-- min build: 1207
+---@param player number
+---@param regenRate number
+function SetPlayerHealthRechargeMultiplier(player, regenRate) end
+
+-- SET_PLAYER_INVINCIBLE  (0xFEBEEBC9CBDF4B12)
+-- Simply sets you as invincible (Health will not deplete).
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerInvincible(player, toggle) end
+
+-- SET_PLAYER_LOCKON  (0x462AA1973CBBA75E)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerLockon(player, toggle) end
+
+-- SET_PLAYER_LOCKON_RANGE_OVERRIDE  (0x3A3CD06597388322)
+-- Affects the range of auto aim target.
+-- min build: 1207
+---@param player number
+---@param range number
+function SetPlayerLockonRangeOverride(player, range) end
+
+-- SET_PLAYER_MAY_NOT_ENTER_ANY_VEHICLE  (0xBEC463B3A11C909E)
+-- min build: 1207
+---@param player number
+function SetPlayerMayNotEnterAnyVehicle(player) end
+
+-- SET_PLAYER_MAY_ONLY_ENTER_THIS_VEHICLE  (0xDA35A134038557EC)
+-- min build: 1207
+---@param player number
+---@param vehicle number
+function SetPlayerMayOnlyEnterThisVehicle(player, vehicle) end
+
+-- SET_PLAYER_MELEE_WEAPON_DAMAGE_MODIFIER  (0xE4CB5A3F18170381)
+-- min build: 1207
+---@param player number
+---@param modifier number
+function SetPlayerMeleeWeaponDamageModifier(player, modifier) end
+
+-- SET_PLAYER_MODEL  (0xED40380076A31506)
+-- Make sure to request the model first and wait until it has loaded.
+-- min build: 1207
+---@param player number
+---@param modelHash number
+---@param p2 boolean
+function SetPlayerModel(player, modelHash, p2) end
+
+-- SET_PLAYER_NOISE_MULTIPLIER  (0xB5EC6BDAEBCA454C)
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function SetPlayerNoiseMultiplier(player, multiplier) end
+
+-- SET_PLAYER_SIMULATE_AIMING  (0xE0447DEF81CCDFD2)
+-- min build: 1207
+---@param player number
+---@param toggle boolean
+function SetPlayerSimulateAiming(player, toggle) end
+
+-- SET_PLAYER_SNEAKING_NOISE_MULTIPLIER  (0x4DE44FA389DCA565)
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function SetPlayerSneakingNoiseMultiplier(player, multiplier) end
+
+-- SET_PLAYER_STAMINA_RECHARGE_MULTIPLIER  (0xFECA17CF3343694B)
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function SetPlayerStaminaRechargeMultiplier(player, multiplier) end
+
+-- SET_PLAYER_TARGETING_MODE  (0xD66A941F401E7302)
+-- Sets your targeting mode for when you're on foot.
+-- enum eTargetingMode
+-- {
+-- 	TARGETING_MODE_INVALID = -1,
+-- 	TARGETING_MODE_CAUSAL, (Wide)
+-- 	TARGETING_MODE_NORMAL,
+-- 	TARGETING_MODE_HARD, (Narrow)
+-- 	TARGETING_MODE_EXPERT (Free Aim)
+-- };
+-- min build: 1207
+---@param targetMode number
+function SetPlayerTargetingMode(targetMode) end
+
+-- SET_PLAYER_TEAM  (0xE8DD8536F01DE600)
+-- Sets the player's team.
+-- min build: 1207
+---@param player number
+---@param team number
+---@param bRestrictToThisScript boolean
+function SetPlayerTeam(player, team, bRestrictToThisScript) end
+
+-- SET_PLAYER_WANTED_LEVEL  (0x384D4765395E006C)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param player number
+---@param wantedLevel number
+---@param disableNoMission boolean
+function SetPlayerWantedLevel(player, wantedLevel, disableNoMission) end
+
+-- SET_PLAYER_WEAPON_DAMAGE_MODIFIER  (0x94D529F7B73D7A85)
+-- This modifies the damage value of your weapon. Whether it is a multiplier or base damage is unknown.
+-- min build: 1207
+---@param player number
+---@param modifier number
+function SetPlayerWeaponDamageModifier(player, modifier) end
+
+-- SET_PLAYER_WEAPON_DEFENSE_MODIFIER  (0xD15CC2D493160BE3)
+-- min build: 1207
+---@param player number
+---@param modifier number
+function SetPlayerWeaponDefenseModifier(player, modifier) end
+
+-- SET_PLAYER_WEAPON_TYPE_DAMAGE_MODIFIER  (0xD04AD186CE8BB129)
+-- min build: 1207
+---@param player number
+---@param weaponHash number
+---@param damageModifier number
+function SetPlayerWeaponTypeDamageModifier(player, weaponHash, damageModifier) end
+
+-- SET_POLICE_RADAR_BLIPS  (0x6FD7DD6B63F2820E)
+-- If toggle is set to false:
+--  The police won't be shown on the (mini)map
+-- 
+-- If toggle is set to true:
+--  The police will be shown on the (mini)map
+-- min build: 1207
+---@param toggle boolean
+function SetPoliceRadarBlips(toggle) end
+
+-- SET_SWIM_MULTIPLIER_FOR_PLAYER  (0xBFCEABDE34DA5085)
+-- Swim speed multiplier.
+-- Multiplier goes up to 1.49f
+-- min build: 1207
+---@param player number
+---@param multiplier number
+function SetSwimMultiplierForPlayer(player, multiplier) end
+
+-- SET_WANTED_LEVEL_MULTIPLIER  (0xD7FA719CB54866C2)
+-- min build: 1207
+---@param multiplier number
+function SetWantedLevelMultiplier(multiplier) end
+
+-- SIMULATE_PLAYER_INPUT_GAIT  (0xFA0C063C422C4355)
+-- min build: 1207
+---@param player number
+---@param speed number
+---@param duration number
+---@param heading number
+---@param p4 boolean
+---@param p5 boolean
+function SimulatePlayerInputGait(player, speed, duration, heading, p4, p5) end
+
+-- START_PLAYER_TELEPORT  (0xDF8822C55EDDA65B)
+-- min build: 1207
+---@param player number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+function StartPlayerTeleport(player, x, y, z, heading, p5, p6, p7, p8) end
+
+-- STOP_PLAYER_TELEPORT  (0x0858B86146601BE8)
+-- Disables the player's teleportation
+-- min build: 1207
+function StopPlayerTeleport() end
+
+-- SUPPRESS_WITNESSES_CALLING_POLICE_THIS_FRAME  (0x96722257E5381E00)
+-- min build: 1207
+---@param player number
+function SuppressWitnessesCallingPoliceThisFrame(player) end
+
+-- UPDATE_PLAYER_TELEPORT  (0xC39DCE4672CBFBC1)
+-- min build: 1207
+---@param player number
+---@return boolean
+function UpdatePlayerTeleport(player) end
+
+-- UPDATE_WANTED_POSITION_THIS_FRAME  (0xD0B0B044112BF424)
+-- min build: 1207
+---@param player number
+function UpdateWantedPositionThisFrame(player) end

--- a/.luals/redm-natives/POPULATION.lua
+++ b/.luals/redm-natives/POPULATION.lua
@@ -1,0 +1,217 @@
+---@meta
+
+-- RDR3 namespace: POPULATION -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x08892122769770D5  (0x08892122769770D5)
+-- min build: 1207
+---@param popZone number
+---@param p1 boolean
+function N_0x08892122769770D5(popZone, p1) end
+
+-- _0x0F1861101C9A9944  (0x0F1861101C9A9944)
+-- min build: 1207
+---@param popZone number
+---@param p1 boolean
+function N_0x0F1861101C9A9944(popZone, p1) end
+
+-- _0x2161278C6322F740  (0x2161278C6322F740)
+-- min build: 1207
+---@param includeFlags number
+---@param excludeFlags number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param volume number
+function N_0x2161278C6322F740(includeFlags, excludeFlags, p2, p3, p4, volume) end
+
+-- _0x247F86595D396344  (0x247F86595D396344)
+-- min build: 1207
+---@param p0 any
+function N_0x247F86595D396344(p0) end
+
+-- _0x2660E7720EDC4BD0  (0x2660E7720EDC4BD0)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x2660E7720EDC4BD0(p0, p1, p2) end
+
+-- _0x324AB2A68AD8AEE5  (0x324AB2A68AD8AEE5)
+-- min build: 1207
+function N_0x324AB2A68AD8AEE5() end
+
+-- _0x578E2FA64E847C60  (0x578E2FA64E847C60)
+-- min build: 1207
+---@param popZone number
+---@param p1 number
+function N_0x578E2FA64E847C60(popZone, p1) end
+
+-- _0x638FCFC6042A9473  (0x638FCFC6042A9473)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x638FCFC6042A9473(p0, p1) end
+
+-- _0x7E6BC0B94F5928F0  (0x7E6BC0B94F5928F0)
+-- min build: 1207
+---@param popZone number
+---@param p1 number
+---@param p2 number
+function N_0x7E6BC0B94F5928F0(popZone, p1, p2) end
+
+-- _0x8EC7CD701F872F87  (0x8EC7CD701F872F87)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0x8EC7CD701F872F87(p0, p1, p2, p3, p4, p5) end
+
+-- _0xC4533E3E87125C9E  (0xC4533E3E87125C9E)
+-- min build: 1207
+---@param p0 any
+function N_0xC4533E3E87125C9E(p0) end
+
+-- _0xDBBF12EA7C1029B2  (0xDBBF12EA7C1029B2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDBBF12EA7C1029B2(p0, p1) end
+
+-- _0xEC116EDB683AD479  (0xEC116EDB683AD479)
+-- Only used for Special Event (XMAS).
+-- _SET_P*
+-- min build: 1207
+---@param p0 boolean
+function N_0xEC116EDB683AD479(p0) end
+
+-- _0xF45E46DEECF7DF6E  (0xF45E46DEECF7DF6E)
+-- min build: 1207
+---@param bitFlag number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xF45E46DEECF7DF6E(bitFlag, p1, p2, p3, p4) end
+
+-- _ADD_AMBIENT_AVOIDANCE_RESTRICTION  (0xB56D41A694E42E86)
+-- flags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/PedFilterFlags
+-- min build: 1207
+---@param volume number
+---@param includeFlags number
+---@param excludeFlags number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+function _AddAmbientAvoidanceRestriction(volume, includeFlags, excludeFlags, p3, p4, p5, p6) end
+
+-- _ADD_AMBIENT_SPAWN_RESTRICTION  (0x18262CAFEBB5FBE1)
+-- flags: see 0xB56D41A694E42E86
+-- min build: 1207
+---@param volume number
+---@param includeFlags number
+---@param excludeFlags number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+function _AddAmbientSpawnRestriction(volume, includeFlags, excludeFlags, p3, p4, p5, p6) end
+
+-- _CREATE_POPZONE_FROM_VOLUME  (0x9AC1C64FE46B6D09)
+-- min build: 1207
+---@param volume number
+---@return number
+function _CreatePopzoneFromVolume(volume) end
+
+-- _DELETE_SCRIPT_POPZONE  (0xA6E6A66FC4CA4224)
+-- min build: 1207
+---@param popZone number
+function _DeleteScriptPopzone(popZone) end
+
+-- _GET_RANDOM_FISH_TYPE_FOR_LOCATION  (0x595478B3BBC3076D)
+-- Returns model hash of the closest fish
+-- min build: 1207
+---@return number
+function _GetRandomFishTypeForLocation() end
+
+-- _IS_POPZONE_VALID  (0xA5BD585005EFCAD4)
+-- min build: 1207
+---@param popZone number
+---@return boolean
+function _IsPopzoneValid(popZone) end
+
+-- _REMOVE_AMBIENT_AVOIDANCE_RESTRICTION  (0x74C2B3DC0B294102)
+-- flags: see 0xB56D41A694E42E86
+-- min build: 1207
+---@param volume number
+function _RemoveAmbientAvoidanceRestriction(volume) end
+
+-- _REMOVE_AMBIENT_SPAWN_RESTRICTION  (0xA1CFB35069D23C23)
+-- min build: 1207
+---@param volume number
+function _RemoveAmbientSpawnRestriction(volume) end
+
+-- _SET_PED_SHOULD_IGNORE_AVOIDANCE_VOLUMES  (0xF74E134F40192884)
+-- Params: p1 = 1 & 2 in R* Scripts, 0 = Disable avoidance, 1 = Enabled avoidance, 2 = Enabled avoidance (?)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function _SetPedShouldIgnoreAvoidanceVolumes(ped, p1) end
+
+-- CLEAR_SPAWNER_INFO_PRIORITY  (0x217A54DE2D200305)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function ClearSpawnerInfoPriority(p0, p1) end
+
+-- DISABLE_AMBIENT_ROAD_POPULATION  (0xC6DCC2A3A8825C85)
+-- min build: 1207
+---@param unk boolean
+function DisableAmbientRoadPopulation(unk) end
+
+-- ENABLE_AMBIENT_ROAD_POPULATION  (0xBC90BDF4E5228EA1)
+-- min build: 1207
+function EnableAmbientRoadPopulation() end
+
+-- GET_NUM_MODELS_IN_POPULATION_SET  (0xA1E3171ED0E47564)
+-- min build: 1207
+---@param popSetHash number
+---@return number
+function GetNumModelsInPopulationSet(popSetHash) end
+
+-- GET_PED_MODEL_NAME_IN_POPULATION_SET  (0x3EAFA1C533B7139E)
+-- min build: 1207
+---@param popSetHash number
+---@param index number
+---@return number
+function GetPedModelNameInPopulationSet(popSetHash, index) end
+
+-- GET_RANDOM_MODEL_FROM_POPULATION_SET  (0x6B12ED8C77E8567B)
+-- min build: 1207
+---@param popSetHash number
+---@param flags number
+---@param p2 number
+---@param p3 boolean
+---@param p4 boolean
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function GetRandomModelFromPopulationSet(popSetHash, flags, p2, p3, p4, x, y, z) end
+
+-- SET_POPZONE_POPULATION_SET  (0x3E6A49D9B519E85C)
+-- min build: 1207
+---@param popZone number
+---@param populationSetHash number
+function SetPopzonePopulationSet(popZone, populationSetHash) end
+
+-- SET_SPAWNER_INFO_PRIORITY  (0x60CDE717A6D47769)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param priority number
+function SetSpawnerInfoPriority(p0, p1, priority) end

--- a/.luals/redm-natives/POSSE.lua
+++ b/.luals/redm-natives/POSSE.lua
@@ -1,0 +1,200 @@
+---@meta
+
+-- RDR3 namespace: POSSE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0xC06CFF658B2E51DA  (0xC06CFF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xC06CFF658B2E51DA(p0, p1, p2) end
+
+-- _0xC07CFF658B2E51DA  (0xC07CFF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC07CFF658B2E51DA(p0, p1) end
+
+-- _0xC084FF658B2E52DA  (0xC084FF658B2E52DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC084FF658B2E52DA(p0) end
+
+-- _0xC084FF658B2E53DA  (0xC084FF658B2E53DA)
+-- min build: 1207
+---@return any
+function N_0xC084FF658B2E53DA() end
+
+-- _0xC084FF658B2E54DA  (0xC084FF658B2E54DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC084FF658B2E54DA(p0) end
+
+-- _0xC084FF658B2E55DA  (0xC084FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC084FF658B2E55DA(p0, p1) end
+
+-- _0xC084FF658B2E61DA  (0xC084FF658B2E61DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC084FF658B2E61DA(p0) end
+
+-- _0xC084FF658B2E71DA  (0xC084FF658B2E71DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xC084FF658B2E71DA(p0, p1, p2) end
+
+-- _0xC084FF658B2E81DA  (0xC084FF658B2E81DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xC084FF658B2E81DA(p0, p1, p2) end
+
+-- _0xC086FF658B2E51DA  (0xC086FF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC086FF658B2E51DA(p0) end
+
+-- _0xC086FF658B2E51DB  (0xC086FF658B2E51DB)
+-- min build: 1207
+---@return any
+function N_0xC086FF658B2E51DB() end
+
+-- _0xC087FF658B2E51DA  (0xC087FF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC087FF658B2E51DA(p0, p1) end
+
+-- _0xC089FF658B2E51DA  (0xC089FF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC089FF658B2E51DA(p0, p1) end
+
+-- _0xC08AFF658B2E51DA  (0xC08AFF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+function N_0xC08AFF658B2E51DA(p0) end
+
+-- _0xC08AFF658B2E51DB  (0xC08AFF658B2E51DB)
+-- min build: 1207
+---@param p0 any
+function N_0xC08AFF658B2E51DB(p0) end
+
+-- _0xC08BFF658B2E51DA  (0xC08BFF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC08BFF658B2E51DA(p0) end
+
+-- _0xC08CFF658B2E51DA  (0xC08CFF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC08CFF658B2E51DA(p0, p1) end
+
+-- _0xC08DEF658B2E51DA  (0xC08DEF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC08DEF658B2E51DA(p0) end
+
+-- _0xC08DFF658B2E51DA  (0xC08DFF658B2E51DA)
+-- min build: 1207
+---@return any
+function N_0xC08DFF658B2E51DA() end
+
+-- _0xC08DFF658B2E51DB  (0xC08DFF658B2E51DB)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC08DFF658B2E51DB(p0) end
+
+-- _0xC08EFF658B2E51DB  (0xC08EFF658B2E51DB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC08EFF658B2E51DB(p0, p1) end
+
+-- _0xC08FFF658B2E51DA  (0xC08FFF658B2E51DA)
+-- min build: 1207
+---@return any
+function N_0xC08FFF658B2E51DA() end
+
+-- _0xC08FFF658B2E51DB  (0xC08FFF658B2E51DB)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xC08FFF658B2E51DB(p0) end
+
+-- _0xC09CFF658B2E51DA  (0xC09CFF658B2E51DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xC09CFF658B2E51DA(p0, p1, p2) end
+
+-- _0xC184FF658B2E55DA  (0xC184FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xC184FF658B2E55DA(p0, p1) end
+
+-- _0xC284FF658B2E55DA  (0xC284FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xC284FF658B2E55DA(p0, p1, p2) end
+
+-- _0xC394FF658B2E55DA  (0xC394FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xC394FF658B2E55DA(p0, p1, p2, p3) end
+
+-- _0xC484FF658B2E55DA  (0xC484FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+function N_0xC484FF658B2E55DA(p0) end
+
+-- _0xC584FF658B2E55DA  (0xC584FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+function N_0xC584FF658B2E55DA(p0) end
+
+-- _0xC684FF658B2E55DA  (0xC684FF658B2E55DA)
+-- min build: 1207
+---@param p0 any
+function N_0xC684FF658B2E55DA(p0) end
+
+-- POSSE_GET_POSSE_MEMBERSHIP_COUNT  (0xC088FF658B2E51DA)
+-- min build: 1207
+---@return number
+function PosseGetPosseMembershipCount() end

--- a/.luals/redm-natives/PROPSET.lua
+++ b/.luals/redm-natives/PROPSET.lua
@@ -1,0 +1,285 @@
+---@meta
+
+-- RDR3 namespace: PROPSET -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x58E0B01D45CA7357  (0x58E0B01D45CA7357)
+-- min build: 1207
+---@param p0 any
+function N_0x58E0B01D45CA7357(p0) end
+
+-- _ADD_ADDITIONAL_PROP_SET_FOR_VEHICLE  (0x75F90E4051CC084C)
+-- https://github.com/femga/rdr3_discoveries/blob/master/vehicles/vehicle_modding/vehicle_propsets.lua
+-- min build: 1207
+---@param vehicle number
+---@param propset number
+function _AddAdditionalPropSetForVehicle(vehicle, propset) end
+
+-- _ADD_LIGHT_PROP_SET_TO_VEHICLE  (0xC0F0417A90402742)
+-- To remove propsets either parse a zero as hash or call 0xE31C0CB1C3186D40
+-- 0xA6A9712955F53D9C returns lightPropset Hashes
+-- https://github.com/femga/rdr3_discoveries/blob/master/vehicles/vehicle_modding/vehicle_lantern_propsets.lua
+-- min build: 1207
+---@param vehicle number
+---@param lightPropset number
+function _AddLightPropSetToVehicle(vehicle, lightPropset) end
+
+-- _ADD_PROP_SET_FOR_VEHICLE  (0xD80FAF919A2E56EA)
+-- List of vehicle propsets (wagons & trains): https://pastebin.com/1CsnvGLu / https://pastebin.com/v7TtqTgE
+-- min build: 1207
+---@param vehicle number
+---@param propset number
+function _AddPropSetForVehicle(vehicle, propset) end
+
+-- _CREATE_PROP_SET  (0xE65C5CBA95F0E510)
+-- propsetType: https://github.com/femga/rdr3_discoveries/blob/master/objects/propsets_list.lua
+-- placementType: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/PlacementType
+-- min build: 1207
+---@param propsetType number
+---@param x number
+---@param y number
+---@param z number
+---@param placementType number
+---@param heading number
+---@param zProbe number
+---@param p7 boolean
+---@param useVegMod boolean
+---@return number
+function _CreatePropSet(propsetType, x, y, z, placementType, heading, zProbe, p7, useVegMod) end
+
+-- _CREATE_PROP_SET_2  (0x899C97A1CCE7D483)
+-- Same as _CREATE_PROP_SET
+-- min build: 1207
+---@param propsetType number
+---@param x number
+---@param y number
+---@param z number
+---@param placementType number
+---@param heading number
+---@param zProbe number
+---@param p7 boolean
+---@param useVegMod boolean
+---@return number
+function _CreatePropSet2(propsetType, x, y, z, placementType, heading, zProbe, p7, useVegMod) end
+
+-- _CREATE_PROP_SET_INSTANCE_ATTACHED_TO_ENTITY_2  (0xACA7FB30269096D4)
+-- Same as CREATE_PROP_SET_INSTANCE_ATTACHED_TO_ENTITY
+-- min build: 1207
+---@param hash number
+---@param x number
+---@param y number
+---@param z number
+---@param entity number
+---@param p5 number
+---@param p6 boolean
+---@param p7 number
+---@param p8 boolean
+---@return number
+function _CreatePropSetInstanceAttachedToEntity2(hash, x, y, z, entity, p5, p6, p7, p8) end
+
+-- _DELETE_PROP_SET  (0x58AC173A55D9D7B4)
+-- min build: 1207
+---@param propSet number
+---@param p1 boolean
+---@param p2 boolean
+function _DeletePropSet(propSet, p1, p2) end
+
+-- _DOES_PROP_SET_OF_TYPE_EXIST_NEAR_COORDS  (0x72068021F498E6E3)
+-- min build: 1207
+---@param propsetHash number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function _DoesPropSetOfTypeExistNearCoords(propsetHash, x, y, z) end
+
+-- _DOES_VEHICLE_HAVE_ANY_LIGHT_PROP_SET  (0xC9B4B3A36F81FD75)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _DoesVehicleHaveAnyLightPropSet(vehicle) end
+
+-- _DOES_VEHICLE_HAVE_ANY_PROP_SET  (0x53784CEA0159439B)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _DoesVehicleHaveAnyPropSet(vehicle) end
+
+-- _GET_ENTITIES_FROM_PROP_SET  (0x738271B660FE0695)
+-- min build: 1207
+---@param propSet number
+---@param itemSet number
+---@param model number
+---@param p3 boolean
+---@param p4 boolean
+---@return number
+function _GetEntitiesFromPropSet(propSet, itemSet, model, p3, p4) end
+
+-- _GET_PROP_SET_AT_COORDS  (0xC061E50F8D299F95)
+-- min build: 1207
+---@param propsetHash number
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function _GetPropSetAtCoords(propsetHash, x, y, z) end
+
+-- _GET_PROP_SET_MODEL  (0xA6A9712955F53D9C)
+-- min build: 1207
+---@param propSet number
+---@return number
+function _GetPropSetModel(propSet) end
+
+-- _GET_TRAIN_CARRIAGE_PROP_SET  (0xCFC0BD09BB1B73FF)
+-- Example before/after deleting a train carriage's propset: https://imgur.com/a/qRNrIrK
+-- min build: 1207
+---@param trainCarriage number
+---@return number
+function _GetTrainCarriagePropSet(trainCarriage) end
+
+-- _GET_VEHICLE_LIGHT_PROP_SET  (0xA079300AF757FB1A)
+-- Returns PropSet handle to be used with _GET_PROP_SET_MODEL
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetVehicleLightPropSet(vehicle) end
+
+-- _GET_VEHICLE_PROP_SET  (0xCE2ACD6F602803E5)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetVehiclePropSet(vehicle) end
+
+-- _GET_VEHICLE_PROP_SET_HASH  (0x36F69E7A22655653)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetVehiclePropSetHash(vehicle) end
+
+-- _HAS_PROP_SET_LOADED  (0x48A88FC684C55FDC)
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _HasPropSetLoaded(hash) end
+
+-- _HAS_PROP_SET_LOADED_2  (0xD090ABEF4D6A7D96)
+-- Same as _HAS_PROP_SET_LOADED
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _HasPropSetLoaded2(hash) end
+
+-- _HAS_VEHICLE_TRAILER_PROP_SET_LOADED  (0x8F3333F0A6900B3C)
+-- min build: 1207
+---@param vehicle number
+---@param wagonIndex number
+---@return boolean
+function _HasVehicleTrailerPropSetLoaded(vehicle, wagonIndex) end
+
+-- _IS_PROP_SET_VISIBLE  (0x0CE8AAFE9E433A23)
+-- min build: 1207
+---@param propSet number
+---@return boolean
+function _IsPropSetVisible(propSet) end
+
+-- _IS_VEHICLE_LIGHT_PROP_SET_LOADED  (0x0790473EEE1977D3)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehicleLightPropSetLoaded(vehicle) end
+
+-- _IS_VEHICLE_PROP_SET_LOADED  (0x155B2FBE72D7D1D0)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehiclePropSetLoaded(vehicle) end
+
+-- _IS_VEHICLE_PROP_SET_LOADED_ADDITIONAL  (0x7264F9CA87A9830B)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehiclePropSetLoadedAdditional(vehicle) end
+
+-- _MOVE_PROPSET_COORDS_AND_HEADING  (0xC4B67EF3FD65622D)
+-- Relocates an existing prop set to specified coordinates and adjusts its heading (rotation) without affecting the prop set's internal layout or structure.
+-- When `onGroundProperly` is true, the prop set automatically aligns accurately with the terrain.
+-- min build: 1207
+---@param propSet number
+---@param x number
+---@param y number
+---@param z number
+---@param onGroundProperly boolean
+---@param heading number
+function _MovePropsetCoordsAndHeading(propSet, x, y, z, onGroundProperly, heading) end
+
+-- _RELEASE_PROP_SET  (0xB1964A83B345B4AB)
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _ReleasePropSet(hash) end
+
+-- _REMOVE_VEHICLE_LIGHT_PROP_SETS  (0xE31C0CB1C3186D40)
+-- min build: 1207
+---@param vehicle number
+function _RemoveVehicleLightPropSets(vehicle) end
+
+-- _REMOVE_VEHICLE_PROP_SETS  (0x3BCF32FF37EA9F1D)
+-- min build: 1207
+---@param vehicle number
+function _RemoveVehiclePropSets(vehicle) end
+
+-- _REQUEST_PROP_SET  (0xF3DE57A46D5585E9)
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _RequestPropSet(hash) end
+
+-- _REQUEST_PROP_SET_2  (0xE72F591958F3ACAB)
+-- Same as _REQUEST_PROP_SET
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _RequestPropSet2(hash) end
+
+-- _SET_PROP_SET_AS_NO_LONGER_NEEDED  (0x909E3C7FAE539FB1)
+-- min build: 1207
+---@param propSet number
+function _SetPropSetAsNoLongerNeeded(propSet) end
+
+-- _SET_PROP_SET_FLAG  (0xC1AB7EEFD3E6EE49)
+-- min build: 1207
+---@param propSet number
+---@param flag number
+function _SetPropSetFlag(propSet, flag) end
+
+-- _SET_PROP_SET_VISIBLE  (0x9D096A5BD02F953E)
+-- min build: 1207
+---@param propSet number
+---@param toggle boolean
+function _SetPropSetVisible(propSet, toggle) end
+
+-- CREATE_PROP_SET_INSTANCE_ATTACHED_TO_ENTITY  (0x9609DBDDE18FAD8C)
+-- min build: 1207
+---@param hash number
+---@param x number
+---@param y number
+---@param z number
+---@param entity number
+---@param p5 number
+---@param p6 boolean
+---@param p7 number
+---@param p8 boolean
+---@return number
+function CreatePropSetInstanceAttachedToEntity(hash, x, y, z, entity, p5, p6, p7, p8) end
+
+-- DOES_PROP_SET_EXIST  (0x7DDDCF815E650FF5)
+-- min build: 1207
+---@param propSet number
+---@return boolean
+function DoesPropSetExist(propSet) end
+
+-- IS_PROP_SET_FULLY_LOADED  (0xF42DB680A8B2A4D9)
+-- min build: 1207
+---@param propSet number
+---@return boolean
+function IsPropSetFullyLoaded(propSet) end

--- a/.luals/redm-natives/QUEUE.lua
+++ b/.luals/redm-natives/QUEUE.lua
@@ -1,0 +1,15 @@
+---@meta
+
+-- RDR3 namespace: QUEUE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _EVENT_QUEUE_IS_EMPTY  (0x402B5D7D269FF796)
+-- min build: 1207
+---@param hash number
+---@return boolean
+function _EventQueueIsEmpty(hash) end
+
+-- _EVENT_QUEUE_POP  (0xD87DF294B049211D)
+-- min build: 1207
+---@param hash number
+function _EventQueuePop(hash) end

--- a/.luals/redm-natives/RECORDING.lua
+++ b/.luals/redm-natives/RECORDING.lua
@@ -1,0 +1,11 @@
+---@meta
+
+-- RDR3 namespace: RECORDING -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- REPLAY_PREVENT_RECORDING_THIS_FRAME  (0xA8C44C13419634F2)
+-- nullsub, doesn't do anything
+-- 
+-- Old name: _STOP_RECORDING_THIS_FRAME
+-- min build: 1207
+function ReplayPreventRecordingThisFrame() end

--- a/.luals/redm-natives/REPLAY.lua
+++ b/.luals/redm-natives/REPLAY.lua
@@ -1,0 +1,36 @@
+---@meta
+
+-- RDR3 namespace: REPLAY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- CLOSE_VIDEO_EDITOR  (0xCEEC64BD27A59312)
+-- Hardcoded to return true.
+-- min build: 1207
+---@param p0 any
+---@return boolean
+function CloseVideoEditor(p0) end
+
+-- IS_VIDEO_EDITOR_RUNNING  (0x9EEB007317FA3B9C)
+-- Hardcoded to return false.
+-- min build: 1207
+---@return boolean
+function IsVideoEditorRunning() end
+
+-- OPEN_VIDEO_EDITOR  (0xB3F2829907403C13)
+-- Hardcoded to return true.
+-- min build: 1207
+---@return boolean
+function OpenVideoEditor() end
+
+-- REPLAY_SYSTEM_HAS_REQUESTED_A_SCRIPT_CLEANUP  (0x0F838D47DE58EDB2)
+-- Hardcoded to return false.
+-- 
+-- Old name: _IS_INTERIOR_RENDERING_DISABLED
+-- min build: 1207
+---@return boolean
+function ReplaySystemHasRequestedAScriptCleanup() end
+
+-- SET_SCRIPTS_HAVE_CLEANED_UP_FOR_REPLAY_SYSTEM  (0x57C6525034E76EB0)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function SetScriptsHaveCleanedUpForReplaySystem() end

--- a/.luals/redm-natives/SAVE.lua
+++ b/.luals/redm-natives/SAVE.lua
@@ -1,0 +1,169 @@
+---@meta
+
+-- RDR3 namespace: SAVE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x443174C20B8B9E7F  (0x443174C20B8B9E7F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x443174C20B8B9E7F(p0, p1, p2) end
+
+-- _0x4FB5869E2B37FC00  (0x4FB5869E2B37FC00)
+-- min build: 1207
+function N_0x4FB5869E2B37FC00() end
+
+-- _0x81F4E92BE3958364  (0x81F4E92BE3958364)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x81F4E92BE3958364(p0, p1, p2) end
+
+-- _0x8E8FFB9E4AD051D2  (0x8E8FFB9E4AD051D2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x8E8FFB9E4AD051D2(p0, p1, p2, p3) end
+
+-- _0x9BB83C4DD7BE0802  (0x9BB83C4DD7BE0802)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x9BB83C4DD7BE0802(p0, p1, p2, p3, p4) end
+
+-- _0xA7ECEBAFBAF997A5  (0xA7ECEBAFBAF997A5)
+-- min build: 1436
+---@param savegameType number
+---@return any
+function N_0xA7ECEBAFBAF997A5(savegameType) end
+
+-- _0xA844FEB5C22C2C74  (0xA844FEB5C22C2C74)
+-- min build: 1207
+function N_0xA844FEB5C22C2C74() end
+
+-- _0xB00CE33465B5406D  (0xB00CE33465B5406D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xB00CE33465B5406D(p0, p1) end
+
+-- _0xC0ABF784590798A9  (0xC0ABF784590798A9)
+-- min build: 1207
+---@param p0 any
+function N_0xC0ABF784590798A9(p0) end
+
+-- _0xE0B45E983BFC0768  (0xE0B45E983BFC0768)
+-- min build: 1207
+function N_0xE0B45E983BFC0768() end
+
+-- _0xE8346E62FD7FB962  (0xE8346E62FD7FB962)
+-- min build: 1207
+function N_0xE8346E62FD7FB962() end
+
+-- _0xED4B0C1057892B2E  (0xED4B0C1057892B2E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xED4B0C1057892B2E(p0, p1, p2, p3) end
+
+-- _SAVEGAME_GET_BOOL  (0xBB7F4273C186BC4B)
+-- Does the exact same as 0x529B9CCD0972AF4E
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetBool(variableName) end
+
+-- _SAVEGAME_GET_FLOAT  (0x35DEFECAE36D4FAE)
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetFloat(variableName) end
+
+-- _SAVEGAME_GET_INT  (0x529B9CCD0972AF4E)
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetInt(variableName) end
+
+-- _SAVEGAME_GET_INT_2  (0x529B9CCD0972AF4D)
+-- Does the exact same as 0x529B9CCD0972AF4E
+-- Commonly used with time/timestamps
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetInt2(variableName) end
+
+-- _SAVEGAME_GET_INT_3  (0xB25B5A375BE5BE26)
+-- Does the exact same as 0x529B9CCD0972AF4E
+-- Commonly used with enums and flags
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetInt3(variableName) end
+
+-- _SAVEGAME_GET_TEXT_LABEL_23  (0x5A10D6506B2F2C63)
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetTextLabel23(variableName) end
+
+-- _SAVEGAME_GET_TEXT_LABEL_31  (0x4845E7E7643A908C)
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetTextLabel31(variableName) end
+
+-- _SAVEGAME_GET_TEXT_LABEL_63  (0x186608A2AC6F9E88)
+-- min build: 1207
+---@param variableName string
+---@return any
+function _SavegameGetTextLabel63(variableName) end
+
+-- _SAVEGAME_HAS_SAVE_FAILED  (0x1431540BCA1A1BD2)
+-- min build: 1207
+---@return boolean
+function _SavegameHasSaveFailed() end
+
+-- SAVEGAME_IS_SAVE_PENDING  (0x3CF46F55C6585590)
+-- min build: 1207
+---@return boolean
+function SavegameIsSavePending() end
+
+-- SAVEGAME_SAVE_MP  (0x1840F3B30ED0105F)
+-- See SAVEGAME_SAVE_SP
+-- min build: 1207
+---@param savegameType number
+---@return boolean
+function SavegameSaveMp(savegameType) end
+
+-- SAVEGAME_SAVE_SP  (0x62C9EB51656D68CE)
+-- enum eSavegameType : Hash
+-- {
+-- 	SAVEGAMETYPE_AMBIENT = 0x3CA4E1F8,
+-- 	SAVEGAMETYPE_DEFAULT = 0xCB6ED080,
+-- 	SAVEGAMETYPE_DELETE_CHAR = 0xCD35F947,
+-- 	SAVEGAMETYPE_END_CREATE_NEWCHAR = 0x4C50A3CE,
+-- 	SAVEGAMETYPE_END_MATCH = 0xE470ED50,
+-- 	SAVEGAMETYPE_END_MISSION = 0x9A444E54,
+-- 	SAVEGAMETYPE_END_SESSION = 0x6D23956C,
+-- 	SAVEGAMETYPE_END_SHOPPING = 0xA311A6C4,
+-- 	SAVEGAMETYPE_RANKUP = 0xE25F8017,
+-- 	SAVEGAMETYPE_SCRIPT_MP_GLOBALS = 0xAFF30AD4,
+-- 	SAVEGAMETYPE_SP_AUTOSAVE = 0xF4AE69EC,
+-- 	SAVEGAMETYPE_SP_DEBUG = 0x6A8122FD,
+-- 	SAVEGAMETYPE_SP_PROPERTY = 0xAE0AB38E
+-- };
+-- min build: 1207
+---@param savegameType number
+---@return boolean
+function SavegameSaveSp(savegameType) end

--- a/.luals/redm-natives/SCRIPT.lua
+++ b/.luals/redm-natives/SCRIPT.lua
@@ -1,0 +1,626 @@
+---@meta
+
+-- RDR3 namespace: SCRIPT -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0A79C81C418F5D38  (0x0A79C81C418F5D38)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x0A79C81C418F5D38(p0, p1) end
+
+-- _0x11B0A0B282FA9B10  (0x11B0A0B282FA9B10)
+-- Used in Script Function DISABLE_REGISTERED_WORLD_BRAINS
+-- min build: 1207
+---@param p0 boolean
+function N_0x11B0A0B282FA9B10(p0) end
+
+-- _0x1BDB5A07307F6929  (0x1BDB5A07307F6929)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1BDB5A07307F6929(p0, p1) end
+
+-- _0x1C5EB3C27F7508CB  (0x1C5EB3C27F7508CB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1C5EB3C27F7508CB(p0, p1) end
+
+-- _0x29FB4CE89472C3CB  (0x29FB4CE89472C3CB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 number
+---@param p3 number
+---@param p4 string
+---@param p5 string
+---@param p6 string
+---@param p7 number
+function N_0x29FB4CE89472C3CB(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _0x42A429CDFED6D99D  (0x42A429CDFED6D99D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x42A429CDFED6D99D(p0, p1, p2) end
+
+-- _0x5827BE85A87B073D  (0x5827BE85A87B073D)
+-- min build: 1207
+---@param p0 any
+function N_0x5827BE85A87B073D(p0) end
+
+-- _0x64F765D9A1F8F02C  (0x64F765D9A1F8F02C)
+-- min build: 1207
+---@return any
+---@return any
+---@return any
+function N_0x64F765D9A1F8F02C() end
+
+-- _0x6F700A4BF7C3331B  (0x6F700A4BF7C3331B)
+-- min build: 1207
+---@param p0 boolean
+function N_0x6F700A4BF7C3331B(p0) end
+
+-- _0x76CBCD9EADC00955  (0x76CBCD9EADC00955)
+-- min build: 1207
+function N_0x76CBCD9EADC00955() end
+
+-- _0xA88E1D7FA1E20080  (0xA88E1D7FA1E20080)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xA88E1D7FA1E20080(p0) end
+
+-- _0xE4ABE20DCE7C7CFE  (0xE4ABE20DCE7C7CFE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xE4ABE20DCE7C7CFE(p0, p1, p2) end
+
+-- _0xE7282390542F570D  (0xE7282390542F570D)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE7282390542F570D(p0) end
+
+-- _0xF9E951A1E5517C06  (0xF9E951A1E5517C06)
+-- min build: 1207
+function N_0xF9E951A1E5517C06() end
+
+-- _0xFFDDF802279BE128  (0xFFDDF802279BE128)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xFFDDF802279BE128(p0, p1, p2) end
+
+-- _ACTIVATE_GOAL_CONTEXT  (0x7D654266025E921B)
+-- goalContext: see <availableContexts> in common/data/stats_and_challenges/goals_*.meta
+-- min build: 1207
+---@param goalContext number
+function _ActivateGoalContext(goalContext) end
+
+-- _AWARDS_GET_UNLOCK_CLAIM_DATA  (0xB9467E41DAB1CF2C)
+-- min build: 1207
+---@param awardHash number
+---@param dataIndex number
+---@return boolean
+---@return any
+---@return any
+function _AwardsGetUnlockClaimData(awardHash, dataIndex) end
+
+-- _BG_RELOAD_ALL_BACKGROUND_SCRIPTS  (0xBE7D814CFA181B56)
+-- min build: 1207
+function _BgReloadAllBackgroundScripts() end
+
+-- _CLEAR_ALL_PLAYER_BITS  (0xDE544B7EC0C187CC)
+-- min build: 1207
+---@return any
+function _ClearAllPlayerBits() end
+
+-- _CLEAR_PLAYER_BIT_AT_INDEX  (0xD426E2E3288469D6)
+-- min build: 1207
+---@param bitIndex number
+---@return any
+function _ClearPlayerBitAtIndex(bitIndex) end
+
+-- _DEACTIVATE_GOAL_CONTEXT  (0x50B72A754EE64A71)
+-- goalContext: see _ACTIVATE_GOAL_CONTEXT
+-- min build: 1207
+---@param goalContext number
+function _DeactivateGoalContext(goalContext) end
+
+-- _DISPLAY_LOADING_SCREENS  (0x1E5B70E53DB661E5)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param gamemodeName string
+---@param title string
+---@param subtitle string
+function _DisplayLoadingScreens(p0, p1, p2, gamemodeName, title, subtitle) end
+
+-- _DOES_COMPRESSED_GLOBAL_BLOCK_BUFFER_EXIST  (0x66EE5B93C308F734)
+-- min build: 1207
+---@param index number
+---@return boolean
+function _DoesCompressedGlobalBlockBufferExist(index) end
+
+-- _GET_GLOBAL_BLOCK_CAN_BE_ACCESSED  (0x42A7EB5C814C2DE0)
+-- min build: 1207
+---@param index number
+---@return boolean
+function _GetGlobalBlockCanBeAccessed(index) end
+
+-- _GET_HASH_OF_THREAD  (0x724CB89D35B283D0)
+-- min build: 1207
+---@param threadId number
+---@return number
+function _GetHashOfThread(threadId) end
+
+-- _GET_THREAD_EXIT_REASON  (0x54AE4FDEEFEAB77E)
+-- enum eThreadExitReason
+-- {
+-- 	THREAD_EXIT_REASON_NONE,
+-- 	THREAD_EXIT_REASON_BACKGROUND_THREAD_STOPPED,
+-- 	THREAD_EXIT_REASON_SESSION_MERGE,
+-- 	THREAD_EXIT_REASON_SCENARIO_OUT_OF_SCOPE,
+-- 	THREAD_EXIT_REASON_REQUESTED_BY_SCRIPT
+-- };
+-- min build: 1207
+---@return number
+function _GetThreadExitReason() end
+
+-- _IS_ANY_PLAYER_BIT_SET  (0x179A6F0EE2E79026)
+-- min build: 1207
+---@return boolean
+---@return number
+function _IsAnyPlayerBitSet() end
+
+-- _IS_BACKGROUND_SCRIPT  (0x20B7F69B40C6B755)
+-- min build: 1207
+---@param threadId number
+---@return boolean
+function _IsBackgroundScript(threadId) end
+
+-- _IS_GOAL_CONTEXT_ACTIVE  (0x7409669C5ED50144)
+-- goalContext: see _ACTIVATE_GOAL_CONTEXT
+-- min build: 1207
+---@param goalContext number
+---@return boolean
+function _IsGoalContextActive(goalContext) end
+
+-- _IS_PLAYER_BIT_SET_AT_INDEX  (0x72B2E00C9BAC6789)
+-- min build: 1207
+---@param bitIndex number
+---@return boolean
+---@return any
+function _IsPlayerBitSetAtIndex(bitIndex) end
+
+-- _IS_THREAD_EXIT_REQUESTED_FOR_THREAD_WITH_THIS_ID  (0x30BED53646C86D11)
+-- min build: 1207
+---@param threadId number
+---@return boolean
+function _IsThreadExitRequestedForThreadWithThisId(threadId) end
+
+-- _LOOT_GET_LOOT_CLAIM_DATA  (0xF1E9045F5AA9E428)
+-- min build: 1311
+---@param dataIndex number
+---@return boolean
+---@return any
+---@return any
+function _LootGetLootClaimData(dataIndex) end
+
+-- _LOOT_GET_RESULT_ITEM  (0x4293B44A855F82CC)
+-- min build: 1207
+---@param itemIndex number
+---@return boolean
+---@return any
+---@return any
+function _LootGetResultItem(itemIndex) end
+
+-- _NET_RPC_GUID_TO_STRING  (0xAC9FF854BD4BA9B5)
+-- Returns "INVALID_NET_RPC_GUID" if netRpcGuid is invalid.
+-- min build: 1311
+---@return string
+---@return any
+function _NetRpcGuidToString() end
+
+-- _REQUEST_THREAD_EXIT  (0x7DE4643157AD646C)
+-- min build: 1207
+---@param threadId number
+function _RequestThreadExit(threadId) end
+
+-- _REQUEST_THREAD_EXIT_FOR_ALL_THREADS_WITH_THIS_NAME  (0x7423F7835770F619)
+-- min build: 1207
+---@param nameHash number
+function _RequestThreadExitForAllThreadsWithThisName(nameHash) end
+
+-- _RESTORE_GLOBAL_BLOCK  (0xDC3914A99B4A5FDF)
+-- min build: 1207
+---@param index number
+---@return boolean
+function _RestoreGlobalBlock(index) end
+
+-- _SET_ALL_GLOBAL_BLOCKS_HAVE_BEEN_LOADED  (0x11986B05885564D2)
+-- min build: 1207
+---@param toggle boolean
+function _SetAllGlobalBlocksHaveBeenLoaded(toggle) end
+
+-- _SET_ALL_PLAYER_BITS  (0x20F4CB76689ACDBC)
+-- min build: 1207
+---@return any
+function _SetAllPlayerBits() end
+
+-- _SET_GLOBAL_BLOCK_CAN_BE_ACCESSED  (0xE66F392BFCE734AF)
+-- min build: 1207
+---@param index number
+---@param toggle boolean
+function _SetGlobalBlockCanBeAccessed(index, toggle) end
+
+-- _SET_PLAYER_BIT_AT_INDEX  (0x31010318BA9897AC)
+-- min build: 1207
+---@param bitIndex number
+---@return any
+function _SetPlayerBitAtIndex(bitIndex) end
+
+-- _STORE_GLOBAL_BLOCK  (0xB952A3AC41D58F2F)
+-- min build: 1207
+---@param index number
+---@return boolean
+function _StoreGlobalBlock(index) end
+
+-- _TRIGGER_SCRIPT_EVENT_2  (0x8B61C950A148FFA2)
+-- min build: 1207
+---@param eventDataSize number
+---@param scriptMetadataIndex number
+---@param threadId number
+---@return any
+function _TriggerScriptEvent2(eventDataSize, scriptMetadataIndex, threadId) end
+
+-- AWARDS_GET_RESULT_ITEM  (0xAC8FAB22A914AE34)
+-- min build: 1207
+---@param awardHash number
+---@param itemIndex number
+---@return boolean
+---@return any
+---@return any
+function AwardsGetResultItem(awardHash, itemIndex) end
+
+-- BAIL_TO_LANDING_PAGE  (0xBC2C927F5C264243)
+-- min build: 1207
+---@param bailCode number
+function BailToLandingPage(bailCode) end
+
+-- BAIL_WITH_PASS_THROUGH_PARAMS  (0xE98204D3C25AE14C)
+-- min build: 1207
+---@param params string
+function BailWithPassThroughParams(params) end
+
+-- BG_DOES_LAUNCH_PARAM_EXIST  (0x4AE1DFF337A86FDE)
+-- min build: 1207
+---@param scriptIndex number
+---@param p1 string
+---@return boolean
+function BgDoesLaunchParamExist(scriptIndex, p1) end
+
+-- BG_END_CONTEXT  (0x3ABF7BA1C3E2C8CF)
+-- Deletes the given context from the background scripts context map.
+-- min build: 1207
+---@param contextName string
+function BgEndContext(contextName) end
+
+-- BG_END_CONTEXT_HASH  (0x6D1431744182CDE8)
+-- Hashed version of BG_END_CONTEXT
+-- min build: 1207
+---@param contextHash number
+function BgEndContextHash(contextHash) end
+
+-- BG_GET_LAUNCH_PARAM_VALUE  (0x55C40B7592BAD213)
+-- min build: 1207
+---@param scriptIndex number
+---@param p1 string
+---@return number
+function BgGetLaunchParamValue(scriptIndex, p1) end
+
+-- BG_GET_SCRIPT_ID_FROM_NAME_HASH  (0x829CD22E043A2577)
+-- min build: 1207
+---@param p0 number
+---@return number
+function BgGetScriptIdFromNameHash(p0) end
+
+-- BG_IS_EXITFLAG_SET  (0x2238EC3EC631AB1F)
+-- Returns true if GtaThread+0x77C is equal to 1.
+-- 
+-- Old name: _BG_EXITED_BECAUSE_BACKGROUND_THREAD_STOPPED
+-- min build: 1207
+---@return boolean
+function BgIsExitflagSet() end
+
+-- BG_SET_EXITFLAG_RESPONSE  (0x4858148E3B8A75D0)
+-- Sets bit 0 in GtaThread+0x784
+-- min build: 1207
+function BgSetExitflagResponse() end
+
+-- BG_START_CONTEXT  (0x49BA5678BA040CA7)
+-- Inserts the given context into the background scripts context map.
+-- min build: 1207
+---@param contextName string
+function BgStartContext(contextName) end
+
+-- BG_START_CONTEXT_HASH  (0x2EB67D564DCC09D5)
+-- Hashed version of BG_START_CONTEXT
+-- min build: 1207
+---@param contextHash number
+function BgStartContextHash(contextHash) end
+
+-- COUNT_PARTICIPANT_BITS  (0x2F050A3FF8738245)
+-- min build: 1207
+---@return number
+---@return any
+function CountParticipantBits() end
+
+-- COUNT_PLAYER_BITS  (0x462C687BEA254BD9)
+-- min build: 1207
+---@return number
+---@return any
+function CountPlayerBits() end
+
+-- DOES_SCRIPT_EXIST  (0x552B171E3F69E5AE)
+-- min build: 1207
+---@param scriptName string
+---@return boolean
+function DoesScriptExist(scriptName) end
+
+-- DOES_SCRIPT_WITH_NAME_HASH_EXIST  (0xA34E89749F628284)
+-- min build: 1207
+---@param scriptHash number
+---@return boolean
+function DoesScriptWithNameHashExist(scriptHash) end
+
+-- DOES_THREAD_EXIST  (0xFF975BC4435A0FA3)
+-- min build: 1207
+---@param threadId number
+---@return boolean
+function DoesThreadExist(threadId) end
+
+-- GET_BLOCK_OF_PLAYER_BITS  (0xFA3B530A5CC693D5)
+-- min build: 1207
+---@param p1 number
+---@return number
+---@return any
+function GetBlockOfPlayerBits(p1) end
+
+-- GET_EVENT_AT_INDEX  (0xA85E614430EFF816)
+-- eventGroup: 0 = SCRIPT_EVENT_QUEUE_AI (CEventGroupScriptAI), 1 = SCRIPT_EVENT_QUEUE_NETWORK (CEventGroupScriptNetwork), 2 = unk, 3 = unk, 4 = SCRIPT_EVENT_QUEUE_SCRIPT_ERRORS (CEventGroupScriptErrors)
+-- 
+-- Returns event name hash: https://alloc8or.re/rdr3/doc/enums/eEventType.txt
+-- min build: 1207
+---@param eventGroup number
+---@param eventIndex number
+---@return number
+function GetEventAtIndex(eventGroup, eventIndex) end
+
+-- GET_EVENT_DATA  (0x57EC5FA4D4D6AFCA)
+-- eventGroup: 0 = SCRIPT_EVENT_QUEUE_AI (CEventGroupScriptAI), 1 = SCRIPT_EVENT_QUEUE_NETWORK (CEventGroupScriptNetwork), 2 = unk, 3 = unk, 4 = SCRIPT_EVENT_QUEUE_SCRIPT_ERRORS (CEventGroupScriptErrors)
+-- 
+-- Note: eventDataSize is NOT the size in bytes, it is the size determined by the SIZE_OF operator (RAGE Script operator, not C/C++ sizeof). That is, the size in bytes divided by 8 (script variables are always 8-byte aligned!).
+-- 
+-- https://github.com/femga/rdr3_discoveries/tree/master/AI/EVENTS
+-- min build: 1207
+---@param eventGroup number
+---@param eventIndex number
+---@param eventDataSize number
+---@return boolean
+---@return any
+function GetEventData(eventGroup, eventIndex, eventDataSize) end
+
+-- GET_EVENT_EXISTS  (0xC9F59C0A710ECD34)
+-- eventGroup: 0 = SCRIPT_EVENT_QUEUE_AI (CEventGroupScriptAI), 1 = SCRIPT_EVENT_QUEUE_NETWORK (CEventGroupScriptNetwork), 2 = unk, 3 = unk, 4 = SCRIPT_EVENT_QUEUE_SCRIPT_ERRORS (CEventGroupScriptErrors)
+-- min build: 1207
+---@param eventGroup number
+---@param eventType number
+---@return boolean
+function GetEventExists(eventGroup, eventType) end
+
+-- GET_HASH_OF_THIS_SCRIPT_NAME  (0xBC2C927F5C264960)
+-- min build: 1207
+---@return number
+function GetHashOfThisScriptName() end
+
+-- GET_ID_OF_THIS_THREAD  (0x55525C346BEF6960)
+-- min build: 1207
+---@return number
+function GetIdOfThisThread() end
+
+-- GET_NO_LOADING_SCREEN  (0x323DAF00687E0F28)
+-- min build: 1207
+---@return boolean
+function GetNoLoadingScreen() end
+
+-- GET_NUMBER_OF_EVENTS  (0x5CE8DE5909565748)
+-- eventGroup: 0 = SCRIPT_EVENT_QUEUE_AI (CEventGroupScriptAI), 1 = SCRIPT_EVENT_QUEUE_NETWORK (CEventGroupScriptNetwork), 2 = unk, 3 = unk, 4 = SCRIPT_EVENT_QUEUE_ERRORS (CEventGroupScriptErrors)
+-- min build: 1207
+---@param eventGroup number
+---@return number
+function GetNumberOfEvents(eventGroup) end
+
+-- GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH  (0x8E34C953364A76DD)
+-- Gets the number of instances of the specified script is currently running.
+-- 
+-- Actually returns numRefs - 1.
+-- if (program)
+-- 	v3 = rage::scrProgram::GetNumRefs(program) - 1;
+-- return v3;
+-- 
+-- Old name: _GET_NUMBER_OF_REFERENCES_OF_SCRIPT_WITH_NAME_HASH
+-- min build: 1207
+---@param scriptHash number
+---@return number
+function GetNumberOfThreadsRunningTheScriptWithThisHash(scriptHash) end
+
+-- GET_THREAD_EXISTENCE_DETAILS  (0xD92FA81B64920E85)
+-- min build: 1207
+---@param threadId number
+---@return boolean
+---@return boolean
+function GetThreadExistenceDetails(threadId) end
+
+-- HAS_SCRIPT_LOADED  (0xE97BD36574F8B0A6)
+-- Returns if a script has been loaded into the game. Used to see if a script was loaded after requesting.
+-- min build: 1207
+---@param scriptName string
+---@return boolean
+function HasScriptLoaded(scriptName) end
+
+-- HAS_SCRIPT_WITH_NAME_HASH_LOADED  (0xA5D8E0C2F3C7EEBC)
+-- min build: 1207
+---@param scriptHash number
+---@return boolean
+function HasScriptWithNameHashLoaded(scriptHash) end
+
+-- HAVE_ALL_CHILD_SCRIPTS_TERMINATED  (0x380FFA15B72408FB)
+-- Waiting for child scripts to terminate / waiting for collapse of child scripts
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function HaveAllChildScriptsTerminated(p0) end
+
+-- IS_LOADING_SCREEN_VISIBLE  (0xB54ADBE65D528FCB)
+-- Same as GET_IS_LOADING_SCREEN_ACTIVE
+-- min build: 1207
+---@return boolean
+function IsLoadingScreenVisible() end
+
+-- IS_THREAD_ACTIVE  (0x46E9AE36D8FA6417)
+-- min build: 1207
+---@param threadId number
+---@param ignoreKilledState boolean
+---@return boolean
+function IsThreadActive(threadId, ignoreKilledState) end
+
+-- IS_THREAD_EXIT_REQUESTED  (0x9E4EF615E307FBBE)
+-- min build: 1207
+---@return boolean
+function IsThreadExitRequested() end
+
+-- REQUEST_SCRIPT  (0x46ED607DDD40D7FE)
+-- min build: 1207
+---@param scriptName string
+function RequestScript(scriptName) end
+
+-- REQUEST_SCRIPT_WITH_NAME_HASH  (0xF6B9CE3F8D5B9B74)
+-- min build: 1207
+---@param scriptHash number
+function RequestScriptWithNameHash(scriptHash) end
+
+-- SCRIPT_THREAD_ITERATOR_GET_NEXT_THREAD_ID  (0x3CE3FB167E837D7C)
+-- If the function returns 0, the end of the iteration has been reached.
+-- min build: 1207
+---@return number
+function ScriptThreadIteratorGetNextThreadId() end
+
+-- SCRIPT_THREAD_ITERATOR_RESET  (0x39382EB8DCD8684D)
+-- Starts a new iteration of the current threads.
+-- Call this first, then SCRIPT_THREAD_ITERATOR_GET_NEXT_THREAD_ID (0x30B4FA1C82DD4B9F)
+-- min build: 1207
+function ScriptThreadIteratorReset() end
+
+-- SET_BLOCK_OF_PLAYER_BITS  (0xC6DFB8C04C86D5A5)
+-- min build: 1207
+---@param p1 number
+---@param p2 number
+---@return any
+function SetBlockOfPlayerBits(p1, p2) end
+
+-- SET_EVENT_FLAG_FOR_DELETION  (0x4768D5252EAEB76F)
+-- min build: 1207
+---@param eventGroup number
+---@param eventIndex number
+---@param p2 boolean
+function SetEventFlagForDeletion(eventGroup, eventIndex, p2) end
+
+-- SET_NO_LOADING_SCREEN  (0x5CB83156AA038F95)
+-- min build: 1207
+---@param toggle boolean
+function SetNoLoadingScreen(toggle) end
+
+-- SET_SCRIPT_AS_NO_LONGER_NEEDED  (0x0086D3067E1CFD1C)
+-- min build: 1207
+---@param scriptName string
+function SetScriptAsNoLongerNeeded(scriptName) end
+
+-- SET_SCRIPT_WITH_NAME_HASH_AS_NO_LONGER_NEEDED  (0x50723A1567C8361E)
+-- min build: 1207
+---@param scriptHash number
+function SetScriptWithNameHashAsNoLongerNeeded(scriptHash) end
+
+-- SHUTDOWN_LOADING_SCREEN  (0xFC179D7E8886DADF)
+-- min build: 1207
+function ShutdownLoadingScreen() end
+
+-- START_NEW_SCRIPT  (0xE81651AD79516E48)
+-- min build: 1207
+---@param scriptName string
+---@param stackSize number
+---@return number
+function StartNewScript(scriptName, stackSize) end
+
+-- START_NEW_SCRIPT_WITH_ARGS  (0xB8BA7F44DF1575E1)
+-- return : script thread id, 0 if failed
+-- Pass pointer to struct of args in p1, size of struct goes into p2
+-- min build: 1207
+---@param scriptName string
+---@param argCount number
+---@param stackSize number
+---@return number
+---@return any
+function StartNewScriptWithArgs(scriptName, argCount, stackSize) end
+
+-- START_NEW_SCRIPT_WITH_NAME_HASH  (0xEB1C67C3A5333A92)
+-- min build: 1207
+---@param scriptHash number
+---@param stackSize number
+---@return number
+function StartNewScriptWithNameHash(scriptHash, stackSize) end
+
+-- START_NEW_SCRIPT_WITH_NAME_HASH_AND_ARGS  (0xC4BB298BD441BE78)
+-- min build: 1207
+---@param scriptHash number
+---@param argCount number
+---@param stackSize number
+---@return number
+---@return any
+function StartNewScriptWithNameHashAndArgs(scriptHash, argCount, stackSize) end
+
+-- STOP_DISPLAYING_MP_TRANSITION_LOADING_SCREENS  (0x778D4733E0F2F265)
+-- min build: 1207
+---@param p0 any
+function StopDisplayingMpTransitionLoadingScreens(p0) end
+
+-- TERMINATE_THIS_THREAD  (0x5E8B6D17FF91CD59)
+-- min build: 1207
+function TerminateThisThread() end
+
+-- TERMINATE_THREAD  (0x87ED52AE40EA1A52)
+-- min build: 1207
+---@param threadId number
+function TerminateThread(threadId) end
+
+-- TRIGGER_SCRIPT_EVENT  (0x5AE99C571D5BBE5D)
+-- eventGroup: 0 = SCRIPT_EVENT_QUEUE_AI (CEventGroupScriptAI), 1 = SCRIPT_EVENT_QUEUE_NETWORK (CEventGroupScriptNetwork), 2 = unk, 3 = unk, 4 = SCRIPT_EVENT_QUEUE_SCRIPT_ERRORS (CEventGroupScriptErrors)
+-- 
+-- Note: eventDataSize is NOT the size in bytes, it is the size determined by the SIZE_OF operator (RAGE Script operator, not C/C++ sizeof). That is, the size in bytes divided by 8 (script variables are always 8-byte aligned!).
+-- 
+-- playerBits (also known as playersToBroadcastTo) is a bitset that indicates which players this event should be sent to. In order to send the event to specific players only, use (1 << playerIndex). Set all bits if it should be broadcast to all players.
+-- min build: 1207
+---@param eventGroup number
+---@param eventDataSize number
+---@param scriptMetadataIndex number
+---@return any
+---@return number
+function TriggerScriptEvent(eventGroup, eventDataSize, scriptMetadataIndex) end

--- a/.luals/redm-natives/SHAPETEST.lua
+++ b/.luals/redm-natives/SHAPETEST.lua
@@ -1,0 +1,124 @@
+---@meta
+
+-- RDR3 namespace: SHAPETEST -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x04AA59CA40571C2E  (0x04AA59CA40571C2E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x04AA59CA40571C2E(p0, p1) end
+
+-- GET_SHAPE_TEST_RESULT  (0xEDE8AC7C5108FB1D)
+-- Returns the result of a shape test: 0 if the handle is invalid, 1 if the shape test is still pending, or 2 if the shape test has completed, and the handle should be invalidated.
+-- 
+-- When used with an asynchronous shape test, this native should be looped until returning 0 or 2, after which the handle is invalidated.
+-- 
+-- enum eShapeTestStatus
+-- {
+-- 	SHAPETEST_STATUS_NONEXISTENT,
+-- 	SHAPETEST_STATUS_RESULTS_NOTREADY,
+-- 	SHAPETEST_STATUS_RESULTS_READY
+-- };
+-- min build: 1207
+---@param shapeTestHandle number
+---@return number
+---@return boolean
+---@return vector3
+---@return vector3
+---@return number
+function GetShapeTestResult(shapeTestHandle) end
+
+-- START_EXPENSIVE_SYNCHRONOUS_SHAPE_TEST_LOS_PROBE  (0x377906D8A31E5586)
+-- Does the same as 0x7EE9F5D83DD4F90E, except blocking until the shape test completes.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param flags number
+---@param entityToIgnore number
+---@param p8 number
+---@return number
+function StartExpensiveSynchronousShapeTestLosProbe(x1, y1, z1, x2, y2, z2, flags, entityToIgnore, p8) end
+
+-- START_SHAPE_TEST_BOX  (0xFE466162C4401D18)
+-- min build: 1207
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param dimensionsX number
+---@param dimensionsY number
+---@param dimensionsZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param rotationOrder number
+---@param flags number
+---@param entityToIgnore number
+---@param options number
+---@return number
+function StartShapeTestBox(posX, posY, posZ, dimensionsX, dimensionsY, dimensionsZ, rotX, rotY, rotZ, rotationOrder, flags, entityToIgnore, options) end
+
+-- START_SHAPE_TEST_CAPSULE  (0x28579D1B8F8AAC80)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param radius number
+---@param flags number
+---@param entityToIgnore number
+---@param p9 number
+---@return number
+function StartShapeTestCapsule(x1, y1, z1, x2, y2, z2, radius, flags, entityToIgnore, p9) end
+
+-- START_SHAPE_TEST_LOS_PROBE  (0x7EE9F5D83DD4F90E)
+-- Asynchronously starts a line-of-sight (raycast) world probe shape test.
+-- 
+-- Use the handle with 0x3D87450E15D98694 or 0x65287525D951F6BE until it returns 0 or 2.
+-- 
+-- p8 is a bit mask with bits 1, 2 and/or 4, relating to collider types; 4 should usually be used.
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param flags number
+---@param entity number
+---@param p8 number
+---@return number
+function StartShapeTestLosProbe(x1, y1, z1, x2, y2, z2, flags, entity, p8) end
+
+-- START_SHAPE_TEST_MOUSE_CURSOR_LOS_PROBE  (0x9839013D8B6014F1)
+-- Old name: _START_SHAPE_TEST_SURROUNDING_COORDS
+-- min build: 1207
+---@param flag number
+---@param entity number
+---@param flag2 number
+---@return number
+---@return vector3
+---@return vector3
+function StartShapeTestMouseCursorLosProbe(flag, entity, flag2) end
+
+-- START_SHAPE_TEST_SWEPT_SPHERE  (0xAA5B7C8309F73230)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param radius number
+---@param flags number
+---@param entity number
+---@param p9 any
+---@return number
+function StartShapeTestSweptSphere(x1, y1, z1, x2, y2, z2, radius, flags, entity, p9) end

--- a/.luals/redm-natives/SOCIALCLUB.lua
+++ b/.luals/redm-natives/SOCIALCLUB.lua
@@ -1,0 +1,229 @@
+---@meta
+
+-- RDR3 namespace: SOCIALCLUB -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- SC_COMMUNITY_EVENT_GET_DISPLAY_NAME  (0x89D9BDE7334B110F)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function ScCommunityEventGetDisplayName(p0) end
+
+-- SC_COMMUNITY_EVENT_GET_DISPLAY_NAME_BY_ID  (0x11EA52CAD1B55910)
+-- min build: 1207
+---@param p0 number
+---@param p1 string
+---@return boolean
+function ScCommunityEventGetDisplayNameById(p0, p1) end
+
+-- SC_COMMUNITY_EVENT_GET_DISPLAY_NAME_FOR_TYPE  (0x85EA0BEC7B1F7622)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@return boolean
+function ScCommunityEventGetDisplayNameForType(p0, p1) end
+
+-- SC_COMMUNITY_EVENT_GET_EVENT_ID  (0xD635DF6BAA5A6017)
+-- min build: 1207
+---@return number
+function ScCommunityEventGetEventId() end
+
+-- SC_COMMUNITY_EVENT_GET_EVENT_ID_FOR_TYPE  (0x03C03ABBABBEF752)
+-- min build: 1207
+---@param p0 string
+---@return number
+function ScCommunityEventGetEventIdForType(p0) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_FLOAT  (0x060BBAD634C2B44B)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+---@return number
+function ScCommunityEventGetExtraDataFloat(p0) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_FLOAT_BY_ID  (0x91C9E2A0F9DD6DD4)
+-- min build: 1207
+---@param p0 number
+---@param p1 string
+---@return boolean
+---@return number
+function ScCommunityEventGetExtraDataFloatById(p0, p1) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_FLOAT_FOR_TYPE  (0x1BDB56DB258F052D)
+-- min build: 1207
+---@param p0 string
+---@param p2 string
+---@return boolean
+---@return number
+function ScCommunityEventGetExtraDataFloatForType(p0, p2) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_INT  (0xB4411D4D6B81438E)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+---@return number
+function ScCommunityEventGetExtraDataInt(p0) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_INT_BY_ID  (0x7C981DE05A7403A0)
+-- min build: 1207
+---@param p0 number
+---@param p1 string
+---@return boolean
+---@return number
+function ScCommunityEventGetExtraDataIntById(p0, p1) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_INT_FOR_TYPE  (0x3519CC3525319A96)
+-- min build: 1207
+---@param p0 string
+---@param p2 string
+---@return boolean
+---@return number
+function ScCommunityEventGetExtraDataIntForType(p0, p2) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_STRING  (0x9F6DCD0C939C71E9)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@return boolean
+function ScCommunityEventGetExtraDataString(p0, p1) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_STRING_BY_ID  (0x049D2196D9D11184)
+-- min build: 1207
+---@param p0 number
+---@param p1 string
+---@param p2 string
+---@return boolean
+function ScCommunityEventGetExtraDataStringById(p0, p1, p2) end
+
+-- SC_COMMUNITY_EVENT_GET_EXTRA_DATA_STRING_FOR_TYPE  (0xC8FC3B2432E8229D)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+---@param p2 string
+---@return boolean
+function ScCommunityEventGetExtraDataStringForType(p0, p1, p2) end
+
+-- SC_COMMUNITY_EVENT_IS_ACTIVE  (0xCBF743C984695CF3)
+-- min build: 1207
+---@return boolean
+function ScCommunityEventIsActive() end
+
+-- SC_COMMUNITY_EVENT_IS_ACTIVE_BY_ID  (0x62B384FEFDE06817)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function ScCommunityEventIsActiveById(p0) end
+
+-- SC_COMMUNITY_EVENT_IS_ACTIVE_FOR_TYPE  (0x09937EB0CEBC2F9F)
+-- min build: 1207
+---@param p0 string
+---@return boolean
+function ScCommunityEventIsActiveForType(p0) end
+
+-- SC_INBOX_GET_MESSAGE_IS_READ_AT_INDEX  (0x74CF39E030A382C4)
+-- min build: 1207
+---@param msgIndex number
+---@return boolean
+function ScInboxGetMessageIsReadAtIndex(msgIndex) end
+
+-- SC_INBOX_GET_MESSAGE_TYPE_AT_INDEX  (0xFF92537C4DDC1241)
+-- min build: 1207
+---@param msgIndex number
+---@return number
+function ScInboxGetMessageTypeAtIndex(msgIndex) end
+
+-- SC_INBOX_GET_TOTAL_NUM_MESSAGES  (0x8EF0F633280C0663)
+-- min build: 1207
+---@return number
+function ScInboxGetTotalNumMessages() end
+
+-- SC_INBOX_MESSAGE_GET_DATA_INT  (0x95BB39C4DA99F348)
+-- min build: 1207
+---@param p0 number
+---@param context string
+---@return boolean
+---@return number
+function ScInboxMessageGetDataInt(p0, context) end
+
+-- SC_INBOX_MESSAGE_GET_DATA_STRING  (0x66F77FD58506FF6B)
+-- min build: 1207
+---@param p0 number
+---@param context string
+---@param out string
+---@return boolean
+function ScInboxMessageGetDataString(p0, context, out) end
+
+-- SC_INBOX_MESSAGE_GET_RAW_TYPE_AT_INDEX  (0x176D077685CD83E4)
+-- min build: 1207
+---@param p0 number
+---@return string
+function ScInboxMessageGetRawTypeAtIndex(p0) end
+
+-- SC_INBOX_SET_MESSAGE_AS_READ_AT_INDEX  (0x63CAC501FFF66DC4)
+-- min build: 1207
+---@param msgIndex number
+---@return boolean
+function ScInboxSetMessageAsReadAtIndex(msgIndex) end
+
+-- SC_PRESENCE_ATTR_SET_FLOAT  (0xA31DAFCDC33775E9)
+-- min build: 1207
+---@param attrHash number
+---@param value number
+---@return boolean
+function ScPresenceAttrSetFloat(attrHash, value) end
+
+-- SC_PRESENCE_ATTR_SET_FLOAT_EX  (0x00000000467F4CAA)
+-- min build: 1207
+---@param attrName string
+---@param value number
+---@param p2 boolean
+---@return boolean
+function ScPresenceAttrSetFloatEx(attrName, value, p2) end
+
+-- SC_PRESENCE_ATTR_SET_INT_EX  (0x0000000085488C49)
+-- min build: 1207
+---@param attrName string
+---@param value number
+---@param p2 boolean
+---@return boolean
+function ScPresenceAttrSetIntEx(attrName, value, p2) end
+
+-- SC_PRESENCE_ATTR_SET_STRING_EX  (0x00000000EB2D93B3)
+-- min build: 1207
+---@param attrName string
+---@param value string
+---@param p2 boolean
+---@return boolean
+function ScPresenceAttrSetStringEx(attrName, value, p2) end
+
+-- SC_PROFANITY_CHECK_STRING  (0x9C74AC9D87B3FFF4)
+-- Starts a task to check an entered string for profanity on the ROS/Social Club services.
+-- min build: 1207
+---@param string string
+---@return boolean
+---@return number
+function ScProfanityCheckString(string) end
+
+-- SC_PROFANITY_GET_CHECK_IS_PENDING  (0x3A10BCD0C8AA0B82)
+-- min build: 1207
+---@param token number
+---@return boolean
+function ScProfanityGetCheckIsPending(token) end
+
+-- SC_PROFANITY_GET_CHECK_IS_VALID  (0x08C8052AF40C4247)
+-- min build: 1207
+---@param token number
+---@return boolean
+function ScProfanityGetCheckIsValid(token) end
+
+-- SC_PROFANITY_GET_STRING_PASSED  (0xF302973BB8BE70E6)
+-- min build: 1207
+---@param token number
+---@return boolean
+function ScProfanityGetStringPassed(token) end
+
+-- SC_PROFANITY_GET_STRING_STATUS  (0x0CF3BFB99EBBE5B1)
+-- min build: 1207
+---@param token number
+---@return number
+function ScProfanityGetStringStatus(token) end

--- a/.luals/redm-natives/SOCIALCLUBFEED.lua
+++ b/.luals/redm-natives/SOCIALCLUBFEED.lua
@@ -1,0 +1,16 @@
+---@meta
+
+-- RDR3 namespace: SOCIALCLUBFEED -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _SC_FEED_SUBMIT_PRESET_MESSAGE  (0xEFB64240F6B17817)
+-- min build: 1207
+---@param type number
+---@param subType number
+---@return number
+function _ScFeedSubmitPresetMessage(type, subType) end
+
+-- SC_FEED_HUB_HAS_NEW_DATA  (0x068332D20CB6F897)
+-- min build: 1232
+---@return boolean
+function ScFeedHubHasNewData() end

--- a/.luals/redm-natives/SPACTIONPROXY.lua
+++ b/.luals/redm-natives/SPACTIONPROXY.lua
@@ -1,0 +1,38 @@
+---@meta
+
+-- RDR3 namespace: SPACTIONPROXY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _SPACTIONPROXY_GET_NEXT_PENDING_BUY_ACTION  (0x1F471B79ACC98BEF)
+-- min build: 1207
+---@return boolean
+---@return any
+function _SpactionproxyGetNextPendingBuyAction() end
+
+-- _SPACTIONPROXY_GET_NEXT_PENDING_CRAFTING_ACTION  (0x1F471B79ACC97BEF)
+-- min build: 1207
+---@return boolean
+---@return any
+function _SpactionproxyGetNextPendingCraftingAction() end
+
+-- _SPACTIONPROXY_MANAGER_IS_FAILED  (0x1F471B79ACC91BEC)
+-- min build: 1207
+---@return boolean
+function _SpactionproxyManagerIsFailed() end
+
+-- _SPACTIONPROXY_MANAGER_IS_READY  (0x1F471B79ACC91BED)
+-- min build: 1207
+---@return boolean
+function _SpactionproxyManagerIsReady() end
+
+-- _SPACTIONPROXY_PROCESS_ACTION  (0x1F471B79ACC94BEF)
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+---@return boolean
+function _SpactionproxyProcessAction(p0, p1) end
+
+-- _SPACTIONPROXY_START_MANAGER  (0x1F471B79ACC91BEE)
+-- min build: 1207
+---@return boolean
+function _SpactionproxyStartManager() end

--- a/.luals/redm-natives/STATS.lua
+++ b/.luals/redm-natives/STATS.lua
@@ -1,0 +1,597 @@
+---@meta
+
+-- RDR3 namespace: STATS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x025E98E317652CDD  (0x025E98E317652CDD)
+-- min build: 1207
+---@param p0 number
+function N_0x025E98E317652CDD(p0) end
+
+-- _0x0FEE2561120F3333  (0x0FEE2561120F3333)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@return any
+function N_0x0FEE2561120F3333() end
+
+-- _0x218F7710A139D012  (0x218F7710A139D012)
+-- min build: 1207
+function N_0x218F7710A139D012() end
+
+-- _0x302E71C1D9EE75B9  (0x302E71C1D9EE75B9)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param p1 number
+---@return boolean
+---@return any
+---@return number
+function N_0x302E71C1D9EE75B9(p1) end
+
+-- _0x378D3B1B11D9385B  (0x378D3B1B11D9385B)
+-- min build: 1207
+---@param p0 number
+function N_0x378D3B1B11D9385B(p0) end
+
+-- _0x3AEABAE3F3C7600C  (0x3AEABAE3F3C7600C)
+-- min build: 1207
+---@return boolean
+function N_0x3AEABAE3F3C7600C() end
+
+-- _0x3EB2791A1FBC8A42  (0x3EB2791A1FBC8A42)
+-- min build: 1207
+---@param statItem number
+---@param p1 number
+function N_0x3EB2791A1FBC8A42(statItem, p1) end
+
+-- _0x3F6FD87D2030ADC6  (0x3F6FD87D2030ADC6)
+-- min build: 1207
+---@return string
+function N_0x3F6FD87D2030ADC6() end
+
+-- _0x4DAC398297981B87  (0x4DAC398297981B87)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0x4DAC398297981B87(p0) end
+
+-- _0x4E463A3CDEFFFE96  (0x4E463A3CDEFFFE96)
+-- Only used in R* Script net_char_creator
+-- min build: 1207
+function N_0x4E463A3CDEFFFE96() end
+
+-- _0x4F2D5FA23DB992DE  (0x4F2D5FA23DB992DE)
+-- Only used in R* Script net_char_creator
+-- min build: 1207
+function N_0x4F2D5FA23DB992DE() end
+
+-- _0x4FCBCC0584CD08E9  (0x4FCBCC0584CD08E9)
+-- min build: 1207
+---@param p0 number
+function N_0x4FCBCC0584CD08E9(p0) end
+
+-- _0x6123E2832C34243D  (0x6123E2832C34243D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x6123E2832C34243D(p0, p1, p2, p3, p4) end
+
+-- _0x8312F09C56149A8A  (0x8312F09C56149A8A)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param animalType number
+function N_0x8312F09C56149A8A(animalType) end
+
+-- _0x8BA3D7B1E83EF803  (0x8BA3D7B1E83EF803)
+-- min build: 1207
+---@param p0 number
+---@return number
+function N_0x8BA3D7B1E83EF803(p0) end
+
+-- _0x8C889E4CBB4B2356  (0x8C889E4CBB4B2356)
+-- min build: 1207
+---@param p0 any
+---@param ped number
+function N_0x8C889E4CBB4B2356(p0, ped) end
+
+-- _0x91A4F58E01ED5E4C  (0x91A4F58E01ED5E4C)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value number
+---@return any
+function N_0x91A4F58E01ED5E4C(value) end
+
+-- _0x99230691875FC218  (0x99230691875FC218)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param x number
+---@param y number
+---@param z number
+function N_0x99230691875FC218(p0, p1, x, y, z) end
+
+-- _0x9D0F5D2E1951CD84  (0x9D0F5D2E1951CD84)
+-- min build: 1207
+---@return number
+function N_0x9D0F5D2E1951CD84() end
+
+-- _0xA2E2BEA4E83F6270  (0xA2E2BEA4E83F6270)
+-- min build: 1207
+---@param p0 number
+---@return any
+function N_0xA2E2BEA4E83F6270(p0) end
+
+-- _0xA59590050F80FF2E  (0xA59590050F80FF2E)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param p0 any
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+function N_0xA59590050F80FF2E(p0, p1, p2, p3) end
+
+-- _0xA596890CF55B5095  (0xA596890CF55B5095)
+-- min build: 1436
+---@param ped number
+---@param p1 boolean
+function N_0xA596890CF55B5095(ped, p1) end
+
+-- _0xB112B9262EC29C20  (0xB112B9262EC29C20)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return string
+function N_0xB112B9262EC29C20(p0, p1) end
+
+-- _0xB5E2EDA2135E0FA1  (0xB5E2EDA2135E0FA1)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return boolean
+---@return number
+function N_0xB5E2EDA2135E0FA1(p0, p1) end
+
+-- _0xBE66B26B6529E943  (0xBE66B26B6529E943)
+-- min build: 1311
+---@param unlockHash number
+---@param ped number
+---@param animalType number
+function N_0xBE66B26B6529E943(unlockHash, ped, animalType) end
+
+-- _0xCA1F0B5103936891  (0xCA1F0B5103936891)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function N_0xCA1F0B5103936891(p0) end
+
+-- _0xCA41E86545413B5B  (0xCA41E86545413B5B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0xCA41E86545413B5B(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xD64DBC8B0424135F  (0xD64DBC8B0424135F)
+-- min build: 1207
+---@param ped number
+---@param animalType number
+function N_0xD64DBC8B0424135F(ped, animalType) end
+
+-- _0xDA26263C07CCE9C2  (0xDA26263C07CCE9C2)
+-- min build: 1207
+---@param p0 number
+function N_0xDA26263C07CCE9C2(p0) end
+
+-- _0xDDBD560745B1EE98  (0xDDBD560745B1EE98)
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+---@param player number
+---@return number
+function N_0xDDBD560745B1EE98(chalHash, goalHash, player) end
+
+-- _0xDF95DF488A645CE7  (0xDF95DF488A645CE7)
+-- min build: 1207
+function N_0xDF95DF488A645CE7() end
+
+-- _0xE141F6B40B1E3683  (0xE141F6B40B1E3683)
+-- statId: see STAT_ID_IS_VALID
+-- Only used in R* SP Scripts
+-- _STAT_ID_SET_*
+-- min build: 1207
+---@param value number
+---@return any
+function N_0xE141F6B40B1E3683(value) end
+
+-- _0xE5A680A5D8B1F687  (0xE5A680A5D8B1F687)
+-- min build: 1207
+---@param p0 number
+function N_0xE5A680A5D8B1F687(p0) end
+
+-- _0xF21A5D66874FCEDD  (0xF21A5D66874FCEDD)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 number
+function N_0xF21A5D66874FCEDD(p0, p1, p2) end
+
+-- _0xF2B5ABDE09958689  (0xF2B5ABDE09958689)
+-- min build: 1311
+---@param unlockHash number
+---@param ped1 number
+---@param ped2 number
+function N_0xF2B5ABDE09958689(unlockHash, ped1, ped2) end
+
+-- _0xF8181B5EF156862C  (0xF8181B5EF156862C)
+-- min build: 1207
+---@param ped number
+function N_0xF8181B5EF156862C(ped) end
+
+-- _STAT_ADD_ANIMAL_SAMPLE_TARGET  (0x90E9A5DADBABC918)
+-- Related to animal tagging
+-- min build: 1355
+---@param animalType number
+function _StatAddAnimalSampleTarget(animalType) end
+
+-- _STAT_CALCULATE_COOLDOWN  (0x1E7384AB5D4F4581)
+-- Calculation: (value / 1000) / 60 % 60
+-- min build: 1207
+---@param value number
+---@return number
+function _StatCalculateCooldown(value) end
+
+-- _STAT_CARRIED_SATCHEL_ITEM_FROM_PED  (0x831BF01C56149A8A)
+-- min build: 1207
+---@param ped number
+function _StatCarriedSatchelItemFromPed(ped) end
+
+-- _STAT_DONATE_INCREMENT_ITEM  (0x7C2ABF6E556B21FC)
+-- min build: 1207
+---@param item number
+---@param slot number
+---@param p2 any
+---@param p3 any
+function _StatDonateIncrementItem(item, slot, p2, p3) end
+
+-- _STAT_ID_DECREMENT_INT  (0xBD861AE8A5181ED7)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value number
+---@return any
+function _StatIdDecrementInt(value) end
+
+-- _STAT_ID_INCREMENT_FLOAT  (0x4A47E38EA3D60939)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value number
+---@return any
+function _StatIdIncrementFloat(value) end
+
+-- _STAT_ID_INCREMENT_INT  (0x6A0184E904CDF25E)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value number
+---@return any
+function _StatIdIncrementInt(value) end
+
+-- _STAT_ITEM_FISH_CAUGHT  (0xDA26263C87CCE9C1)
+-- min build: 1207
+---@param fish number
+---@param weight number
+---@param category number
+---@param subcategory number
+function _StatItemFishCaught(fish, weight, category, subcategory) end
+
+-- _STAT_PHEROMONE_COOLDOWN_LEGENDARY_ANIMAL  (0x5420D398A42917FC)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1311
+---@param entity number
+---@return boolean
+---@return any
+function _StatPheromoneCooldownLegendaryAnimal(entity) end
+
+-- _STATSTRACKER_DEED_STATUS  (0xD5910ECF81A2278C)
+-- min build: 1207
+---@param deedType number
+---@param deedHash number
+---@param missionStatus number
+---@return any
+function _StatstrackerDeedStatus(deedType, deedHash, missionStatus) end
+
+-- CHAL_ACHIEVEMENT_GET_PROGRESS_INT  (0x808712E428F697B8)
+-- min build: 1232
+---@param p0 number
+---@param p1 number
+---@return number
+function ChalAchievementGetProgressInt(p0, p1) end
+
+-- CHAL_ACHIEVEMENT_IS_COMPLETE  (0x77B97A827739D434)
+-- min build: 1232
+---@param p0 number
+---@param p1 number
+---@return boolean
+function ChalAchievementIsComplete(p0, p1) end
+
+-- CHAL_ADD_GOAL_PROGRESS_FLOAT  (0x86922D8C02FB7703)
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+---@param value number
+function ChalAddGoalProgressFloat(chalHash, goalHash, value) end
+
+-- CHAL_ADD_GOAL_PROGRESS_FLOAT_BY_SCORE_ID  (0x86922D8C02FB7705)
+-- min build: 1232
+---@param p0 number
+---@param value number
+function ChalAddGoalProgressFloatByScoreId(p0, value) end
+
+-- CHAL_ADD_GOAL_PROGRESS_INT  (0xDDBD560745B1EE9A)
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+---@param value number
+function ChalAddGoalProgressInt(chalHash, goalHash, value) end
+
+-- CHAL_ADD_GOAL_PROGRESS_INT_BY_SCORE_ID  (0xDDBD560745B1EE9C)
+-- min build: 1207
+---@param p0 number
+---@param value number
+function ChalAddGoalProgressIntByScoreId(p0, value) end
+
+-- CHAL_GET_MAX_RANKS  (0x58CB53DB63F84DEA)
+-- min build: 1207
+---@param chalHash number
+---@return number
+function ChalGetMaxRanks(chalHash) end
+
+-- CHAL_GET_NUM_RANKS_COMPLETED  (0x58CB53DB63F84DE9)
+-- min build: 1207
+---@param chalHash number
+---@return number
+function ChalGetNumRanksCompleted(chalHash) end
+
+-- CHAL_IS_GOAL_ACTIVE  (0x04DAC3929796EB87)
+-- https://github.com/femga/rdr3_discoveries/blob/master/AI/EVENTS/challenge_goals.lua
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+---@return boolean
+function ChalIsGoalActive(chalHash, goalHash) end
+
+-- CHAL_MISSION_ADD_GOAL_PROGRESS_INT  (0x97E18E7C098626DE)
+-- min build: 1207
+---@param missionHash number
+---@param goalHash number
+---@param value number
+function ChalMissionAddGoalProgressInt(missionHash, goalHash, value) end
+
+-- CHAL_MISSION_GET_NUM_GOALS  (0x0B0576DD3A75E58D)
+-- min build: 1207
+---@param missionHash number
+---@return number
+function ChalMissionGetNumGoals(missionHash) end
+
+-- CHAL_MISSION_GET_NUM_GOALS_COMPLETE  (0xA785A52B59B7E7B2)
+-- min build: 1207
+---@param missionHash number
+---@return number
+function ChalMissionGetNumGoalsComplete(missionHash) end
+
+-- CHAL_MISSION_IS_GOAL_COMPLETE  (0xC0BB774787BBF301)
+-- min build: 1207
+---@param missionHash number
+---@param goalHash number
+---@return boolean
+function ChalMissionIsGoalComplete(missionHash, goalHash) end
+
+-- CHAL_NET_START_CHAL  (0x4ABF7E4DB6279E8F)
+-- min build: 1207
+---@param chalHash number
+function ChalNetStartChal(chalHash) end
+
+-- CHAL_NET_START_GOAL  (0xC3FCB47344DCB638)
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+function ChalNetStartGoal(chalHash, goalHash) end
+
+-- CHAL_NET_STOP_CHAL  (0x43B0163154A50C86)
+-- min build: 1207
+---@param chalHash number
+function ChalNetStopChal(chalHash) end
+
+-- CHAL_NET_STOP_GOAL  (0x00CE6A93324A590B)
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+function ChalNetStopGoal(chalHash, goalHash) end
+
+-- CHAL_SET_GOAL_DISABLED  (0xF63DF9EE16393343)
+-- min build: 1436
+---@param chalHash number
+---@param goalHash number
+---@param disabled boolean
+function ChalSetGoalDisabled(chalHash, goalHash, disabled) end
+
+-- CHAL_SET_GOAL_PROGRESS_INT  (0xDDBD560745B1EE9B)
+-- min build: 1207
+---@param chalHash number
+---@param goalHash number
+---@param value number
+function ChalSetGoalProgressInt(chalHash, goalHash, value) end
+
+-- STAT_ADD_BOUNTY_TARGET  (0x6B1044FDC2B09101)
+-- min build: 1207
+---@param unlockHash number
+---@param ped number
+function StatAddBountyTarget(unlockHash, ped) end
+
+-- STAT_BOUNTY_CAPTURED  (0x262EF7CF49CF1EB9)
+-- min build: 1207
+---@param entity number
+function StatBountyCaptured(entity) end
+
+-- STAT_BOUNTY_ESCAPED  (0xB22F05732F72F70C)
+-- min build: 1207
+---@param ped number
+function StatBountyEscaped(ped) end
+
+-- STAT_ID_GET_BOOL  (0x11B5E6D2AE73F48F)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@return boolean
+---@return any
+---@return boolean
+function StatIdGetBool() end
+
+-- STAT_ID_GET_DATE  (0x8B0FACEFC36C824C)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function StatIdGetDate() end
+
+-- STAT_ID_GET_FLOAT  (0xD7AE6C9C9C6AC54D)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@return boolean
+---@return any
+---@return number
+function StatIdGetFloat() end
+
+-- STAT_ID_GET_INT  (0x767FBC2AC802EF3E)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@return boolean
+---@return any
+---@return number
+function StatIdGetInt() end
+
+-- STAT_ID_IS_VALID  (0xC48FE1971C9743FF)
+-- struct StatId
+-- {
+-- 	alignas(8) Hash BaseId;
+-- 	alignas(8) Hash PermutationId;
+-- }
+-- min build: 1207
+---@return boolean
+---@return any
+function StatIdIsValid() end
+
+-- STAT_ID_SET_BOOL  (0x3B5107353267D7A1)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value boolean
+---@param p2 boolean
+---@return boolean
+---@return any
+function StatIdSetBool(value, p2) end
+
+-- STAT_ID_SET_DATE  (0x1FAE9B2FAA2DFE06)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param p2 boolean
+---@return boolean
+---@return any
+---@return any
+function StatIdSetDate(p2) end
+
+-- STAT_ID_SET_FLOAT  (0x481BDF6A10C5EF68)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value number
+---@param p2 boolean
+---@return boolean
+---@return any
+function StatIdSetFloat(value, p2) end
+
+-- STAT_ID_SET_GXT_LABEL  (0x05060A54834F2382)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param label string
+---@param p2 boolean
+---@return boolean
+---@return any
+function StatIdSetGxtLabel(label, p2) end
+
+-- STAT_ID_SET_INT  (0xA4DDF5DF95E65EEE)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@param value number
+---@param p2 boolean
+---@return boolean
+---@return any
+function StatIdSetInt(value, p2) end
+
+-- STAT_ID_SET_TO_POSSE_ID  (0x34B22DE38477EDB4)
+-- statId: see STAT_ID_IS_VALID
+-- min build: 1207
+---@return any
+function StatIdSetToPosseId() end
+
+-- STAT_PHOTOGRAPH_TAKEN  (0x4D31051A4CA83787)
+-- min build: 1311
+---@param itemset number
+function StatPhotographTaken(itemset) end
+
+-- STAT_REGISTER_LEGENDARY_ANIMAL_DEED  (0xCD0D69C65BB0E8B9)
+-- min build: 1311
+---@param deedHash number
+function StatRegisterLegendaryAnimalDeed(deedHash) end
+
+-- STATSTRACKER_DEED_STARTED  (0xB2A38826E5886E83)
+-- min build: 1207
+---@param p0 number
+---@param p1 any
+function StatstrackerDeedStarted(p0, p1) end
+
+-- STATSTRACKER_IS_INITIALIZED  (0x01F4D242765C6B24)
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function StatstrackerIsInitialized(p0) end
+
+-- WEEKLY_COLLECTIBLE_GET_ITEM_IN_SET  (0xBA61BA6205A3F5A8)
+-- min build: 1207
+---@param chalHash number
+---@param setIndex number
+---@param itemIndex number
+---@return boolean
+---@return number
+---@return number
+function WeeklyCollectibleGetItemInSet(chalHash, setIndex, itemIndex) end
+
+-- WEEKLY_COLLECTIBLE_GET_ITEM_SET_BUY_AWARD  (0x610783F646894D25)
+-- min build: 1207
+---@param chalHash number
+---@param index number
+---@return number
+function WeeklyCollectibleGetItemSetBuyAward(chalHash, index) end
+
+-- WEEKLY_COLLECTIBLE_GET_ITEM_SET_LABEL  (0xBFFA88522FF0F730)
+-- min build: 1207
+---@param chalHash number
+---@param index number
+---@return number
+function WeeklyCollectibleGetItemSetLabel(chalHash, index) end
+
+-- WEEKLY_COLLECTIBLE_GET_NUM_ITEMS_IN_SET  (0x7D675C9DDDB365BE)
+-- min build: 1207
+---@param chalHash number
+---@param index number
+---@return number
+function WeeklyCollectibleGetNumItemsInSet(chalHash, index) end
+
+-- WEEKLY_COLLECTIBLE_GET_NUM_SETS  (0x8F5317729F791D10)
+-- min build: 1207
+---@param chalHash number
+---@return number
+function WeeklyCollectibleGetNumSets(chalHash) end

--- a/.luals/redm-natives/STREAMING.lua
+++ b/.luals/redm-natives/STREAMING.lua
@@ -1,0 +1,672 @@
+---@meta
+
+-- RDR3 namespace: STREAMING -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x032A14D082A9B269  (0x032A14D082A9B269)
+-- _SET_E* or _SET_F*
+-- min build: 1207
+---@param p0 number
+function N_0x032A14D082A9B269(p0) end
+
+-- _0x03DDBF2D73799F9E  (0x03DDBF2D73799F9E)
+-- min build: 1207
+---@param p0 any
+function N_0x03DDBF2D73799F9E(p0) end
+
+-- _0x05DD384F39DE1C8C  (0x05DD384F39DE1C8C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x05DD384F39DE1C8C(p0, p1) end
+
+-- _0x071769BCB24379E5  (0x071769BCB24379E5)
+-- min build: 1207
+---@return any
+function N_0x071769BCB24379E5() end
+
+-- _0x07559B29950301FF  (0x07559B29950301FF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x07559B29950301FF(p0, p1) end
+
+-- _0x09FBF15D73EFC900  (0x09FBF15D73EFC900)
+-- min build: 1207
+function N_0x09FBF15D73EFC900() end
+
+-- _0x198B85CC3C7A4593  (0x198B85CC3C7A4593)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x198B85CC3C7A4593(p0, p1) end
+
+-- _0x27AF48C62B281341  (0x27AF48C62B281341)
+-- min build: 1207
+---@return any
+function N_0x27AF48C62B281341() end
+
+-- _0x2A6D1DAAB9EBB262  (0x2A6D1DAAB9EBB262)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2A6D1DAAB9EBB262(p0) end
+
+-- _0x2E24C27B112B5B12  (0x2E24C27B112B5B12)
+-- min build: 1311
+---@param p0 any
+function N_0x2E24C27B112B5B12(p0) end
+
+-- _0x2F4D53023F826FF0  (0x2F4D53023F826FF0)
+-- min build: 1207
+---@return any
+function N_0x2F4D53023F826FF0() end
+
+-- _0x5288B7F0690F7C1F  (0x5288B7F0690F7C1F)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x5288B7F0690F7C1F(p0) end
+
+-- _0x53764309C4618087  (0x53764309C4618087)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x53764309C4618087(p0) end
+
+-- _0x5D5E2102B174B8D2  (0x5D5E2102B174B8D2)
+-- min build: 1207
+---@return any
+function N_0x5D5E2102B174B8D2() end
+
+-- _0x62D5F0588915B277  (0x62D5F0588915B277)
+-- min build: 1207
+function N_0x62D5F0588915B277() end
+
+-- _0x66BC28E50E85270E  (0x66BC28E50E85270E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x66BC28E50E85270E(p0) end
+
+-- _0x6A6E79FBE8678C98  (0x6A6E79FBE8678C98)
+-- min build: 1207
+function N_0x6A6E79FBE8678C98() end
+
+-- _0x7B8C2B846C05E5AD  (0x7B8C2B846C05E5AD)
+-- min build: 1207
+---@return any
+function N_0x7B8C2B846C05E5AD() end
+
+-- _0x80B3E0597366ADF1  (0x80B3E0597366ADF1)
+-- min build: 1207
+function N_0x80B3E0597366ADF1() end
+
+-- _0x85B8F04555AB49B8  (0x85B8F04555AB49B8)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x85B8F04555AB49B8(p0) end
+
+-- _0x8D56BDA343D9519F  (0x8D56BDA343D9519F)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x8D56BDA343D9519F(p0) end
+
+-- _0x99F92061EFE908BA  (0x99F92061EFE908BA)
+-- min build: 1207
+---@return any
+function N_0x99F92061EFE908BA() end
+
+-- _0x9F348DE670423460  (0x9F348DE670423460)
+-- min build: 1207
+---@param p0 any
+function N_0x9F348DE670423460(p0) end
+
+-- _0xA0AE7653E8181725  (0xA0AE7653E8181725)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xA0AE7653E8181725(p0) end
+
+-- _0xAE00387E53B1E9FC  (0xAE00387E53B1E9FC)
+-- min build: 1207
+function N_0xAE00387E53B1E9FC() end
+
+-- _0xAFA87A7D41EE346A  (0xAFA87A7D41EE346A)
+-- min build: 1207
+---@param p0 any
+function N_0xAFA87A7D41EE346A(p0) end
+
+-- _0xB223249B7798EEED  (0xB223249B7798EEED)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xB223249B7798EEED(p0, p1, p2, p3) end
+
+-- _0xB9B9E47EDB9D63DB  (0xB9B9E47EDB9D63DB)
+-- Sorts some unknown data.
+-- 
+-- Likely SORT_*
+-- min build: 1207
+function N_0xB9B9E47EDB9D63DB() end
+
+-- _0xBE8DAA9D8D01DA6A  (0xBE8DAA9D8D01DA6A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xBE8DAA9D8D01DA6A(p0, p1, p2) end
+
+-- _0xCC61D8D6C19D9F14  (0xCC61D8D6C19D9F14)
+-- min build: 1207
+---@param p0 any
+function N_0xCC61D8D6C19D9F14(p0) end
+
+-- _0xD6E39DC5D46DF4AB  (0xD6E39DC5D46DF4AB)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xD6E39DC5D46DF4AB(p0) end
+
+-- _0xD840C130D7AACFA5  (0xD840C130D7AACFA5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD840C130D7AACFA5(p0, p1, p2) end
+
+-- _0xD9F2FF4AF394D926  (0xD9F2FF4AF394D926)
+-- min build: 1207
+function N_0xD9F2FF4AF394D926() end
+
+-- _0xDA7FDEFF4DE86839  (0xDA7FDEFF4DE86839)
+-- min build: 1207
+---@return any
+function N_0xDA7FDEFF4DE86839() end
+
+-- _0xDABFE48BA0D457AA  (0xDABFE48BA0D457AA)
+-- min build: 1207
+---@return any
+function N_0xDABFE48BA0D457AA() end
+
+-- _0xE5B76E5B56CD77DD  (0xE5B76E5B56CD77DD)
+-- min build: 1207
+---@return any
+function N_0xE5B76E5B56CD77DD() end
+
+-- _0xEF1A8A484118735E  (0xEF1A8A484118735E)
+-- min build: 1207
+function N_0xEF1A8A484118735E() end
+
+-- _0xF01D21DF39554115  (0xF01D21DF39554115)
+-- min build: 1207
+---@param p0 any
+function N_0xF01D21DF39554115(p0) end
+
+-- _0xF11D7CB962FCD747  (0xF11D7CB962FCD747)
+-- min build: 1207
+---@param p0 any
+function N_0xF11D7CB962FCD747(p0) end
+
+-- _GET_IPL_BOUNDING_SPHERE  (0x9C77964B0E07B633)
+-- Outputs IPL position and radius (previously wrongly named heading)
+-- https://github.com/femga/rdr3_discoveries/blob/master/imaps/imaps_with_coords_and_heading.lua
+-- min build: 1207
+---@param iplHash number
+---@return boolean
+---@return vector3
+---@return number
+function _GetIplBoundingSphere(iplHash) end
+
+-- _HAS_COLLISION_LOADED_AT_COORD  (0xDA8B2EAF29E872E2)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function _HasCollisionLoadedAtCoord(x, y, z) end
+
+-- _HAS_SCENARIO_TYPE_LOADED  (0x9427C94D2E4094A4)
+-- min build: 1207
+---@param scenarioType number
+---@param p1 boolean
+---@return boolean
+function _HasScenarioTypeLoaded(scenarioType, p1) end
+
+-- _IS_MODEL_AN_OBJECT  (0x274EE1B90CFA669E)
+-- min build: 1207
+---@param model number
+---@return boolean
+function _IsModelAnObject(model) end
+
+-- _IS_POSITION_INSIDE_IPL_STREAMING_EXTENTS  (0x73B40D97D7BAAD77)
+-- Returns true if IPL is streamed in (?)
+-- min build: 1207
+---@param iplHash number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function _IsPositionInsideIplStreamingExtents(iplHash, x, y, z) end
+
+-- _REMOVE_ALL_IPLS  (0xDEEE1F265B7ECEF5)
+-- Removes/unloads all currently active IPLs.
+-- min build: 1311
+function _RemoveAllIpls() end
+
+-- _REMOVE_SCENARIO_ASSET  (0x4EDDD9E9CA5AF985)
+-- min build: 1207
+---@param scenarioType number
+---@return any
+function _RemoveScenarioAsset(scenarioType) end
+
+-- _REQUEST_CLIP_SET_BY_HASH  (0xAC37644A538F7524)
+-- min build: 1207
+---@param clipSetHash number
+function _RequestClipSetByHash(clipSetHash) end
+
+-- _REQUEST_METADATA_AT_COORD  (0xA8432A14D4DC2101)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function _RequestMetadataAtCoord(x, y, z) end
+
+-- _REQUEST_SCENARIO_TYPE  (0x19A6BE7D9C6884D3)
+-- entityModel can be 0 or using Hash or using GET_ENTITY_MODEL
+-- conditionalAnim can be 0 or using Hash also accepts GET_ACTIVE_DYNAMIC_SCENARIO.
+-- min build: 1207
+---@param scenarioType number
+---@param p1 number
+---@param entityModel number
+---@param conditionalAnim number
+---@return number
+function _RequestScenarioType(scenarioType, p1, entityModel, conditionalAnim) end
+
+-- _SET_GUARMA_WORLDHORIZON_ACTIVE  (0x74E2261D2A66849A)
+-- min build: 1207
+---@param toggle boolean
+function _SetGuarmaWorldhorizonActive(toggle) end
+
+-- BEGIN_SRL  (0x0360710033BE60D9)
+-- min build: 1207
+function BeginSrl() end
+
+-- CLEAR_FOCUS  (0x86CCAF7CE493EFBE)
+-- min build: 1207
+function ClearFocus() end
+
+-- CLEAR_HD_AREA  (0xD83B22434E52728D)
+-- min build: 1207
+function ClearHdArea() end
+
+-- DOES_ANIM_DICT_EXIST  (0x537F44CB0D7F150D)
+-- min build: 1207
+---@param animDict string
+---@return boolean
+function DoesAnimDictExist(animDict) end
+
+-- END_SRL  (0x1CE71FB33CA079FE)
+-- min build: 1207
+function EndSrl() end
+
+-- GET_NUMBER_OF_STREAMING_REQUESTS  (0x30CCCC4D88E654CA)
+-- min build: 1207
+---@return number
+function GetNumberOfStreamingRequests() end
+
+-- GET_POPULATION_BUDGET_MULTIPLIER  (0x8A3945405B31048F)
+-- min build: 1207
+---@return number
+function GetPopulationBudgetMultiplier() end
+
+-- HAS_ANIM_DICT_LOADED  (0x27FF6FE8009B40CA)
+-- min build: 1207
+---@param animDict string
+---@return boolean
+function HasAnimDictLoaded(animDict) end
+
+-- HAS_CLIP_SET_LOADED  (0x1F23D6B6DA1CC3B2)
+-- Alias for HAS_ANIM_SET_LOADED.
+-- min build: 1207
+---@param clipSet string
+---@return boolean
+function HasClipSetLoaded(clipSet) end
+
+-- HAS_COLLISION_FOR_MODEL_LOADED  (0x210A79C9EC89778F)
+-- min build: 1207
+---@param model number
+---@return boolean
+function HasCollisionForModelLoaded(model) end
+
+-- HAS_MODEL_LOADED  (0x1283B8B89DD5D1B6)
+-- Checks if the specified model has loaded into memory.
+-- min build: 1207
+---@param model number
+---@return boolean
+function HasModelLoaded(model) end
+
+-- HAS_MOVE_NETWORK_DEF_LOADED  (0x2C04D89A0FB4E244)
+-- min build: 1207
+---@param name string
+---@return boolean
+function HasMoveNetworkDefLoaded(name) end
+
+-- HAS_NAMED_PTFX_ASSET_LOADED  (0x65BB72F29138F5D6)
+-- min build: 1207
+---@param fxNameHash number
+---@return boolean
+function HasNamedPtfxAssetLoaded(fxNameHash) end
+
+-- HAS_PTFX_ASSET_LOADED  (0x13A3F30A9ED0BC31)
+-- min build: 1207
+---@return boolean
+function HasPtfxAssetLoaded() end
+
+-- IPL_GROUP_SWAP_CANCEL  (0x31108BB5715D035F)
+-- min build: 1207
+function IplGroupSwapCancel() end
+
+-- IPL_GROUP_SWAP_FINISH  (0x040EE319EFD1D3B5)
+-- min build: 1207
+function IplGroupSwapFinish() end
+
+-- IPL_GROUP_SWAP_IS_ACTIVE  (0xFC464598F6EE97B0)
+-- min build: 1207
+---@return boolean
+function IplGroupSwapIsActive() end
+
+-- IPL_GROUP_SWAP_IS_READY  (0xC2C05DEFE85A0B64)
+-- min build: 1207
+---@return boolean
+function IplGroupSwapIsReady() end
+
+-- IPL_GROUP_SWAP_START  (0x20D504994FDC4412)
+-- min build: 1207
+---@param iplName1 string
+---@param iplName2 string
+function IplGroupSwapStart(iplName1, iplName2) end
+
+-- IS_ENTITY_FOCUS  (0xF87DE697E9A06EC6)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function IsEntityFocus(entity) end
+
+-- IS_IPL_ACTIVE_BY_HASH  (0x93AC1B91CB6D9913)
+-- Old name: _IS_IMAP_ACTIVE_2
+-- min build: 1207
+---@param iplHash number
+---@return boolean
+function IsIplActiveByHash(iplHash) end
+
+-- IS_IPL_ACTIVE_HASH  (0xD779B9B910BD3B7C)
+-- Old name: _IS_IMAP_ACTIVE
+-- min build: 1207
+---@param iplHash number
+---@return boolean
+function IsIplActiveHash(iplHash) end
+
+-- IS_LOAD_SCENE_ACTIVE  (0xCF45DF50C7775F2A)
+-- min build: 1207
+---@return boolean
+function IsLoadSceneActive() end
+
+-- IS_LOAD_SCENE_LOADED  (0x0909F71B5C070797)
+-- min build: 1207
+---@return boolean
+function IsLoadSceneLoaded() end
+
+-- IS_MODEL_A_PED  (0xC3F09DE9D6D17DDA)
+-- min build: 1207
+---@param model number
+---@return boolean
+function IsModelAPed(model) end
+
+-- IS_MODEL_A_VEHICLE  (0x354F62672DE7DB0A)
+-- Returns whether the specified model represents a vehicle.
+-- min build: 1207
+---@param model number
+---@return boolean
+function IsModelAVehicle(model) end
+
+-- IS_MODEL_IN_CDIMAGE  (0xD6F3B6D7716CFF8E)
+-- Returns whether the specified model exists in the game.
+-- min build: 1207
+---@param model number
+---@return boolean
+function IsModelInCdimage(model) end
+
+-- IS_MODEL_VALID  (0x392C8D8E07B70EFC)
+-- Returns whether the specified model is valid
+-- min build: 1207
+---@param model number
+---@return boolean
+function IsModelValid(model) end
+
+-- IS_PLAYER_SWITCH_IN_PROGRESS  (0xED20CB1F5297791D)
+-- min build: 1207
+---@return boolean
+function IsPlayerSwitchInProgress() end
+
+-- IS_RENDERED_SCENE_LOADED  (0x45BF3A6239A576B7)
+-- min build: 1207
+---@return boolean
+function IsRenderedSceneLoaded() end
+
+-- IS_SRL_LOADED  (0x5C2C88512CF6DAFB)
+-- min build: 1207
+---@return boolean
+function IsSrlLoaded() end
+
+-- LOAD_SCENE_START  (0x387AD749E3B69B70)
+-- min build: 1207
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param radius number
+---@param p7 number
+---@return boolean
+function LoadSceneStart(posX, posY, posZ, offsetX, offsetY, offsetZ, radius, p7) end
+
+-- LOAD_SCENE_START_SPHERE  (0x513F8AA5BF2F17CF)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 any
+---@return boolean
+function LoadSceneStartSphere(x, y, z, radius, p4) end
+
+-- LOAD_SCENE_STOP  (0x5A8B01199C3E79C3)
+-- min build: 1207
+function LoadSceneStop() end
+
+-- PREFETCH_SRL  (0x354837E5A5BAA5AF)
+-- min build: 1207
+---@param srl string
+function PrefetchSrl(srl) end
+
+-- REMOVE_ANIM_DICT  (0x4763145053A33D46)
+-- min build: 1207
+---@param animDict string
+function RemoveAnimDict(animDict) end
+
+-- REMOVE_CLIP_SET  (0x817FA1B1EE7CD6F0)
+-- Alias for REMOVE_ANIM_SET.
+-- min build: 1207
+---@param clipSet string
+function RemoveClipSet(clipSet) end
+
+-- REMOVE_IPL_BY_HASH  (0x431E3AB760629B34)
+-- Old name: _REMOVE_IMAP_2
+-- min build: 1207
+---@param iplHash number
+function RemoveIplByHash(iplHash) end
+
+-- REMOVE_IPL_HASH  (0x5A3E5CF7B4014B96)
+-- Old name: _REMOVE_IMAP
+-- min build: 1207
+---@param iplHash number
+function RemoveIplHash(iplHash) end
+
+-- REMOVE_MOVE_NETWORK_DEF  (0x57A197AD83F66BBF)
+-- min build: 1207
+---@param name string
+function RemoveMoveNetworkDef(name) end
+
+-- REMOVE_NAMED_PTFX_ASSET  (0xF20866829E1C81A2)
+-- min build: 1207
+---@param fxNameHash number
+function RemoveNamedPtfxAsset(fxNameHash) end
+
+-- REMOVE_PTFX_ASSET  (0x042F9049EA419E86)
+-- min build: 1207
+function RemovePtfxAsset() end
+
+-- REQUEST_ADDITIONAL_COLLISION_AT_COORD  (0x83A8D71650D1894F)
+-- min build: 1311
+---@param x number
+---@param y number
+---@param z number
+function RequestAdditionalCollisionAtCoord(x, y, z) end
+
+-- REQUEST_ANIM_DICT  (0xA862A2AD321F94B4)
+-- min build: 1207
+---@param animDict string
+function RequestAnimDict(animDict) end
+
+-- REQUEST_CLIP_SET  (0xEF7611B57A820126)
+-- min build: 1207
+---@param clipSet string
+function RequestClipSet(clipSet) end
+
+-- REQUEST_COLLISION_AT_COORD  (0x0A3720F162A033C9)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function RequestCollisionAtCoord(x, y, z) end
+
+-- REQUEST_COLLISION_FOR_MODEL  (0xF1767BE37F661551)
+-- min build: 1207
+---@param model number
+function RequestCollisionForModel(model) end
+
+-- REQUEST_IPL_BY_HASH  (0x9E211A378F95C97C)
+-- Old name: _REQUEST_IMAP_2
+-- min build: 1207
+---@param iplHash number
+function RequestIplByHash(iplHash) end
+
+-- REQUEST_IPL_HASH  (0x59767C5A7A9AE6DA)
+-- Old name: _REQUEST_IMAP
+-- min build: 1207
+---@param iplHash number
+function RequestIplHash(iplHash) end
+
+-- REQUEST_MODEL  (0xFA28FE3A6246FC30)
+-- Request a model to be loaded into memory.
+-- min build: 1207
+---@param model number
+---@param p1 boolean
+function RequestModel(model, p1) end
+
+-- REQUEST_MOVE_NETWORK_DEF  (0x2B6529C54D29037A)
+-- min build: 1207
+---@param name string
+function RequestMoveNetworkDef(name) end
+
+-- REQUEST_NAMED_PTFX_ASSET  (0xF2B2353BBC0D4E8F)
+-- min build: 1207
+---@param fxNameHash number
+function RequestNamedPtfxAsset(fxNameHash) end
+
+-- REQUEST_PTFX_ASSET  (0x001FF43843028E0C)
+-- min build: 1207
+function RequestPtfxAsset() end
+
+-- SET_ALL_MAPDATA_CULLED  (0x19ABCC581D28E6F9)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+function SetAllMapdataCulled(p0) end
+
+-- SET_FOCUS_ENTITY  (0x955AEDD58F4BD309)
+-- It seems to make the entity's coords mark the point from which LOD-distances are measured. In my testing, setting a vehicle as the focus entity and moving that vehicle more than 300 distance units away from the player will make the level of detail around the player go down drastically (shadows disappear, textures go extremely low res, etc). The player seems to be the default focus entity.
+-- min build: 1207
+---@param entity number
+function SetFocusEntity(entity) end
+
+-- SET_FOCUS_POS_AND_VEL  (0x25F6EF88664540E2)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+function SetFocusPosAndVel(x, y, z, offsetX, offsetY, offsetZ) end
+
+-- SET_GAME_PAUSES_FOR_STREAMING  (0xB3BC8250F4FE8B63)
+-- min build: 1207
+---@param toggle boolean
+function SetGamePausesForStreaming(toggle) end
+
+-- SET_HD_AREA  (0xB88B905AFA35CB4D)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+function SetHdArea(x, y, z, radius) end
+
+-- SET_MAPDATACULLBOX_ENABLED  (0x3CACC83F6FED837C)
+-- min build: 1207
+---@param name string
+---@param toggle boolean
+function SetMapdatacullboxEnabled(name, toggle) end
+
+-- SET_MODEL_AS_NO_LONGER_NEEDED  (0x4AD96EF928BD4F9A)
+-- Marks the model as no longer needed.
+-- min build: 1207
+---@param model number
+function SetModelAsNoLongerNeeded(model) end
+
+-- SET_POPULATION_BUDGET_MULTIPLIER  (0x2F9AC754FE179D58)
+-- min build: 1207
+---@param fBudgetMultiplier number
+function SetPopulationBudgetMultiplier(fBudgetMultiplier) end
+
+-- SET_SCENE_STREAMING_TRACKS_CAM_POS_THIS_FRAME  (0xA03A6812529AD9C8)
+-- min build: 1207
+function SetSceneStreamingTracksCamPosThisFrame() end
+
+-- SET_SRL_LONG_JUMP_MODE  (0x7C907E8A725E5FD2)
+-- min build: 1207
+---@param p0 boolean
+function SetSrlLongJumpMode(p0) end
+
+-- SET_SRL_READAHEAD_TIMES  (0xD346248C1DCE0D76)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+function SetSrlReadaheadTimes(p0, p1, p2, p3) end
+
+-- SET_SRL_TIME  (0x18231AEF458BCFF2)
+-- min build: 1207
+---@param p0 number
+function SetSrlTime(p0) end

--- a/.luals/redm-natives/TASK.lua
+++ b/.luals/redm-natives/TASK.lua
@@ -1,0 +1,5467 @@
+---@meta
+
+-- RDR3 namespace: TASK -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0000A8ACDC2E1B6A  (0x0000A8ACDC2E1B6A)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x0000A8ACDC2E1B6A(ped, p1) end
+
+-- _0x00FFE0F85253C572  (0x00FFE0F85253C572)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x00FFE0F85253C572(p0) end
+
+-- _0x0365000D8BF86531  (0x0365000D8BF86531)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x0365000D8BF86531(p0) end
+
+-- _0x098036CAB8373D36  (0x098036CAB8373D36)
+-- min build: 1207
+---@param p0 any
+function N_0x098036CAB8373D36(p0) end
+
+-- _0x098CAA6DBE7D8D82  (0x098CAA6DBE7D8D82)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x098CAA6DBE7D8D82(p0, p1) end
+
+-- _0x0A98A362C5A19A43  (0x0A98A362C5A19A43)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x0A98A362C5A19A43(p0) end
+
+-- _0x0D322AEF8878B8FE  (0x0D322AEF8878B8FE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0D322AEF8878B8FE(p0, p1) end
+
+-- _0x0E184495B27BB57D  (0x0E184495B27BB57D)
+-- min build: 1207
+function N_0x0E184495B27BB57D() end
+
+-- _0x0F4F6C4CE471259D  (0x0F4F6C4CE471259D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0F4F6C4CE471259D(p0, p1) end
+
+-- _0x10ADFDF07B7DFFBA  (0x10ADFDF07B7DFFBA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x10ADFDF07B7DFFBA(p0, p1, p2) end
+
+-- _0x10C44F633E2D6D9E  (0x10C44F633E2D6D9E)
+-- min build: 1207
+---@param p0 any
+function N_0x10C44F633E2D6D9E(p0) end
+
+-- _0x11C7CE1AE38911B5  (0x11C7CE1AE38911B5)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x11C7CE1AE38911B5(p0) end
+
+-- _0x152664AA3188B193  (0x152664AA3188B193)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return any
+function N_0x152664AA3188B193(p0, p1, p2, p3, p4, p5) end
+
+-- _0x1632EB9386CDBE64  (0x1632EB9386CDBE64)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x1632EB9386CDBE64(p0, p1) end
+
+-- _0x19BC99C678FBA139  (0x19BC99C678FBA139)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x19BC99C678FBA139(p0, p1, p2) end
+
+-- _0x1A7D63CB1B0BB223  (0x1A7D63CB1B0BB223)
+-- min build: 1207
+---@param p0 any
+function N_0x1A7D63CB1B0BB223(p0) end
+
+-- _0x1AC5A8AB50CFAA33  (0x1AC5A8AB50CFAA33)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x1AC5A8AB50CFAA33(p0) end
+
+-- _0x1F298C7BD30D1240  (0x1F298C7BD30D1240)
+-- min build: 1207
+---@param ped number
+function N_0x1F298C7BD30D1240(ped) end
+
+-- _0x1F7A9A9C38C13A56  (0x1F7A9A9C38C13A56)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x1F7A9A9C38C13A56(p0) end
+
+-- _0x2064B33F6E6B92D4  (0x2064B33F6E6B92D4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x2064B33F6E6B92D4(p0, p1, p2, p3) end
+
+-- _0x22CD2C33ED4467A1  (0x22CD2C33ED4467A1)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x22CD2C33ED4467A1(p0) end
+
+-- _0x22CDBF317C40A122  (0x22CDBF317C40A122)
+-- min build: 1207
+---@param ped number
+function N_0x22CDBF317C40A122(ped) end
+
+-- _0x23767D80C7EED7C6  (0x23767D80C7EED7C6)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+function N_0x23767D80C7EED7C6(p0, p1) end
+
+-- _0x28EF780BDEA8A639  (0x28EF780BDEA8A639)
+-- min build: 1207
+---@param ped number
+---@param facingPed number
+function N_0x28EF780BDEA8A639(ped, facingPed) end
+
+-- _0x2948235DB2058E99  (0x2948235DB2058E99)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x2948235DB2058E99(p0, p1) end
+
+-- _0x2A10538D0A005E81  (0x2A10538D0A005E81)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x2A10538D0A005E81(p0, p1) end
+
+-- _0x2B8AF29A78024BD3  (0x2B8AF29A78024BD3)
+-- min build: 1207
+---@param p0 any
+function N_0x2B8AF29A78024BD3(p0) end
+
+-- _0x2C497BDEF897C6DF  (0x2C497BDEF897C6DF)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2C497BDEF897C6DF(p0) end
+
+-- _0x2D657B10F211C572  (0x2D657B10F211C572)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return any
+function N_0x2D657B10F211C572(ped, p1) end
+
+-- _0x2E1D6D87346BB7D2  (0x2E1D6D87346BB7D2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x2E1D6D87346BB7D2(p0, p1, p2, p3) end
+
+-- _0x2EB977293923C723  (0x2EB977293923C723)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x2EB977293923C723(p0, p1) end
+
+-- _0x30146C25686B7836  (0x30146C25686B7836)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x30146C25686B7836(p0, p1) end
+
+-- _0x30B391915538EBE2  (0x30B391915538EBE2)
+-- min build: 1207
+---@param p0 any
+function N_0x30B391915538EBE2(p0) end
+
+-- _0x31BB338F64D5C861  (0x31BB338F64D5C861)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+function N_0x31BB338F64D5C861(ped, p1) end
+
+-- _0x358A1A751B335A11  (0x358A1A751B335A11)
+-- min build: 1207
+---@param p0 any
+function N_0x358A1A751B335A11(p0) end
+
+-- _0x370F57C47F68EBCA  (0x370F57C47F68EBCA)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x370F57C47F68EBCA(p0) end
+
+-- _0x3BBEECC5B8F35318  (0x3BBEECC5B8F35318)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3BBEECC5B8F35318(p0, p1) end
+
+-- _0x3F8387DB1B9F31B7  (0x3F8387DB1B9F31B7)
+-- Used for HORSE_REVIVE
+-- min build: 1207
+---@param p1 boolean
+---@return boolean
+---@return any
+function N_0x3F8387DB1B9F31B7(p1) end
+
+-- _0x3FEB770D8ED9047A  (0x3FEB770D8ED9047A)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x3FEB770D8ED9047A(p0) end
+
+-- _0x41323F4E0C4AE94B  (0x41323F4E0C4AE94B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0x41323F4E0C4AE94B(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x4161648394262FDF  (0x4161648394262FDF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x4161648394262FDF(p0, p1, p2, p3) end
+
+-- _0x41D1331AFAD5A091  (0x41D1331AFAD5A091)
+-- _SET_PED_*
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 any
+function N_0x41D1331AFAD5A091(ped, p1, p2) end
+
+-- _0x450080DDEDB91258  (0x450080DDEDB91258)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x450080DDEDB91258(p0, p1) end
+
+-- _0x4A7D73989F52EB37  (0x4A7D73989F52EB37)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x4A7D73989F52EB37(p0, p1) end
+
+-- _0x4BA972D0E5AD8122  (0x4BA972D0E5AD8122)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x4BA972D0E5AD8122(p0, p1) end
+
+-- _0x4E806A395D43A458  (0x4E806A395D43A458)
+-- min build: 1207
+---@param p0 any
+function N_0x4E806A395D43A458(p0) end
+
+-- _0x4F57397388E1DFF8  (0x4F57397388E1DFF8)
+-- min build: 1207
+function N_0x4F57397388E1DFF8() end
+
+-- _0x50AA09A0DA64E73C  (0x50AA09A0DA64E73C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0x50AA09A0DA64E73C(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x5217B7B6DB78E1F3  (0x5217B7B6DB78E1F3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x5217B7B6DB78E1F3(p0, p1, p2, p3, p4) end
+
+-- _0x59AE5CA4FFB4E378  (0x59AE5CA4FFB4E378)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x59AE5CA4FFB4E378(p0, p1) end
+
+-- _0x59AEA4DC640814B9  (0x59AEA4DC640814B9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x59AEA4DC640814B9(p0, p1) end
+
+-- _0x5B68D0007D9C92EB  (0x5B68D0007D9C92EB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x5B68D0007D9C92EB(p0, p1) end
+
+-- _0x5D9B0BAAF04CF65B  (0x5D9B0BAAF04CF65B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x5D9B0BAAF04CF65B(p0, p1, p2, p3) end
+
+-- _0x615DC4A82E90BB48  (0x615DC4A82E90BB48)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x615DC4A82E90BB48(p0, p1, p2) end
+
+-- _0x643FD1556F621772  (0x643FD1556F621772)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x643FD1556F621772(p0, p1, p2) end
+
+-- _0x651F0530083C0E5A  (0x651F0530083C0E5A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x651F0530083C0E5A(p0, p1) end
+
+-- _0x65D281985F2BDFC2  (0x65D281985F2BDFC2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x65D281985F2BDFC2(p0, p1) end
+
+-- _0x673A8779D229BA5A  (0x673A8779D229BA5A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0x673A8779D229BA5A(p0, p1, p2, p3, p4, p5) end
+
+-- _0x678D3226CF70B9C8  (0x678D3226CF70B9C8)
+-- Returns the entity (object/prop) that the ped is currently inspecting or about to interact with during an some item interaction sequence.
+-- Only used in R* SP Script beat_washed_ashore
+-- Returns Object prop for TASK::_TASK_ITEM_INTERACTION_2
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return number
+function N_0x678D3226CF70B9C8(ped, p1) end
+
+-- _0x6C269F673C47031E  (0x6C269F673C47031E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x6C269F673C47031E(p0) end
+
+-- _0x6DAC799857EF3F11  (0x6DAC799857EF3F11)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x6DAC799857EF3F11(p0, p1) end
+
+-- _0x722D6A49200174FE  (0x722D6A49200174FE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x722D6A49200174FE(p0, p1, p2, p3, p4) end
+
+-- _0x748D5E0D2A1A4C61  (0x748D5E0D2A1A4C61)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x748D5E0D2A1A4C61(p0, p1, p2) end
+
+-- _0x74F0209674864CBD  (0x74F0209674864CBD)
+-- min build: 1207
+---@return any
+function N_0x74F0209674864CBD() end
+
+-- _0x764DB5A48390FBAD  (0x764DB5A48390FBAD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x764DB5A48390FBAD(p0, p1) end
+
+-- _0x76610D12A838EBDE  (0x76610D12A838EBDE)
+-- min build: 1311
+---@param p0 any
+---@return any
+function N_0x76610D12A838EBDE(p0) end
+
+-- _0x7CB99FADDE73CD1B  (0x7CB99FADDE73CD1B)
+-- min build: 1311
+---@param p0 any
+---@return any
+function N_0x7CB99FADDE73CD1B(p0) end
+
+-- _0x7FB78B2199C10E92  (0x7FB78B2199C10E92)
+-- min build: 1207
+---@param p0 any
+function N_0x7FB78B2199C10E92(p0) end
+
+-- _0x801BD27403F3CBA0  (0x801BD27403F3CBA0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x801BD27403F3CBA0(p0, p1, p2, p3) end
+
+-- _0x827A58CED9D4D5B4  (0x827A58CED9D4D5B4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x827A58CED9D4D5B4(p0, p1) end
+
+-- _0x82ED59F095056550  (0x82ED59F095056550)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x82ED59F095056550(p0, p1) end
+
+-- _0x865732725536EE39  (0x865732725536EE39)
+-- min build: 1207
+---@param p0 any
+---@return vector3
+function N_0x865732725536EE39(p0) end
+
+-- _0x8798CF6815B8FE0F  (0x8798CF6815B8FE0F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8798CF6815B8FE0F(p0, p1) end
+
+-- _0x885D19AC2B6FBFF4  (0x885D19AC2B6FBFF4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x885D19AC2B6FBFF4(p0, p1) end
+
+-- _0x88FD60D846D9CD63  (0x88FD60D846D9CD63)
+-- min build: 1207
+---@param ped number
+function N_0x88FD60D846D9CD63(ped) end
+
+-- _0x8E1DDE26D270CC5E  (0x8E1DDE26D270CC5E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8E1DDE26D270CC5E(p0, p1) end
+
+-- _0x8F8C84363810691A  (0x8F8C84363810691A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8F8C84363810691A(p0, p1) end
+
+-- _0x9050DF2C53801208  (0x9050DF2C53801208)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function N_0x9050DF2C53801208(ped, p1) end
+
+-- _0x90703A8F75EE4ABD  (0x90703A8F75EE4ABD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x90703A8F75EE4ABD(p0, p1) end
+
+-- _0x908BB14BCE85C80E  (0x908BB14BCE85C80E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x908BB14BCE85C80E(p0) end
+
+-- _0x91CB5E431F579BA1  (0x91CB5E431F579BA1)
+-- min build: 1207
+---@param p0 any
+---@return vector3
+function N_0x91CB5E431F579BA1(p0) end
+
+-- _0x920684BE432875B1  (0x920684BE432875B1)
+-- min build: 1311
+---@param p0 any
+---@return any
+function N_0x920684BE432875B1(p0) end
+
+-- _0x954451EA2D2120FB  (0x954451EA2D2120FB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x954451EA2D2120FB(p0, p1) end
+
+-- _0x9585FF23C4B8EDE0  (0x9585FF23C4B8EDE0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9585FF23C4B8EDE0(p0, p1) end
+
+-- _0x9667CCE29BFA0780  (0x9667CCE29BFA0780)
+-- min build: 1207
+---@param p0 any
+function N_0x9667CCE29BFA0780(p0) end
+
+-- _0x974DA3408DEC4E79  (0x974DA3408DEC4E79)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x974DA3408DEC4E79(p0) end
+
+-- _0x9ADDBB9242179D56  (0x9ADDBB9242179D56)
+-- min build: 1207
+---@param object number
+---@param ped number
+function N_0x9ADDBB9242179D56(object, ped) end
+
+-- _0x9B6A58FDB0024F12  (0x9B6A58FDB0024F12)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x9B6A58FDB0024F12(p0, p1) end
+
+-- _0x9C8F42A5D1859DC1  (0x9C8F42A5D1859DC1)
+-- min build: 1207
+---@param p0 any
+function N_0x9C8F42A5D1859DC1(p0) end
+
+-- _0x9EBD34958AB6F824  (0x9EBD34958AB6F824)
+-- min build: 1207
+---@param p0 any
+function N_0x9EBD34958AB6F824(p0) end
+
+-- _0x9FF5F9B24E870748  (0x9FF5F9B24E870748)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x9FF5F9B24E870748(p0) end
+
+-- _0xA052608A12559BBB  (0xA052608A12559BBB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA052608A12559BBB(p0, p1) end
+
+-- _0xA21AA2F0C2180125  (0xA21AA2F0C2180125)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA21AA2F0C2180125(p0, p1) end
+
+-- _0xA263ADBBC8056214  (0xA263ADBBC8056214)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA263ADBBC8056214(p0, p1) end
+
+-- _0xA42DC7919159CCCF  (0xA42DC7919159CCCF)
+-- min build: 1207
+---@param p0 any
+function N_0xA42DC7919159CCCF(p0) end
+
+-- _0xA6A76D666A281F2D  (0xA6A76D666A281F2D)
+-- min build: 1207
+---@param p0 any
+---@param item number
+function N_0xA6A76D666A281F2D(p0, item) end
+
+-- _0xA7479FB665361EDB  (0xA7479FB665361EDB)
+-- _SET_SCENARIO_*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xA7479FB665361EDB(p0, p1) end
+
+-- _0xA9E7672F8C6C6F74  (0xA9E7672F8C6C6F74)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xA9E7672F8C6C6F74(p0) end
+
+-- _0xADC45010BC17AF0E  (0xADC45010BC17AF0E)
+-- _SET_SCENARIO_POINT_*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xADC45010BC17AF0E(p0, p1) end
+
+-- _0xAF2EF28CE3084505  (0xAF2EF28CE3084505)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xAF2EF28CE3084505(p0, p1, p2, p3) end
+
+-- _0xB2D15D3551FE4FAE  (0xB2D15D3551FE4FAE)
+-- min build: 1311
+---@param p0 any
+function N_0xB2D15D3551FE4FAE(p0) end
+
+-- _0xB2F47A1AFDFCC595  (0xB2F47A1AFDFCC595)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xB2F47A1AFDFCC595(p0, p1) end
+
+-- _0xB520DBDA7FCF573F  (0xB520DBDA7FCF573F)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xB520DBDA7FCF573F(ped) end
+
+-- _0xB79817DB31FF72B9  (0xB79817DB31FF72B9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xB79817DB31FF72B9(p0, p1) end
+
+-- _0xB8E213D02F37947D  (0xB8E213D02F37947D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function N_0xB8E213D02F37947D(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xB8E3486D107F4194  (0xB8E3486D107F4194)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xB8E3486D107F4194(p0, p1) end
+
+-- _0xBAAB791AA72C2821  (0xBAAB791AA72C2821)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBAAB791AA72C2821(p0, p1) end
+
+-- _0xBC3F847AE2C3DC65  (0xBC3F847AE2C3DC65)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xBC3F847AE2C3DC65(p0, p1) end
+
+-- _0xBD70108D01875299  (0xBD70108D01875299)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xBD70108D01875299(p0) end
+
+-- _0xBEDBE39B5FD98FD6  (0xBEDBE39B5FD98FD6)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function N_0xBEDBE39B5FD98FD6(ped) end
+
+-- _0xBEEFBB608D2AA68A  (0xBEEFBB608D2AA68A)
+-- min build: 1207
+---@param p0 any
+function N_0xBEEFBB608D2AA68A(p0) end
+
+-- _0xCE4E669400E5F8AA  (0xCE4E669400E5F8AA)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xCE4E669400E5F8AA(p0, p1, p2, p3) end
+
+-- _0xD0ABC4EA3B5E21A0  (0xD0ABC4EA3B5E21A0)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xD0ABC4EA3B5E21A0(p0, p1) end
+
+-- _0xD508FA229F1C4900  (0xD508FA229F1C4900)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return any
+function N_0xD508FA229F1C4900(p0, p1, p2, p3, p4, p5) end
+
+-- _0xD999E379265A4501  (0xD999E379265A4501)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD999E379265A4501(p0, p1, p2) end
+
+-- _0xDE0C8B145EA466FF  (0xDE0C8B145EA466FF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0xDE0C8B145EA466FF(p0, p1, p2, p3, p4, p5) end
+
+-- _0xDF56A2B50C04DEA4  (0xDF56A2B50C04DEA4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xDF56A2B50C04DEA4(p0, p1) end
+
+-- _0xDF94844D474F31E5  (0xDF94844D474F31E5)
+-- min build: 1207
+---@param ped number
+function N_0xDF94844D474F31E5(ped) end
+
+-- _0xE01C8DC8EDD28D31  (0xE01C8DC8EDD28D31)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE01C8DC8EDD28D31(p0, p1) end
+
+-- _0xE01F55B2896F6B37  (0xE01F55B2896F6B37)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE01F55B2896F6B37(p0, p1) end
+
+-- _0xE05A5D39BE6E93AF  (0xE05A5D39BE6E93AF)
+-- min build: 1207
+---@param p0 any
+function N_0xE05A5D39BE6E93AF(p0) end
+
+-- _0xE116F6F2DA2D777E  (0xE116F6F2DA2D777E)
+-- min build: 1207
+---@param p0 any
+---@return vector3
+function N_0xE116F6F2DA2D777E(p0) end
+
+-- _0xE1C105E6BBA48270  (0xE1C105E6BBA48270)
+-- min build: 1207
+---@return any
+function N_0xE1C105E6BBA48270() end
+
+-- _0xE2CF104ADD49D4BF  (0xE2CF104ADD49D4BF)
+-- min build: 1207
+---@param p0 any
+function N_0xE2CF104ADD49D4BF(p0) end
+
+-- _0xE55478C5EDF70AC2  (0xE55478C5EDF70AC2)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE55478C5EDF70AC2(p0) end
+
+-- _0xE5831AA1E2FD147C  (0xE5831AA1E2FD147C)
+-- min build: 1207
+---@param p0 any
+function N_0xE5831AA1E2FD147C(p0) end
+
+-- _0xE62754D09354F6CF  (0xE62754D09354F6CF)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE62754D09354F6CF(p0) end
+
+-- _0xE69FDA40AAC3EFC0  (0xE69FDA40AAC3EFC0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE69FDA40AAC3EFC0(p0, p1) end
+
+-- _0xE6A151364C600B24  (0xE6A151364C600B24)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE6A151364C600B24(p0) end
+
+-- _0xE9225354FB7437A7  (0xE9225354FB7437A7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xE9225354FB7437A7(p0, p1) end
+
+-- _0xE9A6400D1A0E7A55  (0xE9A6400D1A0E7A55)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE9A6400D1A0E7A55(p0) end
+
+-- _0xEAF87DA2BE78A15B  (0xEAF87DA2BE78A15B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xEAF87DA2BE78A15B(p0, p1) end
+
+-- _0xEC516FE805D2CB2D  (0xEC516FE805D2CB2D)
+-- min build: 1207
+---@param p0 any
+function N_0xEC516FE805D2CB2D(p0) end
+
+-- _0xEFD875C2791EBEFD  (0xEFD875C2791EBEFD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xEFD875C2791EBEFD(p0, p1, p2, p3) end
+
+-- _0xF3C3503276F4A034  (0xF3C3503276F4A034)
+-- min build: 1436
+---@param entity number
+---@param p1 any
+function N_0xF3C3503276F4A034(entity, p1) end
+
+-- _0xF718931A82EEB898  (0xF718931A82EEB898)
+-- min build: 1207
+function N_0xF718931A82EEB898() end
+
+-- _0xF948F4356F010F11  (0xF948F4356F010F11)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xF948F4356F010F11(p0, p1, p2) end
+
+-- _0xF97F462779B31786  (0xF97F462779B31786)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF97F462779B31786(p0) end
+
+-- _0xFA30E2254461ADEB  (0xFA30E2254461ADEB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFA30E2254461ADEB(p0, p1) end
+
+-- _0xFDECCA06E8B81346  (0xFDECCA06E8B81346)
+-- min build: 1207
+---@param ped number
+---@return any
+function N_0xFDECCA06E8B81346(ped) end
+
+-- _0xFE5D28B9B7837CC1  (0xFE5D28B9B7837CC1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xFE5D28B9B7837CC1(p0, p1, p2, p3) end
+
+-- _0xFF8AFCA532B500D4  (0xFF8AFCA532B500D4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xFF8AFCA532B500D4(p0, p1) end
+
+-- _ADD_COVER_BLOCKING_VOLUME  (0xEB2ED1DC3AEC0654)
+-- min build: 1207
+---@param volume number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+function _AddCoverBlockingVolume(volume, p1, p2, p3, p4) end
+
+-- _ADD_COVER_POINT_FOR_ENTITY  (0x59872EA4CBD11C56)
+-- Returns the entity coverpoint with offset.
+-- min build: 1207
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param heading number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@return number
+function _AddCoverPointForEntity(entity, xOffset, yOffset, zOffset, heading, p5, p6, p7, p8) end
+
+-- _ADD_FLEE_TARGET_COORDS  (0xE8F1A5B4CED3725A)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+function _AddFleeTargetCoords(ped, x, y, z, p4) end
+
+-- _ASSOCIATE_PROP_WITH_SCENARIO  (0x8360C47380B6F351)
+-- min build: 1207
+---@param scenario number
+---@param entity number
+---@param propName string
+---@param p3 boolean
+---@return boolean
+function _AssociatePropWithScenario(scenario, entity, propName, p3) end
+
+-- _CALCULATE_WAYPOINT_DISTANCE_FROM_START  (0x3ACC128510142B9D)
+-- Signed arclength (meters) from the start of a loaded waypoint recording to the point on the path nearest to (x,y,z).
+-- Negative before the first node; clamped to total length past the last node. Recording must be requested/loaded.
+-- min build: 1207
+---@param waypointRecording string
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function _CalculateWaypointDistanceFromStart(waypointRecording, x, y, z) end
+
+-- _CLEAR_VEHICLE_TASKS  (0x141BC64C8D7C5529)
+-- Clears all active tasks assigned to the specified vehicle.
+-- This cancels ongoing behaviors such as TASK_VEHICLE_DRIVE_TO_DESTINATION_2.
+-- And even tasks triggered by horses pulling the vehicle when they start moving due to gunfire etc.
+-- min build: 1207
+---@param vehicle number
+function _ClearVehicleTasks(vehicle) end
+
+-- _CLEAR_VEHICLE_TASKS_SECONDARY  (0xEBA2081E0A5F4D17)
+-- Clears the vehicle's secondary/aux AI task slot (behaviors/overlays).
+-- In R* Scripts, this is often called right after _CLEAR_VEHICLE_TASKS to fully stop/flush vehicle behavior.
+-- min build: 1207
+---@param vehicle number
+function _ClearVehicleTasksSecondary(vehicle) end
+
+-- _CREATE_HERB_COMPOSITES  (0x5B4BBE80AD5972DC)
+-- groundSetting: 0: spawn on ground, 2 (1?): do not spawn on ground
+-- p7: -1 in R* Scripts
+-- Returns compositeId
+-- min build: 1207
+---@param asset number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param groundSetting number
+---@param p7 number
+---@return number
+---@return any
+function _CreateHerbComposites(asset, x, y, z, heading, groundSetting, p7) end
+
+-- _CREATE_WAYPOINT_PATH  (0x5C885E0978B6AD60)
+-- min build: 1207
+---@param pathName string
+---@param nodes number
+---@param p3 number
+---@return boolean
+---@return any
+function _CreateWaypointPath(pathName, nodes, p3) end
+
+-- _CUFF_PED  (0x7981037A96E7D174)
+-- min build: 1207
+---@param ped number
+function _CuffPed(ped) end
+
+-- _DELETE_PATCH_OBJECTS_FROM_HERB_COMPOSITES  (0x5758B1EE0C3FD4AC)
+-- Params: p1 is always false except in script nb_egg_protector
+-- min build: 1207
+---@param compositeId number
+---@param p1 boolean
+function _DeletePatchObjectsFromHerbComposites(compositeId, p1) end
+
+-- _DELETE_SCENARIO_POINT  (0x81948DFE4F5A0283)
+-- min build: 1207
+---@param scenario number
+function _DeleteScenarioPoint(scenario) end
+
+-- _DETACH_CARRIABLE_PED  (0x36D188AECB26094B)
+-- min build: 1207
+---@param ped number
+function _DetachCarriablePed(ped) end
+
+-- _DISASSOCIATE_PROP_FROM_SCENARIO  (0x6EF4E31B4D5D2DA0)
+-- min build: 1207
+---@param scenario number
+---@param propName string
+---@return boolean
+function _DisassociatePropFromScenario(scenario, propName) end
+
+-- _DOES_SCENARIO_GROUP_EXIST_HASH  (0x76E98B52369A289C)
+-- min build: 1207
+---@param scenarioGroup number
+---@return boolean
+function _DoesScenarioGroupExistHash(scenarioGroup) end
+
+-- _DOES_SCENARIO_POINT_HAVE_PROPS  (0xEA31F199A73801D3)
+-- min build: 1207
+---@param scenario number
+---@return boolean
+function _DoesScenarioPointHaveProps(scenario) end
+
+-- _EMIT_PED_CARRIABLE_STRUGGLE_DIRECTION  (0x1ECF56C040FD839C)
+-- min build: 1207
+---@param ped number
+---@param direction number
+function _EmitPedCarriableStruggleDirection(ped, direction) end
+
+-- _EMIT_PED_CARRIABLE_STRUGGLE_INTENSITY  (0xBD1C3C0F271C39D3)
+-- min build: 1207
+---@param ped number
+---@param intensity number
+function _EmitPedCarriableStruggleIntensity(ped, intensity) end
+
+-- _EVALUATE_PED_CARRIABLE_STRUGGLE_AVAILABLE  (0x6AFD84AEAA3EA538)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _EvaluatePedCarriableStruggleAvailable(ped) end
+
+-- _FIND_MODEL_FOR_ITEM  (0xE47DD64B9F02677D)
+-- min build: 1207
+---@param item number
+---@return number
+function _FindModelForItem(item) end
+
+-- _FIND_NEAREST_PED_AROUND_ANIMAL  (0x244430C13BA5258E)
+-- Animals only. Returns the nearest ped around `animalPed` matching the life-state filters (e.g., use (false,true,0) to find a nearby corpse for TASK_EAT).
+-- Last flag appears to bias predators/fish toward dead targets (uncertain).
+-- min build: 1207
+---@param animalPed number
+---@param aliveOnly boolean
+---@param deadOnly boolean
+---@param preferDeadPredators boolean
+---@return number
+function _FindNearestPedAroundAnimal(animalPed, aliveOnly, deadOnly, preferDeadPredators) end
+
+-- _GET_HERB_COMPOSITE_NUM_ENTITIES  (0x96C6ED22FB742C3E)
+-- Flowers, Stalks or whatever the composite has
+-- min build: 1207
+---@param compositeId number
+---@return number
+---@return any
+function _GetHerbCompositeNumEntities(compositeId) end
+
+-- _GET_HOGTIE_ESCAPE_TIMER  (0x4687E69D258BBE41)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetHogtieEscapeTimer(ped) end
+
+-- _GET_HOLD_TO_REEL_SETTING_ENABLED  (0x5952DFA38FA529FE)
+-- Returns whether the “Hold to Reel [Fishing]” gameplay setting is currently enabled.
+-- min build: 1232
+---@return boolean
+function _GetHoldToReelSettingEnabled() end
+
+-- _GET_ITEM_INTERACTION_ENTITY_FROM_PED  (0x05A0100EA714DB68)
+-- item hashes: PRIMARYITEM, P_MUGCOFFEE01X_PH_R_HAND, P_BOTTLEBEER01X_PH_R_HAND
+-- http://prntscr.com/1qtp3bz
+-- https://github.com/femga/rdr3_discoveries/tree/master/tasks/TASK_ITEM_INTERACTION
+-- min build: 1207
+---@param ped number
+---@param item number
+---@return number
+function _GetItemInteractionEntityFromPed(ped, item) end
+
+-- _GET_LED_HORSE_FROM_PED  (0xED1F514AF4732258)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLedHorseFromPed(ped) end
+
+-- _GET_LINKED_SCENARIO_POINTS  (0xE7BBC4E56B989449)
+-- Fills an output array with scenario points linked ("chained") to a given parent scenario point. Returns the number of linked points found. Writes up to maxPoints and zeroes remaining entries. Useful for flows like chained put-down scenarios.
+-- 
+-- Params:
+-- - scenarioPoint: Parent scenario point handle.
+-- - outPoints: Pointer to an int array that receives the linked scenario point handles.
+-- - maxPoints: Capacity of outPoints.
+-- 
+-- Returns: Count of linked scenario points written (0 if none).
+-- min build: 1207
+---@param scenarioPoint number
+---@param maxPoints number
+---@return number
+---@return number
+function _GetLinkedScenarioPoints(scenarioPoint, maxPoints) end
+
+-- _GET_PED_IS_IGNORING_DEAD_BODIES  (0x1948BBE561A2375A)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _GetPedIsIgnoringDeadBodies(ped) end
+
+-- _GET_PED_USING_SCENARIO_POINT  (0x5BA659955369B0E2)
+-- min build: 1207
+---@param scenario number
+---@return number
+function _GetPedUsingScenarioPoint(scenario) end
+
+-- _GET_PED_WRITHE_BREAK_FREE_PROGRESS  (0x03D741CB4052E26C)
+-- Returns the current 'Break Free' prompt progress for a hogtied/knocked-out (writhing) ped.
+-- Range: 0.0-1.0 (hits 1.0 when the ped breaks free). Returns -1.0 if not applicable.
+-- min build: 1232
+---@param ped number
+---@return number
+function _GetPedWritheBreakFreeProgress(ped) end
+
+-- _GET_RANSACK_SCENARIO_CONTAINER_NUM_COMPARTMENTS  (0x640A602946A8C972)
+-- Returns the total number of compartments (drawers, lids, etc.) the specified scenario container entity has.
+-- For example, a chest has 1 compartment, while a cabinet with 3 drawers returns 3.
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetRansackScenarioContainerNumCompartments(entity) end
+
+-- _GET_RANSACK_SCENARIO_CONTAINER_NUM_OPEN_COMPARTMENTS  (0x849791EBBDBA0362)
+-- Returns the number of currently open compartments for the specified scenario container entity.
+-- If the container has closeable compartments (like drawers), this will return how many of them are currently open.
+-- If the container is not closeable (like a chest or safe that cannot be closed again), it will return 0.
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetRansackScenarioContainerNumOpenCompartments(entity) end
+
+-- _GET_RANSACK_SCENARIO_CONTAINER_OPENING_STATE  (0xB219612B5568E9EC)
+-- Returns m_eContainerState
+-- min build: 1207
+---@param entity number
+---@return boolean
+function _GetRansackScenarioContainerOpeningState(entity) end
+
+-- _GET_RANSACK_SCENARIO_CONTAINER_REMAINING_LOOT_COUNT  (0x01AF8A3729231A43)
+-- Returns the total number of lootable items currently inside the specified scenario container entity.
+-- This value decreases as items are looted.Before opening, it may return 0 because contents are not always loaded until the container is opened.
+-- min build: 1207
+---@param entity number
+---@return number
+function _GetRansackScenarioContainerRemainingLootCount(entity) end
+
+-- _GET_REVIVABLE_HORSE  (0x351F74ED6177EBE7)
+-- Returns the targeted revivable horse (critically injured/writhing) when the revive prompt is active; 0 if none.
+-- min build: 1207
+---@return number
+function _GetRevivableHorse() end
+
+-- _GET_SCENARIO_POINT_COORDS  (0xA8452DD321607029)
+-- Params: p1 is always true in R* Scripts
+-- min build: 1207
+---@param scenario number
+---@param p1 boolean
+---@return vector3
+function _GetScenarioPointCoords(scenario, p1) end
+
+-- _GET_SCENARIO_POINT_ENTITY  (0x7467165EE97D3C68)
+-- Note: The current name for this native is the old name of 0x295514F198EFD0CA
+-- Old name for this native: _GET_ENTITY_SCENARIO_POINT_IS_ATTACHED_TO
+-- min build: 1207
+---@param scenario number
+---@return number
+function _GetScenarioPointEntity(scenario) end
+
+-- _GET_SCENARIO_POINT_HEADING  (0xB93EA7184BAA85C3)
+-- Params: p1 is always true in R* Scripts
+-- min build: 1207
+---@param scenario number
+---@param p1 boolean
+---@return number
+function _GetScenarioPointHeading(scenario, p1) end
+
+-- _GET_SCENARIO_POINT_PED_IS_USING  (0xDF7993356F52359A)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return number
+function _GetScenarioPointPedIsUsing(ped, p1) end
+
+-- _GET_SCENARIO_POINT_RADIUS  (0x6718F40313A2B5A6)
+-- min build: 1207
+---@param scenario number
+---@return number
+function _GetScenarioPointRadius(scenario) end
+
+-- _GET_SCENARIO_POINT_TYPE  (0xA92450B5AE687AAF)
+-- min build: 1207
+---@param scenario number
+---@return number
+function _GetScenarioPointType(scenario) end
+
+-- _GET_SCENARIO_POINT_TYPE_PED_IS_USING  (0x2D0571BB55879DA2)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetScenarioPointTypePedIsUsing(ped) end
+
+-- _GET_SCRIPT_TASK_ACTION_TIME  (0xA710DC5D25F8B942)
+-- min build: 1207
+---@param ped number
+---@param task number
+---@return number
+function _GetScriptTaskActionTime(ped, task) end
+
+-- _GET_TASK_COMBAT_READY_TO_SHOOT  (0x5EA655F01D93667A)
+-- Returns true if the ped is in a ranged-attack task and is about to fire (ready/primed to shoot or throw).
+-- Covers firearms and projectiles (throwables/molotov/poison), not melee.
+-- Useful to block other actions just before the shot. Note: different from IS_PED_SHOOTING, which triggers only after the shot.
+-- May return true even in cases where IS_PED_WEAPON_READY_TO_SHOOT returns false.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _GetTaskCombatReadyToShoot(ped) end
+
+-- _GET_TASK_FISHING  (0xF3735ACD11ACD500)
+-- Fishing Research: https://pastebin.com/NmK5ZLVs
+-- Only used in R* Scripts fishing_core and av_fishing_river
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return any
+function _GetTaskFishing(ped) end
+
+-- _GET_TASK_MOVE_NETWORK_ID  (0xCACC2F9D994504B7)
+-- Returns hash of the underlying move network def, see move_networks.xml
+-- https://alloc8or.re/rdr3/doc/misc/move_networks.txt
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetTaskMoveNetworkId(ped) end
+
+-- _GET_TASK_MOVE_NETWORK_PHASE_FLOAT  (0x844CEEE428EA35B0)
+-- min build: 1207
+---@param ped number
+---@param phaseName string
+---@return number
+function _GetTaskMoveNetworkPhaseFloat(ped, phaseName) end
+
+-- _GET_TASK_PED_MOUNT_LEAP_PROGRESS  (0x6BA606AB3A83BC4D)
+-- Returns 0.0-1.0 progress for the current mount-leap task, or -1.0f if no leap is active.
+-- Video demo: https://youtu.be/YZuw9lhqDms
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetTaskPedMountLeapProgress(ped) end
+
+-- _GET_TASK_PED_MOUNT_LEAP_STATE  (0x9420FB11B8D77948)
+-- Returns a coarse state for the mount-leap task (jumping from your mount onto another mount/wagon/train).
+-- -1 = no task; 0 = in-air/ongoing; 1 = boarded/mounted; 2 = boarded rear train trailer.
+-- Use with _GET_TASK_PED_MOUNT_LEAP_PROGRESS for timing.
+-- Video demo: https://youtu.be/YZuw9lhqDms
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetTaskPedMountLeapState(ped) end
+
+-- _GET_WHISTLE_RANGE_MAX_FOR_BONDING_LEVEL  (0x78D8C1D4EB80C588)
+-- Returns the maximum (target) whistle/call distance associated with the next horse bonding level.
+-- Used together with the current level's minimum to derive an effective whistle range based on the horse's bonding progress toward the next rank.
+-- min build: 1207
+---@param bondingLevel number
+---@return number
+function _GetWhistleRangeMaxForBondingLevel(bondingLevel) end
+
+-- _GET_WHISTLE_RANGE_MIN_FOR_BONDING_LEVEL  (0xEB67D4E056C85A81)
+-- Returns the minimum (baseline) whistle/call distance for the given horse bonding level.
+-- This value represents the lower bound used when computing whether a horse is considered "near" or "far" relative to the player, and is interpolated against the next level's max.
+-- min build: 1207
+---@param bondingLevel number
+---@return number
+function _GetWhistleRangeMinForBondingLevel(bondingLevel) end
+
+-- _HAS_REQUESTED_CARRIABLE_CONFIG_LOADED  (0xB8F52A3F84A7CC59)
+-- carriableConfig: see _REQUEST_CARRIABLE_CONFIG
+-- min build: 1207
+---@param carriableConfig number
+---@return boolean
+function _HasRequestedCarriableConfigLoaded(carriableConfig) end
+
+-- _IS_ENTITY_REVIVABLE  (0x6C50B9DCCCA70023)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsEntityRevivable(ped) end
+
+-- _IS_HAT_BEING_PICKED_UP  (0x11CD066F54DA0133)
+-- Returns true while a hat is being picked up
+-- _IS_A* - _IS_D*
+-- min build: 1207
+---@param hatObject number
+---@return boolean
+function _IsHatBeingPickedUp(hatObject) end
+
+-- _IS_HAT_BEING_PICKED_UP_2  (0x4ECCC2815CA79AE2)
+-- Returns true while a hat is being picked up. Similar to 0x11CD066F54DA0133
+-- _IS_A* - _IS_D*
+-- min build: 1207
+---@param hatObject number
+---@return boolean
+function _IsHatBeingPickedUp2(hatObject) end
+
+-- _IS_PED_ARRESTING_ANY_PED  (0xA9CC7856D52DBD25)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedArrestingAnyPed(ped) end
+
+-- _IS_PED_BEING_LED  (0xAC5045AB7F1A34FD)
+-- Returns true if the given ped (usually a horse) is currently being led by a ped (lead/rope).
+-- Mirrors usage with _IS_PED_LEADING_HORSE(ped) and _GET_LED_HORSE_FROM_PED(ped).
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedBeingLed(ped) end
+
+-- _IS_PED_DUELLING  (0xC8B29D18022EA2B7)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedDuelling(ped) end
+
+-- _IS_PED_LEADING_HORSE  (0xEFC4303DDC6E60D3)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedLeadingHorse(ped) end
+
+-- _IS_PED_LOOKING_AT_COORD  (0x508F5053E3F6F0C4)
+-- Returns true if the ped's current 'IK look-at' target is within `radius` of (x, y, z). This checks the active look-at point (head/eyes) not LOS or heading and returns false if the ped has no active look-at target. Typical radius range: 1.0-30.0.
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function _IsPedLookingAtCoord(ped, x, y, z, radius) end
+
+-- _IS_REVIVABLE_HORSE_PROMPT_VISIBLE  (0x756C7B4C43DF0422)
+-- Checks for the revive-horse prompt.
+-- strict=true: prompt must be usable (enabled and inputs not blocked). strict=false: true if the prompt simply exists (may be disabled).
+-- min build: 1207
+---@param strict boolean
+---@return boolean
+function _IsRevivableHorsePromptVisible(strict) end
+
+-- _IS_SCENARIO_GROUP_ENABLED_HASH  (0xDCC374913DE6AAA6)
+-- min build: 1207
+---@param scenarioGroup number
+---@return boolean
+function _IsScenarioGroupEnabledHash(scenarioGroup) end
+
+-- _IS_SCENARIO_IN_USE  (0x1ACBC313966C21F3)
+-- Checks whether a specified scenario is currently being used (actively played) by any entity (player or ped).
+-- Returns true if the scenario is already occupied, otherwise false.
+-- min build: 1436
+---@param scenario number
+---@return boolean
+function _IsScenarioInUse(scenario) end
+
+-- _IS_SCENARIO_POINT_ACTIVE  (0x0CC36D4156006509)
+-- min build: 1207
+---@param scenario number
+---@return boolean
+function _IsScenarioPointActive(scenario) end
+
+-- _IS_SCENARIO_POINT_FLAG_SET  (0x8569C38D2FB80650)
+-- min build: 1207
+---@param scenario number
+---@param flag number
+---@return boolean
+function _IsScenarioPointFlagSet(scenario, flag) end
+
+-- _MAKE_OBJECT_CARRIABLE  (0x78B4567E18B54480)
+-- min build: 1207
+---@param object number
+function _MakeObjectCarriable(object) end
+
+-- _PED_FISHINGROD_HOOK_ENTITY  (0x1A52076D26E09004)
+-- min build: 1207
+---@param ped number
+---@param entity number
+function _PedFishingrodHookEntity(ped, entity) end
+
+-- _PED_FISHINGROD_HOOK_OBJECT  (0xCE71C2F9BAA3F975)
+-- Used with 'P_BODYPARTARMFLOAT02X' model in fishing_core.c
+-- min build: 1207
+---@param ped number
+---@param object number
+function _PedFishingrodHookObject(ped, object) end
+
+-- _PED_IS_IN_SCENARIO_BASE  (0x02EBBB3989B7E695)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _PedIsInScenarioBase(ped) end
+
+-- _REMOVE_CARRIABLE_CONFIG  (0x6AFDA2264925BD11)
+-- carriableConfig: see _REQUEST_CARRIABLE_CONFIG
+-- min build: 1207
+---@param carriableConfig number
+function _RemoveCarriableConfig(carriableConfig) end
+
+-- _REQUEST_CARRIABLE_CONFIG  (0xFF745B0346E19E2C)
+-- Config: https://pastebin.com/gZvuq7fV
+-- min build: 1207
+---@param carriableConfig number
+function _RequestCarriableConfig(carriableConfig) end
+
+-- _REQUEST_HERB_COMPOSITE_ASSET  (0x73F0D0327BFA0812)
+-- https://github.com/femga/rdr3_discoveries/tree/master/objects/composites
+-- min build: 1207
+---@param asset number
+---@return boolean
+function _RequestHerbCompositeAsset(asset) end
+
+-- _RESET_SCENARIO_FOR_ENTITY  (0x2E20878FD208A68E)
+-- min build: 1207
+---@param scenario number
+---@param entity number
+function _ResetScenarioForEntity(scenario, entity) end
+
+-- _RESET_SCENARIO_SCRIPT  (0x5A40040BB5AE3EA2)
+-- min build: 1207
+---@param scenario number
+function _ResetScenarioScript(scenario) end
+
+-- _SET_ABOARD_PED_BOAT_POSE  (0x517D01BF27B682D1)
+-- Set a ped's boat-local offset and/or facing (degrees). Boats only. Flags: 0=apply both; 1=heading only (lock offset); 2=offset only (lock heading); 3=apply neither.
+-- min build: 1207
+---@param ped number
+---@param boat number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param heading number
+---@param flags number
+function _SetAboardPedBoatPose(ped, boat, offsetX, offsetY, offsetZ, heading, flags) end
+
+-- _SET_CARRIABLE_CONFIG_PROMPT_ENABLED  (0x816A3ACD265E2297)
+-- Enables or disables the interaction prompt for a given carriable config (e.g. DEAD_CARRIABLE_HUMAN).
+-- Use after loading the config; when disabled, pickup/use prompts will not appear.
+-- carriableConfig: see _REQUEST_CARRIABLE_CONFIG
+-- min build: 1207
+---@param carriableConfig number
+---@param toggle boolean
+function _SetCarriableConfigPromptEnabled(carriableConfig, toggle) end
+
+-- _SET_FISHING_BAIT  (0x9B0C7FA063E67629)
+-- Baits: p_fishHook02x, p_baitBread01x, p_baitCorn01x, p_baitCheese01x, p_baitWorm01x, p_baitCricket01x, p_crawdad01x, p_finisheDragonfly01x, p_finisdFishlure01x, p_finishdCrawd01x, p_finisheDragonflyLegendary01x, p_finisdFishlureLegendary01x, p_finishdCrawdLegendary01x, p_lgoc_spinner_v4
+-- min build: 1207
+---@param ped number
+---@param bait string
+---@param withoutBuoy boolean
+---@param instantly boolean
+function _SetFishingBait(ped, bait, withoutBuoy, instantly) end
+
+-- _SET_HOGTIE_ESCAPE_TIMER  (0xAB591AE6B48B913E)
+-- Sets the time it takes for a hogtied ped to escape
+-- -1.0f for ped to never escape
+-- min build: 1207
+---@param ped number
+---@param time number
+function _SetHogtieEscapeTimer(ped, time) end
+
+-- _SET_INTIMIDATED_FACING_ANGLE  (0x0FE797DD9F70DFA6)
+-- Controls intimidated/hogtied ped facing.
+-- If useLimits=false, always face the player; if =true, clamp facing within [minAngle, maxAngle] degrees.
+-- Angle note: the range defines the allowed yaw cone around the intimidator e.g., [0,90] permits a quarter-turn, [-30,30] a tight ±30°, and wider ranges allow more swivel.
+-- min build: 1207
+---@param ped number
+---@param useLimits boolean
+---@param minAngle number
+---@param maxAngle number
+function _SetIntimidatedFacingAngle(ped, useLimits, minAngle, maxAngle) end
+
+-- _SET_ITEM_INTERACTION_STATE  (0xB35370D5353995CB)
+-- All Interaction states
+-- https://github.com/abdulkadiraktas/rdr3_discoveries/tree/master/tasks/ItemInteraction#4-item_interaction_state_name--item_interaction_propid
+-- min build: 1207
+---@param ped number
+---@param itemInteractionState number
+---@param p2 number
+function _SetItemInteractionState(ped, itemInteractionState, p2) end
+
+-- _SET_PED_CLEAR_AIMING_IN_THE_AIR  (0x34C0010188D7C54A)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function _SetPedClearAimingInTheAir(ped, p1) end
+
+-- _SET_PED_IGNORE_DEAD_BODIES  (0x013A7BA5015C1372)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedIgnoreDeadBodies(ped, toggle) end
+
+-- _SET_PED_PATH_AVOID_TRAFFIC  (0x7C015D8BCEC72CF4)
+-- min build: 1207
+---@param ped number
+---@param avoidTraffic boolean
+function _SetPedPathAvoidTraffic(ped, avoidTraffic) end
+
+-- _SET_PED_PATH_LADDER_COST_MODIFIER  (0x70F7A1EAB1AE3AA8)
+-- _SET_PED_PATH_P*
+-- min build: 1232
+---@param ped number
+---@param modifier number
+function _SetPedPathLadderCostModifier(ped, modifier) end
+
+-- _SET_PED_PATH_MAY_ENTER_DEEP_WATER  (0x9DE63896B176EA94)
+-- min build: 1207
+---@param ped number
+---@param mayEnterDeepWater boolean
+function _SetPedPathMayEnterDeepWater(ped, mayEnterDeepWater) end
+
+-- _SET_PED_PATH_MAY_USE_SLIDING_SURFACES  (0x06ECF3925BC2ABAE)
+-- min build: 1311
+---@param ped number
+---@param useSlidingSurfaces boolean
+function _SetPedPathMayUseSlidingSurfaces(ped, useSlidingSurfaces) end
+
+-- _SET_PED_PATH_NEVER_USE_INTERIORS  (0x42CFD8FD8CC8DC69)
+-- min build: 1207
+---@param ped number
+---@param neverUseInteriors boolean
+function _SetPedPathNeverUseInteriors(ped, neverUseInteriors) end
+
+-- _SET_PED_PATH_PREFER_HORSE_WALKABLE  (0x216343750545A486)
+-- min build: 1207
+---@param ped number
+---@param preferHorseWalkable boolean
+---@param p2 number
+function _SetPedPathPreferHorseWalkable(ped, preferHorseWalkable, p2) end
+
+-- _SET_PED_PATH_PREFER_STAY_IN_WATER  (0xC6170856E54557B2)
+-- min build: 1207
+---@param ped number
+---@param preferStayInWater boolean
+---@param p2 number
+function _SetPedPathPreferStayInWater(ped, preferStayInWater, p2) end
+
+-- _SET_PED_PATH_PREFER_TO_AVOID_FOLIAGE  (0x12990818C1D35886)
+-- min build: 1207
+---@param ped number
+---@param preferAvoidFoliage boolean
+---@param p2 number
+function _SetPedPathPreferToAvoidFoliage(ped, preferAvoidFoliage, p2) end
+
+-- _SET_PED_PATH_PREFER_TO_AVOID_MUD  (0x8BB283A7888AD1AD)
+-- min build: 1207
+---@param ped number
+---@param preferAvoidMud boolean
+---@param p2 number
+function _SetPedPathPreferToAvoidMud(ped, preferAvoidMud, p2) end
+
+-- _SET_RANSACK_SCENARIO_CONTAINER_OPENING_STATE  (0x188F8071F244B9B8)
+-- Opens/closes containers: ChestDugUp
+-- min build: 1207
+---@param entity number
+---@param open boolean
+function _SetRansackScenarioContainerOpeningState(entity, open) end
+
+-- _SET_SCENARIO_GROUP_ENABLED_HASH  (0x9925EDDB6EAB88CD)
+-- min build: 1207
+---@param scenarioGroup number
+---@param toggle boolean
+function _SetScenarioGroupEnabledHash(scenarioGroup, toggle) end
+
+-- _SET_SCENARIO_POINT_ACTIVE  (0xEEE4829304F93EEE)
+-- min build: 1207
+---@param scenario number
+---@param active boolean
+function _SetScenarioPointActive(scenario, active) end
+
+-- _SET_SCENARIO_POINT_COORDS  (0x2056AB38DF06825C)
+-- min build: 1207
+---@param scenario number
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param p4 boolean
+function _SetScenarioPointCoords(scenario, xPos, yPos, zPos, p4) end
+
+-- _SET_SCENARIO_POINT_FLAG  (0x5AF19B6CC2115D34)
+-- flag: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/CScenarioPointFlags__Flags
+-- min build: 1207
+---@param scenario number
+---@param flag number
+---@param value boolean
+function _SetScenarioPointFlag(scenario, flag, value) end
+
+-- _SET_SCENARIO_POINT_HEADING  (0xD3A0DA8F91612C6E)
+-- min build: 1207
+---@param scenario number
+---@param heading number
+---@param p2 boolean
+function _SetScenarioPointHeading(scenario, heading, p2) end
+
+-- _SET_SCENARIO_POINT_RADIUS  (0xC47D9080A9A8856A)
+-- min build: 1207
+---@param scenario number
+---@param radius number
+function _SetScenarioPointRadius(scenario, radius) end
+
+-- _SET_SCENARIO_TYPE_ENABLED_HASH  (0xD00E50E673802D71)
+-- min build: 1207
+---@param scenarioType number
+---@param toggle boolean
+function _SetScenarioTypeEnabledHash(scenarioType, toggle) end
+
+-- _SET_TASK_FISHING  (0xF3735ACD11ACD501)
+-- Only used in R* Scripts fishing_core and av_fishing_river
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return any
+function _SetTaskFishing(ped) end
+
+-- _SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT_2  (0x099D4A855D53B03B)
+-- min build: 1207
+---@param ped number
+---@param signalName string
+---@param value number
+function _SetTaskMoveNetworkSignalFloat2(ped, signalName, value) end
+
+-- _SET_TASK_MOVE_NETWORK_SIGNAL_VECTOR  (0x4662BFE01938D98D)
+-- min build: 1207
+---@param ped number
+---@param signalName string
+---@param x number
+---@param y number
+---@param z number
+function _SetTaskMoveNetworkSignalVector(ped, signalName, x, y, z) end
+
+-- _SWAP_REINS_FOR_PEDS  (0xFC7F71CF49F70B6B)
+-- Swaps the wagon/coach reins control between the ped and their adjacent front-seat partner.
+-- min build: 1207
+---@param ped number
+function _SwapReinsForPeds(ped) end
+
+-- _TASK_ANIMAL_BLEED_OUT  (0x30A768C30D385EC5)
+-- min build: 1207
+---@param ped number
+---@param killer number
+---@param flee boolean
+---@param weaponHash number
+---@param p4 number
+---@param boneId number
+function _TaskAnimalBleedOut(ped, killer, flee, weaponHash, p4, boneId) end
+
+-- _TASK_BOARD_VEHICLE  (0xE53D17AD837CBF7C)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param p2 number
+---@param p3 any
+---@param speed number
+---@param boardingFlags number
+function _TaskBoardVehicle(ped, vehicle, p2, p3, speed, boardingFlags) end
+
+-- _TASK_BOARD_VEHICLE_2  (0xE41A09C8DDFF7AA4)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 number
+---@param speed number
+---@param boardingFlags number
+function _TaskBoardVehicle2(ped, p1, p2, speed, boardingFlags) end
+
+-- _TASK_CLIMB_2  (0xDF1D85BCAF60D537)
+-- min build: 1207
+---@param ped number
+---@param heading number
+function _TaskClimb2(ped, heading) end
+
+-- _TASK_COMBAT_PED_AT_COORDS  (0xC624414FA748B9BA)
+-- Coords: volume coords used in R* Script smuggler2
+-- p4/p5 = 0 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param p5 number
+function _TaskCombatPedAtCoords(ped, x, y, z, p4, p5) end
+
+-- _TASK_CUT_FREE_HOGTIED_TARGET_PED  (0x81D16C4FF3A77ADF)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+function _TaskCutFreeHogtiedTargetPed(ped, targetPed) end
+
+-- _TASK_CUT_FREE_HOGTIED_TARGET_PED_EX  (0x525421A507216084)
+-- Extended variant of _TASK_CUT_FREE_HOGTIED_TARGET_PED. If p2 is 0.0f, it behaves like _TASK_CUT_FREE_HOGTIED_TARGET_PED; otherwise it calls a different internal path using p2.
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+function _TaskCutFreeHogtiedTargetPedEx(ped, targetPed, p2) end
+
+-- _TASK_DISEMBARK_VEHICLE  (0xA7C6854BB5A4192A)
+-- min build: 1207
+---@param p0 any
+---@param vehicle number
+---@param p2 number
+---@param p3 any
+---@param p4 number
+---@param p5 any
+function _TaskDisembarkVehicle(p0, vehicle, p2, p3, p4, p5) end
+
+-- _TASK_EMOTE_ACTION  (0x6A1AF481407BF6E9)
+-- Triggers the 'action / flourish' sub-clip of the ped's currently playing emote.
+-- Returns true on success, false if no valid emote state.
+-- Observed in ingame UIs to fire a flourish while an emote loop is active.
+-- Internally resets the ped's synced-emote entity and sets a flag to play the action once.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _TaskEmoteAction(ped) end
+
+-- _TASK_EMOTE_OUTRO  (0xBDFEEB7600BCD938)
+-- min build: 1207
+---@param ped number
+function _TaskEmoteOutro(ped) end
+
+-- _TASK_EQUIP_HAT  (0xAA0AF6025160243A)
+-- _A*
+-- min build: 1207
+---@param hatObject number
+---@param ped number
+function _TaskEquipHat(hatObject, ped) end
+
+-- _TASK_FLEE_FROM_COORD  (0x6879FF208ED87F2A)
+-- fleeType: see TASK_FLEE_COORD
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+function _TaskFleeFromCoord(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) end
+
+-- _TASK_FLEE_FROM_PED  (0x7B74D8EEDE9B5727)
+-- fleeType: see TASK_FLEE_COORD
+-- min build: 1207
+---@param ped number
+---@param fleeFromTarget number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param targetPed number
+function _TaskFleeFromPed(ped, fleeFromTarget, x, y, z, distance, p6, p7, p8, targetPed) end
+
+-- _TASK_FORCE_FIRE_AT_ENTITY_WHILE_AIMING  (0x2416EC2F31F75266)
+-- Makes a ped that is already aiming keep firing at `targetEntity` for `durationMs`.
+-- Uses projectile logic if holding a throwable/bow, otherwise gun logic. `p3` unused; `p4` is an extra mode flag (observed 0/1).
+-- _TASK_FORCE_M*
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param durationMs number
+---@param p3 any
+---@param p4 boolean
+function _TaskForceFireAtEntityWhileAiming(ped, targetEntity, durationMs, p3, p4) end
+
+-- _TASK_GUARD_DEFENSIVE_AREA  (0x1FC9B33976BACD6C)
+-- Uses CTaskSetAndGuardArea. TASK_GUARD_ASSIGNED_DEFENSIVE_AREA uses CTaskStandGuard instead.
+-- min build: 1207
+---@param ped number
+---@param volume number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param patrolProximity number
+---@param duration number
+function _TaskGuardDefensiveArea(ped, volume, x, y, z, heading, patrolProximity, duration) end
+
+-- _TASK_INTIMIDATED  (0x648B75D44930D6BD)
+-- Only used in R* SP Script homeinvasion:
+-- Params p2, p3, p4: 0, 0, 1
+-- min build: 1207
+---@param p0 any
+---@param ped number
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return boolean
+function _TaskIntimidated(p0, ped, p2, p3, p4) end
+
+-- _TASK_INTIMIDATED_2  (0x933ACC1A1771A288)
+-- min build: 1207
+---@param victim number
+---@param attacker number
+---@param p2 number
+---@param p3 boolean
+---@param p4 boolean
+---@param everyFrame boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param flag number
+---@return boolean
+function _TaskIntimidated2(victim, attacker, p2, p3, p4, everyFrame, p6, p7, flag) end
+
+-- _TASK_ITEM_INTERACTION_2  (0x72F52AA2D2B172CC)
+-- min build: 1207
+---@param ped number
+---@param propNameGxt number
+---@param prop number
+---@param propId number
+---@param itemInteractionState number
+---@param p5 number
+---@param p6 any
+---@param p7 number
+function _TaskItemInteraction2(ped, propNameGxt, prop, propId, itemInteractionState, p5, p6, p7) end
+
+-- _TASK_ITEM_INTERACTION_3  (0xD61D5E1AD9876DEB)
+-- Params: p3, p4, p5, p6: 0, 0, 0, -1.0f in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param item number
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 number
+---@return any
+function _TaskItemInteraction3(ped, item, p3, p4, p5, p6) end
+
+-- _TASK_JUMP_2  (0x91083103137D7254)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param entity number
+function _TaskJump2(ped, x, y, z, entity) end
+
+-- _TASK_KNOCKED_OUT_SET_DURATION  (0xFFB520A3E16F7B7B)
+-- Sets the knockout timer in seconds for a ped that is currently in the knocked-out state.
+-- min build: 1207
+---@param ped number
+---@param koTimeDuration number
+function _TaskKnockedOutSetDuration(ped, koTimeDuration) end
+
+-- _TASK_KNOCKED_OUT_SET_TUNING  (0x8B1FDF63C3193EDA)
+-- Sets an unknown float tuning setting for a ped that is currently in the knocked-out state.
+-- min build: 1207
+---@param ped number
+---@param tuning number
+function _TaskKnockedOutSetTuning(ped, tuning) end
+
+-- _TASK_PATROL_2  (0x964B06C88E4C86DB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function _TaskPatrol2(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _TASK_PERFORM_SEQUENCE_2  (0x4FC0AF869D6E309D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TaskPerformSequence2(p0, p1, p2, p3) end
+
+-- _TASK_PLAY_EMOTE  (0x884E3436CC1F41DD)
+-- Similar to 0xB31A277C1AC7B7FF but checks if the ped's inventory contains the specified emote kit.
+-- min build: 1207
+---@param ped number
+---@param emoteType number
+---@param playbackMode number
+---@param emote number
+---@param isSecondaryTask boolean
+---@param canBreakOut boolean
+---@param disableEarlyOutAnimTag boolean
+---@param ignoreInvalidMainTask boolean
+---@param destroyProps boolean
+function _TaskPlayEmote(ped, emoteType, playbackMode, emote, isSecondaryTask, canBreakOut, disableEarlyOutAnimTag, ignoreInvalidMainTask, destroyProps) end
+
+-- _TASK_POINT_AT_ENTITY  (0xF40A109B4B79A848)
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param durationMs number
+function _TaskPointAtEntity(ped, targetEntity, durationMs) end
+
+-- _TASK_PUT_PED_DIRECTLY_INTO_COVER_FROM_COORDS  (0xDF8A5855B9F9A97B)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param fromX number
+---@param fromY number
+---@param fromZ number
+---@param timeout number
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+---@param p15 any
+---@param p16 any
+---@param p17 any
+function _TaskPutPedDirectlyIntoCoverFromCoords(ped, x, y, z, fromX, fromY, fromZ, timeout, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) end
+
+-- _TASK_START_SCENARIO_IN_PLACE_2  (0xA917E39F2CEFD215)
+-- Takes scenario point handle instead of hash
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 string
+---@param p3 number
+---@param p4 boolean
+---@param p5 number
+---@param p6 boolean
+function _TaskStartScenarioInPlace2(ped, p1, p2, p3, p4, p5, p6) end
+
+-- _TASK_THROW_PROJECTILE_2  (0x7282356DFF6B5A51)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TaskThrowProjectile2(p0, p1, p2, p3) end
+
+-- _TASK_USE_NEAREST_SCENARIO_TO_COORD  (0x322BFDEA666E2B0E)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param duration number
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 boolean
+function _TaskUseNearestScenarioToCoord(ped, x, y, z, distance, duration, p6, p7, p8, p9) end
+
+-- _TASK_USE_SCENARIO_POINT_2  (0x0F6641449DD86FBE)
+-- min build: 1207
+---@param ped number
+---@param ped2 number
+---@param p2 any
+---@param p3 string
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 boolean
+function _TaskUseScenarioPoint2(ped, ped2, p2, p3, p4, p5, p6, p7) end
+
+-- _TASK_VEHICLE_ADD_NEXT_DESTINATION  (0x1D125814EBC517EB)
+-- Adds a waypoint to an AI vehicle's active drive-to-destination task; only the last 3 points are kept (ignored if no such task).
+-- min build: 1207
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+function _TaskVehicleAddNextDestination(vehicle, x, y, z) end
+
+-- _TASK_VEHICLE_DRIVE_TO_COORD_2  (0xF0108F01FB105DA2)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function _TaskVehicleDriveToCoord2(ped, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- _TASK_VEHICLE_DRIVE_TO_DESTINATION_2  (0x391073B9D3CCE2BA)
+-- Tasks vehicle towards owner
+-- min build: 1207
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@param speed number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+function _TaskVehicleDriveToDestination2(vehicle, x, y, z, speed, p5, p6, p7, p8) end
+
+-- _TASK_VEHICLE_DRIVE_TO_POINT_2  (0x6524A8981E8BE7C9)
+-- Params: p4 = 3.f or 8.f, p5 = 0.25f, p6 = 0 in R* Scripts
+-- min build: 1207
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param p5 number
+---@param p6 any
+function _TaskVehicleDriveToPoint2(vehicle, x, y, z, p4, p5, p6) end
+
+-- _TASK_VEHICLE_FLEE_ON_CLEANUP  (0x55CD5FDDD4335C1E)
+-- Vehicle Auto Drive (?)
+-- p1/p2/p3: usually 1f, 1f, 0f or 0f, 0f, 0f
+-- Speed: usually 8f
+-- Types: 1148979456 (task with flee), 1148979587 (dismissing the vehicle)
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param speed number
+---@param type number
+function _TaskVehicleFleeOnCleanup(vehicle, p1, p2, p3, speed, type) end
+
+-- _TASK_VEHICLE_FOLLOW_WAYPOINT_RECORDING_2  (0x041D17A9E221AE30)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function _TaskVehicleFollowWaypointRecording2(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _TASK_VEHICLE_IS_HEADING_TO_COORDS  (0x583AE9AF9CEE0958)
+-- Returns true if the vehicle's current drive-to task is targeting the given coordinates (i.e., its active destination matches x,y,z).
+-- Useful to avoid reissuing TASK_VEHICLE_DRIVE_TO_DESTINATION_2 when already en route.
+-- min build: 1207
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function _TaskVehicleIsHeadingToCoords(vehicle, x, y, z) end
+
+-- _TRANSITION_SCENARIO_TO_CONDITIONAL_ANIM  (0x79197F7D2BB5E73A)
+-- Requests an authored transition for a ped that is currently using a scenario point, switching into a specific conditional/clipset branch defined for that scenario.
+-- 
+-- Meta / authoring:
+-- - This mirrors entries in "script_common_ca.meta" where a transition links a <FromConditionalAnims> key to a target <ClipSet> (clipsetDict + clipName).
+-- - fromConditionalAnim should match the <FromConditionalAnims> name for the transition (some scripts pass 0 when they don’t care / use the default authored path).
+-- 
+-- Notes:
+-- - Scripts commonly call PED::_ADD_SCENARIO_TRANSITION(ped) immediately before this native.
+-- - Return value only indicates the transition request was accepted/triggered; scripts often verify the ped is still using the scenario point afterward (PED::IS_PED_USING_THIS_SCENARIO).
+-- 
+-- C++ style usage (from scripts):
+-- - PED::_ADD_SCENARIO_TRANSITION(ped);
+-- - if (TASK::_TRANSITION_SCENARIO_TO_CONDITIONAL_ANIM(ped, scenarioPoint, clipsetDict, clipName, fromConditionalAnim, 0)) {
+--     if (PED::IS_PED_USING_THIS_SCENARIO(ped, scenarioPoint)) {
+--       // transition took; continue state machine
+--     }
+--   }
+-- 
+-- Example video: https://imgur.com/a/ReSsWNj
+-- min build: 1207
+---@param ped number
+---@param scenarioPoint number
+---@param clipsetDict string
+---@param clipName string
+---@param fromConditionalAnim string
+---@param flags number
+---@return boolean
+function _TransitionScenarioToConditionalAnim(ped, scenarioPoint, clipsetDict, clipName, fromConditionalAnim, flags) end
+
+-- _UPDATE_TASK_GO_TO_COORD_WITH_OFFSET  (0x3FFCD7BBA074CC80)
+-- In-place update for a running follow-to-offset/go-to task: sets new target coords + local offset, with speed and arrival tolerance (foot or mount; no effect if no compatible task).
+-- min build: 1207
+---@param ped number
+---@param targetX number
+---@param targetY number
+---@param targetZ number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param speed number
+---@param tolerance number
+function _UpdateTaskGoToCoordWithOffset(ped, targetX, targetY, targetZ, offsetX, offsetY, offsetZ, speed, tolerance) end
+
+-- ADD_COVER_BLOCKING_AREA  (0x45C597097DD7CB81)
+-- min build: 1207
+---@param playerX number
+---@param playerY number
+---@param playerZ number
+---@param radiusX number
+---@param radiusY number
+---@param radiusZ number
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 boolean
+function AddCoverBlockingArea(playerX, playerY, playerZ, radiusX, radiusY, radiusZ, p6, p7, p8, p9) end
+
+-- ADD_COVER_POINT  (0xD5C12A75C7B9497F)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 boolean
+---@return number
+function AddCoverPoint(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- ADD_FLEE_TARGET_PED  (0x3923EC958249657D)
+-- Params: p2 is always -1.f in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+function AddFleeTargetPed(ped, targetPed, p2) end
+
+-- ADD_PATROL_ROUTE_LINK  (0x23083260DEC3A551)
+-- min build: 1207
+---@param node1 number
+---@param node2 number
+function AddPatrolRouteLink(node1, node2) end
+
+-- ADD_PATROL_ROUTE_NODE  (0x8EDF950167586B7C)
+-- min build: 1207
+---@param nodeId number
+---@param scenarioName string
+---@param x number
+---@param y number
+---@param z number
+---@param lookPosX number
+---@param lookPosY number
+---@param lookPosZ number
+---@param duration number
+---@param p9 boolean
+function AddPatrolRouteNode(nodeId, scenarioName, x, y, z, lookPosX, lookPosY, lookPosZ, duration, p9) end
+
+-- ARE_COMPOSITE_LOOTABLE_ENTITY_DEF_ASSETS_LOADED  (0x5E5D96BE25E9DF68)
+-- Returns true when requested asset is loaded
+-- min build: 1207
+---@param asset number
+---@return boolean
+function AreCompositeLootableEntityDefAssetsLoaded(asset) end
+
+-- ASSISTED_MOVEMENT_IS_ROUTE_LOADED  (0x60F9A4393A21F741)
+-- min build: 1207
+---@param route string
+---@return boolean
+function AssistedMovementIsRouteLoaded(route) end
+
+-- ASSISTED_MOVEMENT_REMOVE_ROUTE  (0x3548536485DD792B)
+-- min build: 1207
+---@param route string
+function AssistedMovementRemoveRoute(route) end
+
+-- ASSISTED_MOVEMENT_SET_ROUTE_PROPERTIES  (0xD5002D78B7162E1B)
+-- min build: 1207
+---@param route string
+---@param props number
+function AssistedMovementSetRouteProperties(route, props) end
+
+-- CAN_START_ITEM_INTERACTION  (0x2D19BC4DF626CBE7)
+-- min build: 1207
+---@param ped number
+---@param itemHash number
+---@param interactionAnimHash number
+---@param p3 number
+---@return boolean
+function CanStartItemInteraction(ped, itemHash, interactionAnimHash, p3) end
+
+-- CLEAR_DRIVEBY_TASK_UNDERNEATH_DRIVING_TASK  (0xC35B5CDB2824CF69)
+-- min build: 1207
+---@param ped number
+function ClearDrivebyTaskUnderneathDrivingTask(ped) end
+
+-- CLEAR_PED_SECONDARY_TASK  (0x176CECF6F920D707)
+-- min build: 1207
+---@param ped number
+function ClearPedSecondaryTask(ped) end
+
+-- CLEAR_PED_TASKS  (0xE1EF3C1216AFF2CD)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+function ClearPedTasks(ped, p1, p2) end
+
+-- CLEAR_PED_TASKS_IMMEDIATELY  (0xAAA34F8A7CB32098)
+-- Immediately stops the pedestrian from whatever it's doing. They stop fighting, animations, etc. they forget what they were doing.
+-- 
+-- resetCrouch TRUE = ped will stand up if crouching, FALSE = ped will remain crouching if crouched
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param resetCrouch boolean
+function ClearPedTasksImmediately(ped, p1, resetCrouch) end
+
+-- CLEAR_SEQUENCE_TASK  (0x3841422E9C488D8C)
+-- min build: 1207
+---@return number
+function ClearSequenceTask() end
+
+-- CLOSE_PATROL_ROUTE  (0xB043ECA801B8CBC1)
+-- min build: 1207
+function ClosePatrolRoute() end
+
+-- CLOSE_SEQUENCE_TASK  (0x39E72BC99E6360CB)
+-- min build: 1207
+---@param taskSequenceId number
+function CloseSequenceTask(taskSequenceId) end
+
+-- CREATE_PATROL_ROUTE  (0xAF8A443CCC8018DC)
+-- min build: 1207
+function CreatePatrolRoute() end
+
+-- CREATE_SCENARIO_POINT_HASH  (0x94B745CE41DB58A1)
+-- Returns scenario
+-- min build: 1207
+---@param scenarioHash number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p5 any
+---@param p6 any
+---@param p7 boolean
+---@return number
+function CreateScenarioPointHash(scenarioHash, x, y, z, heading, p5, p6, p7) end
+
+-- CREATE_SCENARIO_POINT_HASH_ATTACHED_TO_ENTITY  (0x794AB1379A74064D)
+-- Returns scenario
+-- min build: 1207
+---@param entity number
+---@param scenarioHash number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p6 any
+---@param p7 any
+---@param p8 boolean
+---@return number
+function CreateScenarioPointHashAttachedToEntity(entity, scenarioHash, x, y, z, heading, p6, p7, p8) end
+
+-- DELETE_PATROL_ROUTE  (0x7767DD9D65E91319)
+-- min build: 1207
+---@param patrolRoute string
+function DeletePatrolRoute(patrolRoute) end
+
+-- DOES_SCENARIO_EXIST_IN_AREA  (0x5A59271FFADD33C1)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 boolean
+---@param p5 any
+---@param p6 boolean
+---@return boolean
+function DoesScenarioExistInArea(x, y, z, radius, p4, p5, p6) end
+
+-- DOES_SCENARIO_GROUP_EXIST  (0xF9034C136C9E00D3)
+-- min build: 1207
+---@param scenarioGroup string
+---@return boolean
+function DoesScenarioGroupExist(scenarioGroup) end
+
+-- DOES_SCENARIO_OF_TYPE_EXIST_IN_AREA_HASH  (0x6EEAD6AF637DA752)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param typeHash number
+---@param radius number
+---@param p5 boolean
+---@return boolean
+function DoesScenarioOfTypeExistInAreaHash(x, y, z, typeHash, radius, p5) end
+
+-- DOES_SCENARIO_POINT_EXIST  (0x841475AC96E794D1)
+-- min build: 1207
+---@param scenario number
+---@return boolean
+function DoesScenarioPointExist(scenario) end
+
+-- DOES_SCRIPTED_COVER_POINT_EXIST_AT_COORDS  (0xA98B8E3C088E5A31)
+-- Checks if there is a cover point at position
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return boolean
+function DoesScriptedCoverPointExistAtCoords(p0, p1, p2, p3) end
+
+-- END_DUEL  (0xEED08A3A98B847E2)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 number
+function EndDuel(ped, p1, p2) end
+
+-- FIND_SCENARIO_OF_TYPE_HASH  (0xF533D68FF970D190)
+-- min build: 1207
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param scenarioType number
+---@param distance number
+---@param p5 any
+---@param p6 boolean
+---@return number
+function FindScenarioOfTypeHash(xPos, yPos, zPos, scenarioType, distance, p5, p6) end
+
+-- FORCE_SCENARIO_GROUP_PRIORITY  (0x444C910A5058E568)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function ForceScenarioGroupPriority(p0, p1) end
+
+-- GET_ACTIVE_VEHICLE_MISSION_TYPE  (0x534AEBA6E5ED4CAB)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetActiveVehicleMissionType(vehicle) end
+
+-- GET_IS_CARRIABLE_ENTITY  (0x0CCFE72B43C9CF96)
+-- min build: 1207
+---@param entity number
+---@return boolean
+function GetIsCarriableEntity(entity) end
+
+-- GET_IS_PED_AIMING_IN_THE_AIR  (0x8785E6E40C7A8819)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetIsPedAimingInTheAir(ped) end
+
+-- GET_IS_TASK_ACTIVE  (0xB0760331C7AA4155)
+-- min build: 1207
+---@param ped number
+---@param taskIndex number
+---@return boolean
+function GetIsTaskActive(ped, taskIndex) end
+
+-- GET_IS_WAYPOINT_RECORDING_LOADED  (0xCB4E8BE8A0063C5D)
+-- min build: 1207
+---@param waypointRecording string
+---@return boolean
+function GetIsWaypointRecordingLoaded(waypointRecording) end
+
+-- GET_ITEM_INTERACTION_ITEM_ID  (0x804425C4BBD00883)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetItemInteractionItemId(ped) end
+
+-- GET_ITEM_INTERACTION_PROMPT_PROGRESS  (0xBC864A70AD55E0C1)
+-- min build: 1207
+---@param ped number
+---@param inputContext number
+---@return number
+function GetItemInteractionPromptProgress(ped, inputContext) end
+
+-- GET_ITEM_INTERACTION_STATE  (0x6AA3DCA2C6F5EB6D)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetItemInteractionState(ped) end
+
+-- GET_PED_DESIRED_MOVE_BLEND_RATIO  (0x8517D4A6CA8513ED)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedDesiredMoveBlendRatio(ped) end
+
+-- GET_PED_WAYPOINT_DISTANCE  (0xE6A877C64CAF1BC5)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedWaypointDistance(ped) end
+
+-- GET_PED_WAYPOINT_OVERRIDE_SPEED  (0xD39A2F3E7FCAFF08)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedWaypointOverrideSpeed(ped) end
+
+-- GET_PED_WAYPOINT_PROGRESS  (0x2720AAA75001E094)
+-- min build: 1207
+---@param ped number
+---@return number
+function GetPedWaypointProgress(ped) end
+
+-- GET_PROP_FOR_SCENARIO_POINT  (0x295514F198EFD0CA)
+-- Old name: _GET_SCENARIO_POINT_ENTITY
+-- min build: 1207
+---@param scenarioPoint number
+---@param name string
+---@return number
+function GetPropForScenarioPoint(scenarioPoint, name) end
+
+-- GET_RANSACK_SCENARIO_POINT_PED_IS_USING  (0xD04241BBF6D03A5E)
+-- min build: 1207
+---@param ped number
+---@return any
+function GetRansackScenarioPointPedIsUsing(ped) end
+
+-- GET_SCENARIO_POINTS_IN_AREA  (0x345EC3B7EBDE1CB5)
+-- Note: scenariosInRadius is an array, and its size and values should be aligned to 8 bytes.
+-- min build: 1207
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param radius number
+---@param size number
+---@return number
+---@return any
+function GetScenarioPointsInArea(posX, posY, posZ, radius, size) end
+
+-- GET_SCRIPT_TASK_STATUS  (0x77F1BEB8863288D5)
+-- Gets the status of a script-assigned task, and returns an int between 0-8
+-- taskHash: https://alloc8or.re/rdr3/doc/enums/eScriptTaskHash.txt 
+-- 
+-- WAITING_TO_START_TASK = 0,
+-- PERFORMING_TASK
+-- DORMANT_TASK
+-- VACANT_STAGE
+-- GROUP_TASK_STAGE
+-- ATTRACTOR_SCRIPT_TASK_STAGE
+-- SECONDARY_TASK_STAGE
+-- TASK_NOT_FOUND
+-- FINISHED_TASK
+-- min build: 1207
+---@param ped number
+---@param taskHash number
+---@param p2 boolean
+---@return number
+function GetScriptTaskStatus(ped, taskHash, p2) end
+
+-- GET_SCRIPTED_COVER_POINT_COORDS  (0x594A1028FC2A3E85)
+-- min build: 1207
+---@param coverpoint number
+---@return vector3
+function GetScriptedCoverPointCoords(coverpoint) end
+
+-- GET_SEQUENCE_PROGRESS  (0x00A9010CFE1E3533)
+-- returned values:
+-- 0 to 7 = task that's currently in progress, 0 meaning the first one.
+-- -1 no task sequence in progress.
+-- min build: 1207
+---@param ped number
+---@return number
+function GetSequenceProgress(ped) end
+
+-- GET_TASK_MOVE_NETWORK_EVENT  (0xB4F47213DF45A64C)
+-- min build: 1207
+---@param ped number
+---@param eventName string
+---@return boolean
+function GetTaskMoveNetworkEvent(ped, eventName) end
+
+-- GET_TASK_MOVE_NETWORK_STATE  (0x717E4D1F2048376D)
+-- min build: 1207
+---@param ped number
+---@return string
+function GetTaskMoveNetworkState(ped) end
+
+-- GET_VEHICLE_WAYPOINT_PLAYBACK_OVERRIDE_SPEED  (0x3DC971EB22F73447)
+-- min build: 1207
+---@param p0 any
+---@return any
+function GetVehicleWaypointPlaybackOverrideSpeed(p0) end
+
+-- GET_VEHICLE_WAYPOINT_PROGRESS  (0x9824CFF8FC66E159)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleWaypointProgress(vehicle) end
+
+-- GET_VEHICLE_WAYPOINT_TARGET_POINT  (0x416B62AC8B9E5BBD)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleWaypointTargetPoint(vehicle) end
+
+-- GET_WAYPOINT_DISTANCE_ALONG_ROUTE  (0xA5B769058763E497)
+-- min build: 1207
+---@param waypointRecording string
+---@param p1 number
+---@return number
+function GetWaypointDistanceAlongRoute(waypointRecording, p1) end
+
+-- IS_DRIVEBY_TASK_UNDERNEATH_DRIVING_TASK  (0x8785E6E40C7A8818)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsDrivebyTaskUnderneathDrivingTask(ped) end
+
+-- IS_EMOTE_TASK_RUNNING  (0xCF9B71C0AF824036)
+-- min build: 1355
+---@param ped number
+---@param p1 any
+---@return boolean
+function IsEmoteTaskRunning(ped, p1) end
+
+-- IS_MOUNTED_WEAPON_TASK_UNDERNEATH_DRIVING_TASK  (0xA320EF046186FA3B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsMountedWeaponTaskUnderneathDrivingTask(ped) end
+
+-- IS_MOVE_BLEND_RATIO_RUNNING  (0xD4D8636C0199A939)
+-- min build: 1207
+---@param moveBlendRatio number
+---@return boolean
+function IsMoveBlendRatioRunning(moveBlendRatio) end
+
+-- IS_MOVE_BLEND_RATIO_SPRINTING  (0x24A2AD74FA9814E2)
+-- min build: 1207
+---@param moveBlendRatio number
+---@return boolean
+function IsMoveBlendRatioSprinting(moveBlendRatio) end
+
+-- IS_MOVE_BLEND_RATIO_STILL  (0x349CE7B56DAFD95C)
+-- min build: 1207
+---@param moveBlendRatio number
+---@return boolean
+function IsMoveBlendRatioStill(moveBlendRatio) end
+
+-- IS_MOVE_BLEND_RATIO_WALKING  (0xF133BBBE91E1691F)
+-- min build: 1207
+---@param moveBlendRatio number
+---@return boolean
+function IsMoveBlendRatioWalking(moveBlendRatio) end
+
+-- IS_PED_ACTIVE_IN_SCENARIO  (0xAA135F9482C82CC3)
+-- min build: 1207
+---@param ped number
+---@param scenario number
+---@return boolean
+function IsPedActiveInScenario(ped, scenario) end
+
+-- IS_PED_BEING_ARRESTED  (0x90A09F3A45FED688)
+-- This function is hard-coded to always return false.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedBeingArrested(ped) end
+
+-- IS_PED_CUFFED  (0x74E559B3BC910685)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedCuffed(ped) end
+
+-- IS_PED_EXITING_SCENARIO  (0x0C3CB2E600C8977D)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function IsPedExitingScenario(ped, p1) end
+
+-- IS_PED_GETTING_UP  (0x2A74E1D5F2F00EEC)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedGettingUp(ped) end
+
+-- IS_PED_IN_HIT_REACT  (0xF330A5C062B29BED)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInHitReact(ped) end
+
+-- IS_PED_IN_WRITHE  (0xDEB6D52126E7D640)
+-- This native checks if a ped is on the ground, in pain from a (gunshot) wound.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedInWrithe(ped) end
+
+-- IS_PED_RUNNING  (0xC5286FFC176F28A2)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRunning(ped) end
+
+-- IS_PED_RUNNING_INSPECTION_TASK  (0x038B1F1674F0E242)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRunningInspectionTask(ped) end
+
+-- IS_PED_RUNNING_TASK_ITEM_INTERACTION  (0xEC7E480FF8BD0BED)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedRunningTaskItemInteraction(ped) end
+
+-- IS_PED_SCENARIO_REACT_LOOKING  (0x916B8E075ABC8B4E)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function IsPedScenarioReactLooking(ped, p1) end
+
+-- IS_PED_SPRINTING  (0x57E457CD2C0FC168)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedSprinting(ped) end
+
+-- IS_PED_STILL  (0xAC29253EEF8F0180)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedStill(ped) end
+
+-- IS_PED_WALKING  (0xDE4C184B2B9B071A)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedWalking(ped) end
+
+-- IS_SCENARIO_GROUP_ENABLED  (0x367A09DED4E05B99)
+-- min build: 1207
+---@param scenarioGroup string
+---@return boolean
+function IsScenarioGroupEnabled(scenarioGroup) end
+
+-- IS_SCENARIO_OCCUPIED  (0x788756D73AC2E07C)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+---@return boolean
+function IsScenarioOccupied(p0, p1, p2, p3, p4) end
+
+-- IS_SCENARIO_TYPE_ENABLED  (0x3A815DB3EA088722)
+-- min build: 1207
+---@param scenarioType string
+---@return boolean
+function IsScenarioTypeEnabled(scenarioType) end
+
+-- IS_TASK_MOVE_NETWORK_ACTIVE  (0x921CE12C489C4C41)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsTaskMoveNetworkActive(ped) end
+
+-- IS_TASK_MOVE_NETWORK_READY_FOR_TRANSITION  (0x30ED88D5E0C56A37)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsTaskMoveNetworkReadyForTransition(ped) end
+
+-- IS_TEAM_CARRIABLE_ENTITY  (0x559A6F8C5133B4EE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return boolean
+function IsTeamCarriableEntity(p0, p1) end
+
+-- IS_WAYPOINT_PLAYBACK_GOING_ON_FOR_PED  (0xE03B3F2D3DC59B64)
+-- min build: 1207
+---@param ped number
+---@param waypointRecording string
+---@return boolean
+function IsWaypointPlaybackGoingOnForPed(ped, waypointRecording) end
+
+-- IS_WAYPOINT_PLAYBACK_GOING_ON_FOR_VEHICLE  (0xF5134943EA29868C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return boolean
+function IsWaypointPlaybackGoingOnForVehicle(p0, p1) end
+
+-- MAKE_OBJECT_NOT_CARRIABLE  (0x67BFCED22909834D)
+-- min build: 1207
+---@param object number
+function MakeObjectNotCarriable(object) end
+
+-- OPEN_PATROL_ROUTE  (0xA36BFB5EE89F3D82)
+-- Note: patrolRoute must be prefixed with 'miss_' for it to be valid
+-- min build: 1207
+---@param patrolRoute string
+function OpenPatrolRoute(patrolRoute) end
+
+-- OPEN_SEQUENCE_TASK  (0xE8854A4326B9E12B)
+-- min build: 1207
+---@return number
+function OpenSequenceTask() end
+
+-- PED_HAS_USE_SCENARIO_TASK  (0x295E3CCEC879CCD7)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function PedHasUseScenarioTask(ped) end
+
+-- PLAY_ANIM_ON_RUNNING_SCENARIO  (0x748040460F8DF5DC)
+-- min build: 1207
+---@param ped number
+---@param animDict string
+---@param animName string
+function PlayAnimOnRunningScenario(ped, animDict, animName) end
+
+-- PLAY_ENTITY_SCRIPTED_ANIM  (0x77A1EEC547E7FCF1)
+-- min build: 1207
+---@param entity number
+---@return any
+function PlayEntityScriptedAnim(entity) end
+
+-- REACT_LOOK_AT  (0xE7FA07624574B79A)
+-- lookIntensity: see SET_PED_SHOULD_PLAY_FLEE_SCENARIO_EXIT
+-- 
+-- exitAnimation: LOOK_RETURN_GENERIC = 1,
+-- LOOK_RETURN_DISMISSIVE = 2,
+-- LOOK_RETURN_RELIEVED = 3
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param lookIntensity number
+---@param exitAnimation number
+---@param duration number
+---@param p5 number
+---@param targetPed2 number
+---@param p7 any
+---@param p8 any
+function ReactLookAt(ped, targetPed, lookIntensity, exitAnimation, duration, p5, targetPed2, p7, p8) end
+
+-- REACT_LOOK_AT_END  (0x541E5B41DCA45828)
+-- min build: 1207
+---@param ped number
+---@param exitAnimation number
+---@param p2 boolean
+function ReactLookAtEnd(ped, exitAnimation, p2) end
+
+-- REMOVE_ALL_COVER_BLOCKING_AREAS  (0xDB6708C0B46F56D8)
+-- min build: 1207
+function RemoveAllCoverBlockingAreas() end
+
+-- REMOVE_COVER_POINT  (0xAE287C923D891715)
+-- min build: 1207
+---@param coverpoint number
+function RemoveCoverPoint(coverpoint) end
+
+-- REMOVE_WAYPOINT_RECORDING  (0xFF1B8B4AA1C25DC8)
+-- min build: 1207
+---@param waypointRecording string
+function RemoveWaypointRecording(waypointRecording) end
+
+-- REQUEST_TASK_MOVE_NETWORK_STATE_TRANSITION  (0xD01015C7316AE176)
+-- min build: 1207
+---@param ped number
+---@param name string
+function RequestTaskMoveNetworkStateTransition(ped, name) end
+
+-- REQUEST_WAYPOINT_RECORDING  (0x9EEFB62EB27B5792)
+-- min build: 1207
+---@param waypointRecording string
+function RequestWaypointRecording(waypointRecording) end
+
+-- RESET_SCENARIO_GROUPS_ENABLED  (0xDD902D0349AFAD3A)
+-- min build: 1207
+function ResetScenarioGroupsEnabled() end
+
+-- RESET_SCENARIO_TYPES_ENABLED  (0x0D40EE2A7F2B2D6D)
+-- min build: 1207
+function ResetScenarioTypesEnabled() end
+
+-- SET_ANIM_FILTER  (0x87B66D77D545DB66)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function SetAnimFilter(p0, p1, p2, p3) end
+
+-- SET_ANIM_RATE  (0x032D49C5E359C847)
+-- min build: 1207
+---@param p0 any
+---@param p1 number
+---@param p2 any
+---@param p3 boolean
+function SetAnimRate(p0, p1, p2, p3) end
+
+-- SET_DRIVE_TASK_CRUISE_SPEED  (0x5C9B84BD7D31D908)
+-- min build: 1207
+---@param driver number
+---@param cruiseSpeed number
+function SetDriveTaskCruiseSpeed(driver, cruiseSpeed) end
+
+-- SET_DRIVE_TASK_MAX_CRUISE_SPEED  (0x404A5AA9B9F0B746)
+-- Not implemented.
+-- min build: 1207
+---@param ped number
+---@param maxCruiseSpeed number
+function SetDriveTaskMaxCruiseSpeed(ped, maxCruiseSpeed) end
+
+-- SET_DRIVEBY_TASK_TARGET  (0xE5B302114D8162EE)
+-- min build: 1207
+---@param shootingPed number
+---@param targetPed number
+---@param targetVehicle number
+---@param x number
+---@param y number
+---@param z number
+function SetDrivebyTaskTarget(shootingPed, targetPed, targetVehicle, x, y, z) end
+
+-- SET_ENABLE_SPEED_RESTRAIN_FOR_WAYPOINT_RECORDING_LEADER  (0x295F03DC97BEEBC1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function SetEnableSpeedRestrainForWaypointRecordingLeader(p0, p1) end
+
+-- SET_ENHANCED_BREAK_FREE  (0x1BF9D36A5EAFFBAE)
+-- clipset: CLIPSET@MECH_HOGTIE@HUMAN@BREAKOUT_MG@GROUND, CLIPSET@MECH_HOGTIE@HUMAN@BREAKOUT_MG@SHOULDER, CLIPSET@MECH_HOGTIE@HUMAN@BREAKOUT_MG@MOUNT
+-- clipset can also be 0
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param clipset string
+---@return boolean
+function SetEnhancedBreakFree(ped, p1, clipset) end
+
+-- SET_HIGH_FALL_TASK  (0x8C825BDC7741D37C)
+-- Makes the ped ragdoll like when falling from a great height
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+function SetHighFallTask(ped, p1, p2, p3) end
+
+-- SET_PED_DESIRED_MOVE_BLEND_RATIO  (0x1E982AC8716912C5)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function SetPedDesiredMoveBlendRatio(ped, p1) end
+
+-- SET_PED_PATH_AVOID_FIRE  (0x4455517B28441E60)
+-- min build: 1207
+---@param ped number
+---@param avoidFire boolean
+function SetPedPathAvoidFire(ped, avoidFire) end
+
+-- SET_PED_PATH_CAN_DROP_FROM_HEIGHT  (0xE361C5C71C431A4F)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedPathCanDropFromHeight(ped, toggle) end
+
+-- SET_PED_PATH_CAN_USE_CLIMBOVERS  (0x8E06A6FE76C9EFF4)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedPathCanUseClimbovers(ped, toggle) end
+
+-- SET_PED_PATH_CAN_USE_LADDERS  (0x77A5B103C87F476E)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedPathCanUseLadders(ped, toggle) end
+
+-- SET_PED_PATH_CLIMB_COST_MODIFIER  (0x88E32DB8C1A4AA4B)
+-- min build: 1207
+---@param ped number
+---@param modifier number
+function SetPedPathClimbCostModifier(ped, modifier) end
+
+-- SET_PED_PATH_DEEP_SNOW_COST_MODIFIER  (0xE8C296B75EACC357)
+-- min build: 1207
+---@param ped number
+---@param modifier number
+function SetPedPathDeepSnowCostModifier(ped, modifier) end
+
+-- SET_PED_PATH_FOLIAGE_COST_MODIFIER  (0x3AD8EFF9703BE657)
+-- min build: 1207
+---@param ped number
+---@param modifier number
+function SetPedPathFoliageCostModifier(ped, modifier) end
+
+-- SET_PED_PATH_MAY_ENTER_WATER  (0xF35425A4204367EC)
+-- min build: 1207
+---@param ped number
+---@param mayEnterWater boolean
+function SetPedPathMayEnterWater(ped, mayEnterWater) end
+
+-- SET_PED_PATH_PREFER_TO_AVOID_WATER  (0x38FE1EC73743793C)
+-- min build: 1207
+---@param ped number
+---@param avoidWater boolean
+---@param p2 number
+function SetPedPathPreferToAvoidWater(ped, avoidWater, p2) end
+
+-- SET_PED_WAYPOINT_ROUTE_OFFSET  (0xED98E10B0AFCE4B4)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@return boolean
+function SetPedWaypointRouteOffset(ped, p1, p2, p3) end
+
+-- SET_SCENARIO_GROUP_ENABLED  (0x02C8E5B49848664E)
+-- min build: 1207
+---@param scenarioGroup string
+---@param toggle boolean
+function SetScenarioGroupEnabled(scenarioGroup, toggle) end
+
+-- SET_SCENARIO_TYPE_ENABLED  (0xEB47EC4E34FB7EE1)
+-- min build: 1207
+---@param scenarioType string
+---@param toggle boolean
+function SetScenarioTypeEnabled(scenarioType, toggle) end
+
+-- SET_SEQUENCE_TO_REPEAT  (0x58C70CF3A41E4AE7)
+-- repeatMode: 0 = REPEAT_NOT; 1 = REPEAT_FOREVER
+-- min build: 1207
+---@param taskSequenceId number
+---@param repeatMode number
+function SetSequenceToRepeat(taskSequenceId, repeatMode) end
+
+-- SET_TASK_MOVE_NETWORK_SIGNAL_BOOL  (0xB0A6CFD2C69C1088)
+-- min build: 1207
+---@param ped number
+---@param signalName string
+---@param value boolean
+function SetTaskMoveNetworkSignalBool(ped, signalName, value) end
+
+-- SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT  (0xD5BB4025AE449A4E)
+-- min build: 1207
+---@param ped number
+---@param signalName string
+---@param value number
+function SetTaskMoveNetworkSignalFloat(ped, signalName, value) end
+
+-- SET_TEAM_CARRIABLE_ENTITY  (0x545BF19F86E80F11)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function SetTeamCarriableEntity(p0, p1, p2) end
+
+-- SET_UP_SPEED_RESTRAIN_INFORMATION_FOR_PLAYER_FOLLOWER  (0xB5C51DD544F14F58)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function SetUpSpeedRestrainInformationForPlayerFollower(p0, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- START_TASK_ITEM_INTERACTION  (0xAE72E7DF013AAA61)
+-- Params: p3 = 0, 1; p5 = 0.0f, -1.0f
+-- https://github.com/femga/rdr3_discoveries/tree/master/tasks/TASK_ITEM_INTERACTION
+-- min build: 1207
+---@param ped number
+---@param itemHash number
+---@param interactionAnimHash number
+---@param p3 number
+---@param flag number
+---@param p5 number
+function StartTaskItemInteraction(ped, itemHash, interactionAnimHash, p3, flag, p5) end
+
+-- STOP_ANIM_PLAYBACK  (0xEE08C992D238C5D1)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+function StopAnimPlayback(ped, p1, p2) end
+
+-- STOP_ANIM_TASK  (0x97FF36A1D40EA00A)
+-- min build: 1207
+---@param ped number
+---@param animDictionary string
+---@param animationName string
+---@param p3 number
+function StopAnimTask(ped, animDictionary, animationName, p3) end
+
+-- TASK_ACHIEVE_HEADING  (0x93B93A37987F1F3D)
+-- Makes the specified ped achieve the specified heading.
+-- 
+-- pedHandle: The handle of the ped to assign the task to.
+-- heading: The desired heading.
+-- timeout: The time, in milliseconds, to allow the task to complete. If the task times out, it is canceled, and the ped will stay at the heading it managed to reach in the time.
+-- min build: 1207
+---@param ped number
+---@param heading number
+---@param timeout number
+function TaskAchieveHeading(ped, heading, timeout) end
+
+-- TASK_AIM_AT_COORD  (0x4AF1D73861212F52)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param time number
+---@param p5 boolean
+---@param p6 boolean
+function TaskAimAtCoord(ped, x, y, z, time, p5, p6) end
+
+-- TASK_AIM_AT_ENTITY  (0xCF7569BD0FB480A0)
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param time number
+---@param p3 boolean
+---@param p4 boolean
+function TaskAimAtEntity(ped, targetEntity, time, p3, p4) end
+
+-- TASK_AIM_GUN_AT_COORD  (0x6671F3EEC681BDA1)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param time number
+---@param p5 boolean
+---@param p6 boolean
+function TaskAimGunAtCoord(ped, x, y, z, time, p5, p6) end
+
+-- TASK_AIM_GUN_AT_ENTITY  (0x9B53BB6E8943AF53)
+-- duration: the amount of time in milliseconds to do the task.  -1 will keep the task going until either another task is applied, or CLEAR_ALL_TASKS() is called with the ped
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param duration number
+---@param p3 boolean
+---@param p4 number
+function TaskAimGunAtEntity(ped, targetEntity, duration, p3, p4) end
+
+-- TASK_AMBIENT_ANIMAL_HUNT  (0x4B39D8F9D0FE7749)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskAmbientAnimalHunt(ped, p1, p2) end
+
+-- TASK_AMBIENT_ANIMAL_STALK  (0x37C13863ABA1B4A3)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskAmbientAnimalStalk(ped, p1, p2) end
+
+-- TASK_ANIMAL_ALERTED  (0x979D93372FC8C565)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskAnimalAlerted(ped, p1, p2) end
+
+-- TASK_ANIMAL_FLEE  (0xA899B61C66F09134)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 any
+function TaskAnimalFlee(ped, targetPed, p2) end
+
+-- TASK_ANIMAL_INTERACTION  (0xCD181A959CFDD7F4)
+-- https://github.com/femga/rdr3_discoveries/tree/master/tasks/TASK_ANIMAL_INTERACTION
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param interactionType number
+---@param interactionModel number
+---@param skipIdleAnimationClip boolean
+function TaskAnimalInteraction(ped, targetPed, interactionType, interactionModel, skipIdleAnimationClip) end
+
+-- TASK_ANIMAL_UNALERTED  (0x21FDF9A25CFE1CE5)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function TaskAnimalUnalerted(ped, p1, p2, p3, p4) end
+
+-- TASK_ANIMAL_WRITHE  (0x8C038A39C4A4B6D6)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskAnimalWrithe(ped, p1, p2) end
+
+-- TASK_ARREST_PED  (0xF3B9A78A178572B1)
+-- min build: 1207
+---@param ped number
+---@param target number
+function TaskArrestPed(ped, target) end
+
+-- TASK_BARK  (0x83BFC1F836B2F3F2)
+-- min build: 1207
+---@param ped number
+---@param barkAtTarget number
+---@param mood number
+function TaskBark(ped, barkAtTarget, mood) end
+
+-- TASK_BOAT_MISSION  (0x15C86013127CE63F)
+-- min build: 1207
+---@param pedDriver number
+---@param boat number
+---@param p2 any
+---@param p3 any
+---@param x number
+---@param y number
+---@param z number
+---@param p7 any
+---@param maxSpeed number
+---@param drivingStyle number
+---@param p10 number
+---@param p11 any
+function TaskBoatMission(pedDriver, boat, p2, p3, x, y, z, p7, maxSpeed, drivingStyle, p10, p11) end
+
+-- TASK_BREAK_VEHICLE_DOOR_LOCK  (0xBB28D1BC9EA8A6A5)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+function TaskBreakVehicleDoorLock(ped, vehicle) end
+
+-- TASK_CARRIABLE  (0xF0B4F759F35CC7F5)
+-- carriableSlot:
+--  7 > Back of a horse
+--  6 > Right side of a horse
+--  5 > Left side of a horse
+-- flags:
+--  512: enables the prompt being the name of the item when using a generic item
+-- min build: 1207
+---@param entity number
+---@param carryConfig number
+---@param carrier number
+---@param carriableSlot number
+---@param flags number
+function TaskCarriable(entity, carryConfig, carrier, carriableSlot, flags) end
+
+-- TASK_CLEAR_DEFENSIVE_AREA  (0x95A6C46A31D1917D)
+-- min build: 1207
+---@param ped number
+function TaskClearDefensiveArea(ped) end
+
+-- TASK_CLEAR_LOOK_AT  (0x0F804F1DB19B9689)
+-- min build: 1207
+---@param ped number
+function TaskClearLookAt(ped) end
+
+-- TASK_CLIMB  (0x89D9FCC2435112F1)
+-- Climbs or vaults the nearest thing.
+-- min build: 1207
+---@param ped number
+---@param unused boolean
+function TaskClimb(ped, unused) end
+
+-- TASK_CLIMB_LADDER  (0xB6C987F9285A3814)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 boolean
+---@param p3 boolean
+function TaskClimbLadder(ped, p1, p2, p3) end
+
+-- TASK_COMBAT_ANIMAL_CHARGE_PED  (0xEE3AA414CF99F368)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 boolean
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function TaskCombatAnimalChargePed(ped, targetPed, p2, p3, p4, p5, p6) end
+
+-- TASK_COMBAT_ANIMAL_WARN  (0xF960F3D57B660E96)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskCombatAnimalWarn(ped, p1, p2) end
+
+-- TASK_COMBAT_HATED_TARGETS  (0x8182B561A29BD597)
+-- min build: 1207
+---@param ped number
+---@param radius number
+function TaskCombatHatedTargets(ped, radius) end
+
+-- TASK_COMBAT_HATED_TARGETS_AROUND_PED  (0x7BF835BB9E2698C8)
+-- Despite its name, it only attacks ONE hated target. The one closest hated target.
+-- min build: 1207
+---@param ped number
+---@param radius number
+---@param flags number
+---@param p3 any
+function TaskCombatHatedTargetsAroundPed(ped, radius, flags, p3) end
+
+-- TASK_COMBAT_HATED_TARGETS_AROUND_PED_TIMED  (0x2BBA30B854534A0C)
+-- min build: 1207
+---@param ped number
+---@param radius number
+---@param time number
+---@param flags number
+function TaskCombatHatedTargetsAroundPedTimed(ped, radius, time, flags) end
+
+-- TASK_COMBAT_HATED_TARGETS_IN_AREA  (0x4CF5F55DAC3280A0)
+-- Despite its name, it only attacks ONE hated target. The one closest to the specified position.
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param flags number
+---@param p6 any
+function TaskCombatHatedTargetsInArea(ped, x, y, z, radius, flags, p6) end
+
+-- TASK_COMBAT_HATED_TARGETS_NO_LOS_TEST  (0xB5BC69D9C4060BC3)
+-- min build: 1207
+---@param ped number
+---@param radius number
+function TaskCombatHatedTargetsNoLosTest(ped, radius) end
+
+-- TASK_COMBAT_PED  (0xF166E48407BAC484)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+---@param p3 number
+function TaskCombatPed(ped, targetPed, p2, p3) end
+
+-- TASK_COMBAT_PED_TIMED  (0x944F30DCB7096BDE)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+---@param p3 any
+function TaskCombatPedTimed(ped, targetPed, p2, p3) end
+
+-- TASK_COMPANION_AMBIENT  (0xE017CF6E2527FE4F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function TaskCompanionAmbient(ped, p1) end
+
+-- TASK_CONFRONT  (0x3A2A2071DF5CC569)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+---@return boolean
+function TaskConfront(ped, targetPed, p2) end
+
+-- TASK_COWER  (0x3EB1FE9E8E908E15)
+-- min build: 1207
+---@param ped number
+---@param duration number
+---@param pedToCowerFrom number
+---@param p3 string
+function TaskCower(ped, duration, pedToCowerFrom, p3) end
+
+-- TASK_DISEMBARK_NEAREST_TRAIN_CARRIAGE  (0x0A11F3BDEC03ED5F)
+-- flags: See TASK_ENTER_VEHICLE
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param flags number
+function TaskDisembarkNearestTrainCarriage(ped, p1, flags) end
+
+-- TASK_DISMOUNT_ANIMAL  (0x48E92D3DDE23C23A)
+-- Dismounts the ped from the animal it's mounted on. taskFlag affects what side the rider gets off. p2-p5 are almost always 0.
+-- flags: See TASK_ENTER_VEHICLE
+-- min build: 1207
+---@param rider number
+---@param taskFlag number
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param targetPed number
+function TaskDismountAnimal(rider, taskFlag, p2, p3, p4, targetPed) end
+
+-- TASK_DRIVE_BY  (0x2F8AF0E82773A171)
+-- min build: 1207
+---@param driverPed number
+---@param targetPed number
+---@param targetVehicle number
+---@param targetX number
+---@param targetY number
+---@param targetZ number
+---@param distanceToShoot number
+---@param pedAccuracy number
+---@param p8 boolean
+---@param firingPattern number
+function TaskDriveBy(driverPed, targetPed, targetVehicle, targetX, targetY, targetZ, distanceToShoot, pedAccuracy, p8, firingPattern) end
+
+-- TASK_DUCK  (0xA14B5FBF986BAC23)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+function TaskDuck(ped, p1) end
+
+-- TASK_DUEL  (0x5D5B0D5BC3626E5A)
+-- Params: p4 either 0.2f, 0.25f, 0.31f, 0.4f
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 number
+---@param entity number
+---@param p4 number
+---@param p5 number
+---@param vPosOpponentX number
+---@param vPosOpponentY number
+---@param vPosOpponentZ number
+---@param fOpponentHead number
+---@param p10 number
+function TaskDuel(ped, p1, p2, entity, p4, p5, vPosOpponentX, vPosOpponentY, vPosOpponentZ, fOpponentHead, p10) end
+
+-- TASK_DUMP_CARRIABLE_FROM_PARENT  (0x17CA98707B15926A)
+-- min build: 1207
+---@param ped number
+---@param ped2 number
+---@param entity number
+function TaskDumpCarriableFromParent(ped, ped2, entity) end
+
+-- TASK_EAT  (0xBD7949BD07299672)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskEat(ped, p1, p2) end
+
+-- TASK_ENTER_ANIM_SCENE  (0xC2329B0206426644)
+-- flags:
+-- MOVE_WHILST_WAITING_FOR_PATH = (1 << 0),
+-- DO_NOT_STAND_STILL_AT_END_OF_PATH = (1 << 1),
+-- SKIP_NAVIGATION = (1 << 2),
+-- TEASF_AUTO_START_ANIM_SCENE = (1 << 3),
+-- FORCE_STAND_STILL_AT_END_OF_PATH = (1 << 6),
+-- ENTER_ANIM_SCENE_DONT_FOLLOW_NAVMESH = (1 << 7)
+-- min build: 1207
+---@param ped number
+---@param animScene number
+---@param entityName string
+---@param playbackListName string
+---@param enterSpeed number
+---@param bAutoStart boolean
+---@param flag number
+---@param p7 number
+---@param p8 number
+function TaskEnterAnimScene(ped, animScene, entityName, playbackListName, enterSpeed, bAutoStart, flag, p7, p8) end
+
+-- TASK_ENTER_VEHICLE  (0xC20E50AA46D09CA8)
+-- flags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eEnterExitVehicleFlags
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param timeout number
+---@param seat number
+---@param speed number
+---@param flag number
+---@param p6 any
+function TaskEnterVehicle(ped, vehicle, timeout, seat, speed, flag, p6) end
+
+-- TASK_EVASIVE_ANIM  (0x5F22926E1BCE9B08)
+-- Params: p2 is returned by BUILTIN::SHIFT_LEFT
+-- min build: 1207
+---@param ped1 number
+---@param ped2 number
+---@param p2 number
+function TaskEvasiveAnim(ped1, ped2, p2) end
+
+-- TASK_EVERYONE_LEAVE_VEHICLE_IN_ORDER  (0x6F1C49F275BD25B3)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function TaskEveryoneLeaveVehicleInOrder(vehicle, p1) end
+
+-- TASK_EXTEND_ROUTE  (0x1E7889778264843A)
+-- Adds a new point to the current point route. Call TASK_FLUSH_ROUTE before the first call to this. Call TASK_FOLLOW_POINT_ROUTE to make the Ped go the route.
+-- 
+-- A maximum of 8 points can be added.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+function TaskExtendRoute(x, y, z) end
+
+-- TASK_FLEE_COORD  (0x58428248BF4B64E4)
+-- Params: p5 = some flag?, p6 = -1.0f, p8 = 0 in R* Scripts
+-- fleeStyle: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eFleeStyle
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param fleeStyle number
+---@param p5 number
+---@param p6 number
+---@param duration number
+---@param p8 number
+function TaskFleeCoord(ped, x, y, z, fleeStyle, p5, p6, duration, p8) end
+
+-- TASK_FLEE_COORD_VIA  (0x390E0B697D25EAF5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+function TaskFleeCoordVia(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) end
+
+-- TASK_FLEE_PED  (0xFD45175A6DFD7CE9)
+-- Params: p4 = -1.0f, p5 = -1, p6 = 0 in R* Scripts
+-- fleeStyle: see TASK_FLEE_COORD
+-- min build: 1207
+---@param ped number
+---@param fleeFromTarget number
+---@param fleeStyle number
+---@param flag number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+function TaskFleePed(ped, fleeFromTarget, fleeStyle, flag, p4, p5, p6) end
+
+-- TASK_FLEE_PED_VIA  (0x5802E0F910E4CF1D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function TaskFleePedVia(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- TASK_FLUSH_ROUTE  (0x841142A1376E9006)
+-- Clears the current point route. Call this before TASK_EXTEND_ROUTE and TASK_FOLLOW_POINT_ROUTE.
+-- min build: 1207
+function TaskFlushRoute() end
+
+-- TASK_FLY_AWAY  (0xE86A537B5A3C297C)
+-- min build: 1207
+---@param ped number
+---@param fleeFromTarget number
+function TaskFlyAway(ped, fleeFromTarget) end
+
+-- TASK_FLY_TO_COORD  (0xD6CFC2D59DA72042)
+-- min build: 1207
+---@param ped number
+---@param travelMbr number
+---@param x number
+---@param y number
+---@param z number
+---@param p5 boolean
+---@param p6 boolean
+function TaskFlyToCoord(ped, travelMbr, x, y, z, p5, p6) end
+
+-- TASK_FLYING_CIRCLE  (0x72997893BFB8ECCC)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function TaskFlyingCircle(ped, p1, p2, p3, p4, p5, p6) end
+
+-- TASK_FOLLOW_AND_CONVERSE_WITH_PED  (0x489FFCCCE7392B55)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 any
+---@param p3 any
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 any
+---@param p8 any
+---@param p9 number
+---@param p10 number
+function TaskFollowAndConverseWithPed(ped, targetPed, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- TASK_FOLLOW_ENTITY_ALONG_WAYPOINT_RECORDING_AT_OFFSET  (0x4D2B787BAE9AB760)
+-- min build: 1207
+---@param ped0 number
+---@param ped1 number
+---@param waypointRecording string
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 boolean
+function TaskFollowEntityAlongWaypointRecordingAtOffset(ped0, ped1, waypointRecording, p3, p4, p5, p6, p7, p8) end
+
+-- TASK_FOLLOW_ENTITY_WHILE_AIMING_AT_ENTITY  (0x2D532EAA142CF83F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function TaskFollowEntityWhileAimingAtEntity(ped, p1, p2, p3, p4, p5, p6, p7) end
+
+-- TASK_FOLLOW_NAV_MESH_TO_COORD  (0x15D3A79D4E44B913)
+-- If no timeout, set timeout to -1.
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param speedMultiplier number
+---@param timeout number
+---@param stoppingRange number
+---@param flags number
+---@param heading number
+function TaskFollowNavMeshToCoord(ped, x, y, z, speedMultiplier, timeout, stoppingRange, flags, heading) end
+
+-- TASK_FOLLOW_NAV_MESH_TO_COORD_ADVANCED  (0x17F58B88D085DBAC)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param speedMultiplier number
+---@param timeout number
+---@param stoppingRange number
+---@param flags number
+---@param p8 number
+---@param p9 number
+---@param p10 number
+---@param entity number
+---@param unk number
+function TaskFollowNavMeshToCoordAdvanced(ped, x, y, z, speedMultiplier, timeout, stoppingRange, flags, p8, p9, p10, entity, unk) end
+
+-- TASK_FOLLOW_PAVEMENT_TO_COORD  (0x1B1475414E70DD8E)
+-- min build: 1207
+---@param ped number
+---@return any
+function TaskFollowPavementToCoord(ped) end
+
+-- TASK_FOLLOW_POINT_ROUTE  (0x0E14C5550DC3CD1D)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function TaskFollowPointRoute(ped, p1, p2, p3, p4, p5) end
+
+-- TASK_FOLLOW_TO_OFFSET_OF_COORD  (0x2E3676282C18A692)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+function TaskFollowToOffsetOfCoord(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- TASK_FOLLOW_TO_OFFSET_OF_ENTITY  (0x304AE42E357B8C7E)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param offsetX number
+---@param offsetY number
+---@param offsetZ number
+---@param movementSpeed number
+---@param timeout number
+---@param stoppingRange number
+---@param persistFollowing boolean
+---@param p9 boolean
+---@param walkOnly boolean
+---@param p11 boolean
+---@param p12 boolean
+---@param p13 boolean
+function TaskFollowToOffsetOfEntity(ped, entity, offsetX, offsetY, offsetZ, movementSpeed, timeout, stoppingRange, persistFollowing, p9, walkOnly, p11, p12, p13) end
+
+-- TASK_FOLLOW_WAYPOINT_RECORDING  (0x0759591819534F7B)
+-- Follow a loaded waypoint recording. startIndex/endIndex bound the segment; patrol makes it loop back-and-forth; aimWeapon sets aiming stance; durationMs=-1 for natural pacing, otherwise caps time (snaps to end on expiry).
+-- min build: 1207
+---@param ped number
+---@param waypointRecording string
+---@param startIndex number
+---@param flags number
+---@param endIndex number
+---@param patrol boolean
+---@param aimWeapon boolean
+---@param durationMs number
+function TaskFollowWaypointRecording(ped, waypointRecording, startIndex, flags, endIndex, patrol, aimWeapon, durationMs) end
+
+-- TASK_FOLLOW_WAYPOINT_RECORDING_ADVANCED  (0x0CFC13EBC19BCA52)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function TaskFollowWaypointRecordingAdvanced(ped, p1) end
+
+-- TASK_FOLLOW_WAYPOINT_RECORDING_AT_OFFSET  (0xBE9B0520BD7C445B)
+-- min build: 1207
+---@param ped number
+---@param waypointRecording string
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 boolean
+function TaskFollowWaypointRecordingAtOffset(ped, waypointRecording, p2, p3, p4, p5, p6) end
+
+-- TASK_FORCE_MOTION_STATE  (0x4F056E1AFFEF17AB)
+-- motionStateHash: see FORCE_PED_MOTION_STATE
+-- min build: 1207
+---@param ped number
+---@param motionStateHash number
+---@param p2 boolean
+function TaskForceMotionState(ped, motionStateHash, p2) end
+
+-- TASK_GO_STRAIGHT_TO_COORD  (0xD76B57B44F1E6F8B)
+-- Go to coords wihtout using navmesh, if timeBeforeTeleport is -1 then it never teleports p8 is 1 or 0 still unknown.
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param moveBlendSpeedY number
+---@param timeBeforeTeleport number
+---@param finalHeading number
+---@param targetRadius number
+---@param p8 number
+function TaskGoStraightToCoord(ped, x, y, z, moveBlendSpeedY, timeBeforeTeleport, finalHeading, targetRadius, p8) end
+
+-- TASK_GO_STRAIGHT_TO_COORD_RELATIVE_TO_ENTITY  (0x61E360B7E040D12E)
+-- Go to coords relative to entity wihtout using navmesh, if timeBeforeTeleport is -1 then it never teleports; p7 is 1 or 0 still unknown.
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param moveBlendRatio number
+---@param timeBeforeTeleport number
+---@param p7 number
+function TaskGoStraightToCoordRelativeToEntity(ped, entity, xOffset, yOffset, zOffset, moveBlendRatio, timeBeforeTeleport, p7) end
+
+-- TASK_GO_TO_COORD_AND_AIM_AT_HATED_ENTITIES_NEAR_COORD  (0xA55547801EB331FC)
+-- min build: 1207
+---@param ped number
+---@param goToLocationX number
+---@param goToLocationY number
+---@param goToLocationZ number
+---@param focusLocationX number
+---@param focusLocationY number
+---@param focusLocationZ number
+---@param speed number
+---@param shootAtEnemies boolean
+---@param distanceToStopAt number
+---@param noRoadsDistance number
+---@param unkTrue boolean
+---@param unkFlag number
+---@param aimingFlag number
+---@param firingPattern number
+function TaskGoToCoordAndAimAtHatedEntitiesNearCoord(ped, goToLocationX, goToLocationY, goToLocationZ, focusLocationX, focusLocationY, focusLocationZ, speed, shootAtEnemies, distanceToStopAt, noRoadsDistance, unkTrue, unkFlag, aimingFlag, firingPattern) end
+
+-- TASK_GO_TO_COORD_AND_AIM_AT_HATED_ENTITIES_NEAR_COORD_USING_COMBAT_STYLE  (0x87BD711FC31EA273)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+function TaskGoToCoordAndAimAtHatedEntitiesNearCoordUsingCombatStyle(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- TASK_GO_TO_COORD_ANY_MEANS  (0x5BC448CB78FA3E88)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param speed number
+---@param entity number
+---@param p6 boolean
+---@param walkingStyle number
+---@param p8 number
+function TaskGoToCoordAnyMeans(ped, x, y, z, speed, entity, p6, walkingStyle, p8) end
+
+-- TASK_GO_TO_COORD_ANY_MEANS_EXTRA_PARAMS  (0x1DD45F9ECFDB1BC9)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param speed number
+---@param p5 any
+---@param p6 boolean
+---@param walkingStyle number
+---@param p8 number
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+function TaskGoToCoordAnyMeansExtraParams(ped, x, y, z, speed, p5, p6, walkingStyle, p8, p9, p10, p11, p12) end
+
+-- TASK_GO_TO_COORD_ANY_MEANS_EXTRA_PARAMS_WITH_CRUISE_SPEED  (0xB8ECD61F531A7B02)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+function TaskGoToCoordAnyMeansExtraParamsWithCruiseSpeed(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- TASK_GO_TO_COORD_WHILE_AIMING_AT_COORD  (0x11315AB3385B8AC0)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+---@param p15 any
+function TaskGoToCoordWhileAimingAtCoord(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) end
+
+-- TASK_GO_TO_COORD_WHILE_AIMING_AT_COORD_USING_COMBAT_STYLE  (0x639C0425A0B4E77E)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+---@param p15 any
+function TaskGoToCoordWhileAimingAtCoordUsingCombatStyle(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) end
+
+-- TASK_GO_TO_COORD_WHILE_AIMING_AT_ENTITY  (0xB2A16444EAD9AE47)
+-- min build: 1207
+---@param ped1 number
+---@param x number
+---@param y number
+---@param z number
+---@param ped2 number
+---@param p5 number
+---@param p6 any
+---@param p7 number
+---@param p8 number
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param firingPattern number
+---@param p13 number
+---@param p14 any
+function TaskGoToCoordWhileAimingAtEntity(ped1, x, y, z, ped2, p5, p6, p7, p8, p9, p10, p11, firingPattern, p13, p14) end
+
+-- TASK_GO_TO_COORD_WHILE_AIMING_AT_ENTITY_USING_COMBAT_STYLE  (0x78426D0982D083C9)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+function TaskGoToCoordWhileAimingAtEntityUsingCombatStyle(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- TASK_GO_TO_ENTITY  (0x6A071245EB0D1882)
+-- min build: 1207
+---@param ped number
+---@param target number
+---@param duration number
+---@param distance number
+---@param speed number
+---@param p5 number
+---@param p6 number
+function TaskGoToEntity(ped, target, duration, distance, speed, p5, p6) end
+
+-- TASK_GO_TO_ENTITY_WHILE_AIMING_AT_ENTITY  (0x97465886D35210E9)
+-- shootatEntity:
+-- If true, peds will shoot at Entity till it is dead.
+-- If false, peds will just walk till they reach the entity and will cease shooting.
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function TaskGoToEntityWhileAimingAtEntity(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- TASK_GO_TO_ENTITY_WHILE_AIMING_AT_ENTITY_USING_COMBAT_STYLE  (0xCEF0117C233026AD)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function TaskGoToEntityWhileAimingAtEntityUsingCombatStyle(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- TASK_GO_TO_WHISTLE  (0xBAD6545608CECA6E)
+-- enum eWhistleType
+-- {
+-- 	WHISTLE_MAIN,
+-- 	WHISTLE_SECONDARY,
+-- 	WHISTLE_DOUBLE,
+-- 	WHISTLE_URGENT,
+-- 	WHISTLE_LONG
+-- };
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param whistleType number
+function TaskGoToWhistle(ped, p1, whistleType) end
+
+-- TASK_GOTO_ENTITY_AIMING  (0xA9DA48FAB8A76C12)
+-- ped = Ped you want to perform this task.
+-- target = the Entity they should aim at.
+-- distanceToStopAt = distance from the target, where the ped should stop to aim.
+-- StartAimingDist = distance where the ped should start to aim.
+-- min build: 1207
+---@param ped number
+---@param target number
+---@param distanceToStopAt number
+---@param StartAimingDist number
+function TaskGotoEntityAiming(ped, target, distanceToStopAt, StartAimingDist) end
+
+-- TASK_GOTO_ENTITY_OFFSET  (0xE39B4FF4FDEBDE27)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param p2 any
+---@param x number
+---@param y number
+---@param z number
+---@param duration number
+function TaskGotoEntityOffset(ped, entity, p2, x, y, z, duration) end
+
+-- TASK_GOTO_ENTITY_OFFSET_XY  (0x338E7EF52B6095A9)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param duration number
+---@param targetRadius number
+---@param xOffset number
+---@param yOffset number
+---@param moveBlendRatio number
+---@param offsetFlags number
+function TaskGotoEntityOffsetXy(ped, entity, duration, targetRadius, xOffset, yOffset, moveBlendRatio, offsetFlags) end
+
+-- TASK_GOTO_ENTITY_OFFSET_XY_AIMING  (0x901BD69984400F62)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function TaskGotoEntityOffsetXyAiming(ped, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- TASK_GOTO_ENTITY_OFFSET_XYZ  (0xFA6DA9D151769392)
+-- min build: 1311
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function TaskGotoEntityOffsetXyz(ped, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- TASK_GOTO_ENTITY_OFFSET_XYZ_AIMING  (0x41B0832CA96B5351)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function TaskGotoEntityOffsetXyzAiming(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- TASK_GRAPPLE  (0x779A2FFACEFAEA7B)
+-- grappleStyle: AR_GRAPPLE_MOUNT_STANDING_FROM_FRONT, AR_GRAPPLE_MOUNT_STANDING_FROM_RIGHT, AR_GRAPPLE_MOUNT_STANDING_FROM_BACK, AR_GRAPPLE_MOUNT_STANDING_FROM_LEFT, AR_GRAPPLE_MOUNT_FROM_FRONT, AR_WOLF_EXECUTION_ENTER_FROM_BACK, AR_GRAPPLE_DRAG_FRONT_ON_ASS, AR_GRAPPLE_FRONT_FROM_LEFT_FAR, AR_BEAR_CHALLENGE_FRONT, AR_GRAPPLE_FRONT_FROM_FRONT, AR_GRAPPLE_MOUNT_FACEUP_FROM_FRONT
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param grappleStyle number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@return boolean
+function TaskGrapple(ped, targetPed, grappleStyle, p3, p4, p5, p6) end
+
+-- TASK_GUARD  (0xB9FB242EACCAF30F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskGuard(ped, p1, p2) end
+
+-- TASK_GUARD_ASSIGNED_DEFENSIVE_AREA  (0xD2A207EEBDF9889B)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 any
+function TaskGuardAssignedDefensiveArea(ped, p1, p2, p3, p4, p5, p6) end
+
+-- TASK_GUARD_CURRENT_POSITION  (0x4A58A47A72E3FCB4)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 boolean
+function TaskGuardCurrentPosition(ped, p1, p2, p3) end
+
+-- TASK_HANDS_UP  (0xF2EAB31979A7F910)
+-- flags: 0 = HANDS_UP_NOTHING; 1 = HANDS_UP_STRAIGHT_TO_LOOP
+-- min build: 1207
+---@param ped number
+---@param duration number
+---@param facingPed number
+---@param timeToFacePed number
+---@param flags number
+function TaskHandsUp(ped, duration, facingPed, timeToFacePed, flags) end
+
+-- TASK_HITCH_ANIMAL  (0x9030AD4B6207BFE8)
+-- min build: 1207
+---@param ped number
+---@param scenarioPoint number
+---@param flag number
+function TaskHitchAnimal(ped, scenarioPoint, flag) end
+
+-- TASK_HOGTIE_TARGET_PED  (0x27829AFD3E03AC1A)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+function TaskHogtieTargetPed(ped, targetPed) end
+
+-- TASK_HOGTIEABLE  (0x6AFD8FE0D723328F)
+-- min build: 1207
+---@param ped number
+function TaskHogtieable(ped) end
+
+-- TASK_HORSE_ACTION  (0xA09CFD29100F06C3)
+-- https://github.com/femga/rdr3_discoveries/tree/master/tasks/TASK_HORSE_ACTION
+-- Params: p2, p3 are set to 0 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param action number
+---@param targetPed number
+---@param p3 any
+function TaskHorseAction(ped, action, targetPed, p3) end
+
+-- TASK_INVESTIGATE  (0x5C8514540D27FBFB)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function TaskInvestigate(ped, p1, p2, p3, p4, p5) end
+
+-- TASK_JUMP  (0x0AE4086104E067B1)
+-- min build: 1207
+---@param ped number
+---@param unused boolean
+function TaskJump(ped, unused) end
+
+-- TASK_KNOCKED_OUT  (0xF90427F00A495A28)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param permanently boolean
+function TaskKnockedOut(ped, p1, permanently) end
+
+-- TASK_KNOCKED_OUT_AND_HOGTIED  (0x42AC6401ABB8C7E5)
+-- koTimeOffset (seconds): offset applied to the knockout timer-positive delays recovery (longer KO), negative brings recovery sooner, 0.0 initializes with no extension (immediate baseline).
+-- flags (bitmask): 1 = default variant (forwarded to the KO task ctor; R* commonly uses 1), 2 = sets an unk internal synced toggle for this task, 4 = sets another unk internal synced toggle.
+-- min build: 1207
+---@param ped number
+---@param koTimeOffset number
+---@param flags number
+function TaskKnockedOutAndHogtied(ped, koTimeOffset, flags) end
+
+-- TASK_LASSO_PED  (0xC716EB2BD16370A3)
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+function TaskLassoPed(ped, targetPed) end
+
+-- TASK_LEAD_AND_CONVERSE  (0xAA19711D33C6708C)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function TaskLeadAndConverse(ped, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- TASK_LEAD_HORSE  (0x9A7A4A54596FE09D)
+-- min build: 1207
+---@param ped number
+---@param horse number
+function TaskLeadHorse(ped, horse) end
+
+-- TASK_LEAVE_ANY_VEHICLE  (0x504D54DF3F6F2247)
+-- flags: See TASK_ENTER_VEHICLE
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param taskFlag number
+function TaskLeaveAnyVehicle(ped, p1, taskFlag) end
+
+-- TASK_LEAVE_VEHICLE  (0xD3DBCE61A490BE02)
+-- flags: See TASK_ENTER_VEHICLE
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param flags number
+---@param unkPed number
+function TaskLeaveVehicle(ped, vehicle, flags, unkPed) end
+
+-- TASK_LOOK_AT_COORD  (0x6FA46612594F7973)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param duration number
+---@param flags number
+---@param p6 number
+---@param p7 boolean
+function TaskLookAtCoord(ped, x, y, z, duration, flags, p6, p7) end
+
+-- TASK_LOOK_AT_ENTITY  (0x69F4BE8C8CC4796C)
+-- param3: duration in ms, use -1 to look forever
+-- param4: using 2048 is fine
+-- param5: using 3 is fine
+-- min build: 1207
+---@param ped number
+---@param lookAtTarget number
+---@param duration number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+function TaskLookAtEntity(ped, lookAtTarget, duration, p3, p4, p5) end
+
+-- TASK_LOOT_ENTITY  (0x48FAE038401A2888)
+-- min build: 1207
+---@param ped number
+---@param entity number
+function TaskLootEntity(ped, entity) end
+
+-- TASK_LOOT_NEAREST_ENTITY  (0xCF1501CBC4059412)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+---@param p5 number
+function TaskLootNearestEntity(ped, x, y, z, p4, p5) end
+
+-- TASK_MELEE  (0x482C99D0B38D1B0A)
+-- Params: p2: AR_TAKEDOWN_FRONT, AR_EXECUTION_FRONT, 0 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param targetPed number
+---@param p2 number
+---@param p3 any
+---@param p4 any
+---@param p5 number
+---@param p6 any
+---@param p7 number
+---@return boolean
+function TaskMelee(ped, targetPed, p2, p3, p4, p5, p6, p7) end
+
+-- TASK_MOUNT_ANIMAL  (0x92DB0739813C5186)
+-- timer: in ms, if it reaches 0 it will auto warp the ped on the horse
+-- mountStyle: See TASK_ENTER_VEHICLE
+-- Flags will still apply to mountStyle
+-- min build: 1207
+---@param ped number
+---@param mount number
+---@param timer number
+---@param seatIndex number
+---@param pedSpeed number
+---@param mountStyle number
+---@param p6 any
+---@param p7 any
+function TaskMountAnimal(ped, mount, timer, seatIndex, pedSpeed, mountStyle, p6, p7) end
+
+-- TASK_MOVE_BE_IN_FORMATION  (0x4AA5AA97C65E4A2F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 any
+function TaskMoveBeInFormation(ped, p1, p2, p3, p4, p5, p6) end
+
+-- TASK_MOVE_FOLLOW_ROAD_USING_NAVMESH  (0x79482C12482A860D)
+-- Params: moveBlendRatio commonly 1.25f, p5 is always 0 in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param moveBlendRatio number
+---@param x number
+---@param y number
+---@param z number
+---@param p5 any
+function TaskMoveFollowRoadUsingNavmesh(ped, moveBlendRatio, x, y, z, p5) end
+
+-- TASK_MOVE_IN_TRAFFIC  (0x8AA1593AEC087A29)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 any
+---@param p3 any
+function TaskMoveInTraffic(ped, p1, p2, p3) end
+
+-- TASK_MOVE_IN_TRAFFIC_AWAY_FROM_ENTITY  (0x13DED0BC45600FE1)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function TaskMoveInTrafficAwayFromEntity(ped, p1, p2, p3, p4) end
+
+-- TASK_MOVE_IN_TRAFFIC_TO_DESTINATION  (0xDCA3A13F7A45338B)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function TaskMoveInTrafficToDestination(ped, p1, p2, p3, p4, p5, p6, p7) end
+
+-- TASK_MOVE_NETWORK_ADVANCED_BY_NAME_WITH_INIT_PARAMS  (0x7B6A04F98BBAFB2C)
+-- min build: 1207
+---@param ped number
+---@param moveNetworkDefName string
+---@param xPos number
+---@param yPos number
+---@param zPos number
+---@param xRot number
+---@param yRot number
+---@param zRot number
+---@param p9 number
+---@param p10 number
+---@param p11 number
+---@param p12 number
+---@param flag number
+---@param p14 number
+---@return any
+function TaskMoveNetworkAdvancedByNameWithInitParams(ped, moveNetworkDefName, xPos, yPos, zPos, xRot, yRot, zRot, p9, p10, p11, p12, flag, p14) end
+
+-- TASK_MOVE_NETWORK_ADVANCED_BY_NAME_WITH_INIT_PARAMS_ATTACHED  (0xF92171093BCABED4)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+---@param p15 any
+---@param p16 any
+---@param p17 any
+function TaskMoveNetworkAdvancedByNameWithInitParamsAttached(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) end
+
+-- TASK_MOVE_NETWORK_BY_NAME  (0x2D537BA194896636)
+-- min build: 1207
+---@param ped number
+---@param task string
+---@param multiplier number
+---@param p3 boolean
+---@param animDict string
+---@param flags number
+function TaskMoveNetworkByName(ped, task, multiplier, p3, animDict, flags) end
+
+-- TASK_MOVE_NETWORK_BY_NAME_WITH_INIT_PARAMS  (0x139805C2A67C4795)
+-- min build: 1207
+---@param ped number
+---@param moveNetworkDefName string
+---@param p3 number
+---@param p4 boolean
+---@param animDict string
+---@param flags number
+---@return any
+function TaskMoveNetworkByNameWithInitParams(ped, moveNetworkDefName, p3, p4, animDict, flags) end
+
+-- TASK_PATROL  (0xBDA5DF49D080FE4E)
+-- min build: 1207
+---@param ped number
+---@param patrolRoute string
+---@param p2 any
+---@param p3 boolean
+---@param p4 boolean
+function TaskPatrol(ped, patrolRoute, p2, p3, p4) end
+
+-- TASK_PAUSE  (0xE73A266DB0CA9042)
+-- This tasks the ped to do nothing for the specified amount of milliseconds.
+-- This is useful if you want to add a delay between tasks when using a sequence task.
+-- min build: 1207
+---@param ped number
+---@param ms number
+function TaskPause(ped, ms) end
+
+-- TASK_PED_SLIDE_TO_COORD  (0xD04FE6765D990A06)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param p5 number
+function TaskPedSlideToCoord(ped, x, y, z, heading, p5) end
+
+-- TASK_PERFORM_SEQUENCE  (0x5ABA3986D90D8A3B)
+-- min build: 1207
+---@param ped number
+---@param taskSequenceId number
+function TaskPerformSequence(ped, taskSequenceId) end
+
+-- TASK_PERFORM_SEQUENCE_FROM_PROGRESS  (0x89221B16730234F0)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function TaskPerformSequenceFromProgress(ped, p1, p2, p3) end
+
+-- TASK_PERSISTENT_CHARACTER  (0x4391700CBD89C3D8)
+-- min build: 1207
+---@param ped number
+function TaskPersistentCharacter(ped) end
+
+-- TASK_PICK_UP_WEAPON  (0x55B0ECFD98596624)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function TaskPickUpWeapon(ped, p1) end
+
+-- TASK_PICKUP_CARRIABLE_ENTITY  (0x502EC17B1BED4BFA)
+-- min build: 1207
+---@param ped number
+---@param entity number
+function TaskPickupCarriableEntity(ped, entity) end
+
+-- TASK_PLACE_CARRIED_ENTITY_AT_COORD  (0xC7F0B43DCDC57E3D)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param x number
+---@param y number
+---@param z number
+---@param p5 number
+---@param flags number
+function TaskPlaceCarriedEntityAtCoord(ped, entity, x, y, z, p5, flags) end
+
+-- TASK_PLACE_CARRIED_ENTITY_ON_MOUNT  (0x6D3D87C57B3D52C7)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param mount number
+---@param p3 number
+function TaskPlaceCarriedEntityOnMount(ped, entity, mount, p3) end
+
+-- TASK_PLANT_BOMB  (0x965FEC691D55E9BF)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+function TaskPlantBomb(ped, x, y, z, heading) end
+
+-- TASK_PLAY_ANIM  (0xEA47FE3719165B94)
+-- https://github.com/femga/rdr3_discoveries/tree/master/animations
+-- flags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eScriptedAnimFlags
+-- ikFlags: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eIkControlFlags
+-- min build: 1207
+---@param ped number
+---@param animDict string
+---@param animName string
+---@param speed number
+---@param speedMultiplier number
+---@param duration number
+---@param flags number
+---@param playbackRate number
+---@param p8 boolean
+---@param ikFlags number
+---@param p10 boolean
+---@param taskFilter string
+---@param p12 boolean
+function TaskPlayAnim(ped, animDict, animName, speed, speedMultiplier, duration, flags, playbackRate, p8, ikFlags, p10, taskFilter, p12) end
+
+-- TASK_PLAY_ANIM_ADVANCED  (0x83CDB10EA29B370B)
+-- flags: see TASK_PLAY_ANIM
+-- ikFlags: see TASK_PLAY_ANIM
+-- min build: 1207
+---@param ped number
+---@param animDict string
+---@param animName string
+---@param posX number
+---@param posY number
+---@param posZ number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param speed number
+---@param speedMultiplier number
+---@param duration number
+---@param flags number
+---@param p13 number
+---@param p14 number
+---@param p15 number
+---@param p16 number
+function TaskPlayAnimAdvanced(ped, animDict, animName, posX, posY, posZ, rotX, rotY, rotZ, speed, speedMultiplier, duration, flags, p13, p14, p15, p16) end
+
+-- TASK_PLAY_EMOTE_WITH_HASH  (0xB31A277C1AC7B7FF)
+-- https://github.com/femga/rdr3_discoveries/blob/master/animations/kit_emotes_list.lua
+-- emote: https://alloc8or.re/rdr3/doc/enums/eEmote.txt
+-- 
+-- enum eEmoteType
+-- {
+-- 	EMOTE_TYPE_INVALID = -1,
+-- 	EMOTE_TYPE_REACT,
+-- 	EMOTE_TYPE_ACTION,
+-- 	EMOTE_TYPE_TAUNT,
+-- 	EMOTE_TYPE_GREET,
+-- 	EMOTE_TYPE_TWIRL_GUN,
+-- 	EMOTE_TYPE_DANCE_FLOOR
+-- };
+-- 
+-- enum eEmotePlaybackMode
+-- {
+-- 	EMOTE_PM_INVALID = -1,
+-- 	EMOTE_PM_UPPERBODY,
+-- 	EMOTE_PM_UPPERBODY_LOOP,
+-- 	EMOTE_PM_FULLBODY,
+-- };
+-- min build: 1207
+---@param ped number
+---@param emoteType number
+---@param playbackMode number
+---@param emote number
+---@param isSecondaryTask boolean
+---@param canBreakOut boolean
+---@param disableEarlyOutAnimTag boolean
+---@param ignoreInvalidMainTask boolean
+---@param destroyProps boolean
+function TaskPlayEmoteWithHash(ped, emoteType, playbackMode, emote, isSecondaryTask, canBreakOut, disableEarlyOutAnimTag, ignoreInvalidMainTask, destroyProps) end
+
+-- TASK_PLAY_UPPER_ANIM_FACING_ENTITY  (0xAD67214236AB1CFE)
+-- min build: 1207
+---@param ped number
+---@param animDict string
+---@param animName string
+---@param entity number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 boolean
+---@param p10 boolean
+---@param p11 number
+---@param p12 string
+---@param p13 number
+---@param p14 number
+function TaskPlayUpperAnimFacingEntity(ped, animDict, animName, entity, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- TASK_POLICE  (0x87BE56724650408E)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function TaskPolice(ped, p1) end
+
+-- TASK_PUT_PED_DIRECTLY_INTO_COVER  (0x4172393E6BE1FECE)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param timeout number
+---@param p5 boolean
+---@param p6 number
+---@param p7 any
+---@param p8 any
+---@param coverpoint number
+---@param p10 boolean
+---@param p11 boolean
+---@param p12 any
+function TaskPutPedDirectlyIntoCover(ped, x, y, z, timeout, p5, p6, p7, p8, coverpoint, p10, p11, p12) end
+
+-- TASK_PUT_PED_DIRECTLY_INTO_GRAPPLE  (0xA05F3F20889D7A5B)
+-- grappleStyle: AR_GRAPPLE_STRUGGLE, AR_ALLIGATOR_LEG_GRAB_CHALLENGE_FAIL, AR_GRAPPLE_BACK_FROM_BACK, AR_GRAPPLE_BACK_DEFEND, AR_GRAPPLE_FRONT_FROM_FRONT
+-- min build: 1207
+---@param ped number
+---@param grappleTarget number
+---@param grappleStyle number
+---@param p3 number
+---@param p4 number
+---@param p5 boolean
+---@param p6 number
+function TaskPutPedDirectlyIntoGrapple(ped, grappleTarget, grappleStyle, p3, p4, p5, p6) end
+
+-- TASK_PUT_PED_DIRECTLY_INTO_MELEE  (0x1C6CD14A876FFE39)
+-- meleeStyles: AR_GRAPPLE_BACK_FROM_BACK, AR_GRAPPLE_MOUNT_FACEDOWN_FROM_FRONT, AR_ALLIGATOR_LEAPKILL, AR_ALLIGATOR_WAIST_AUTOKILL_FRONT
+-- min build: 1207
+---@param ped number
+---@param meleeTarget number
+---@param meleeStyle number
+---@param p3 number
+---@param animBlendRatio number
+---@param p5 boolean
+---@param p6 number
+function TaskPutPedDirectlyIntoMelee(ped, meleeTarget, meleeStyle, p3, animBlendRatio, p5, p6) end
+
+-- TASK_REACT  (0xC4C32C31920E1B70)
+-- Makes a ped react to an entity.
+-- Params: reactingTo Entity can be 0, p8 is always 4
+-- min build: 1207
+---@param ped number
+---@param reactingTo number
+---@param x number
+---@param y number
+---@param z number
+---@param reactionName string
+---@param p6 number
+---@param p7 number
+---@param p8 number
+function TaskReact(ped, reactingTo, x, y, z, reactionName, p6, p7, p8) end
+
+-- TASK_RELOAD_WEAPON  (0x62D2916F56B9CD2D)
+-- min build: 1207
+---@param ped number
+---@param unused boolean
+function TaskReloadWeapon(ped, unused) end
+
+-- TASK_REVIVE_TARGET  (0x356088527D9EBAAD)
+-- min build: 1207
+---@param ped number
+---@param reviver number
+---@param tool number
+function TaskReviveTarget(ped, reviver, tool) end
+
+-- TASK_RIDE_TRAIN  (0x37FB1C870E2EC2C6)
+-- min build: 1207
+---@param ped number
+---@param train number
+---@param scenarioPoint number
+---@param scenarioHash number
+function TaskRideTrain(ped, train, scenarioPoint, scenarioHash) end
+
+-- TASK_ROB_PED  (0x7BB967F85D8CCBDB)
+-- min build: 1207
+---@param ped number
+---@param target number
+---@param p2 number
+---@param flag number
+---@param p4 number
+function TaskRobPed(ped, target, p2, flag, p4) end
+
+-- TASK_SCRIPTED_ANIMATION  (0x126EF75F1E17ABE5)
+-- min build: 1207
+---@param ped number
+---@return any
+function TaskScriptedAnimation(ped) end
+
+-- TASK_SEEK_CLEAR_LOS_TO_ENTITY  (0x8D7F2A63688C20A4)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function TaskSeekClearLosToEntity(ped, entity, p2, p3, p4) end
+
+-- TASK_SEEK_COVER_FROM_PED  (0x84D32B3BEC531324)
+-- min build: 1207
+---@param ped number
+---@param fromPed number
+---@param duration number
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function TaskSeekCoverFromPed(ped, fromPed, duration, p3, p4, p5) end
+
+-- TASK_SEEK_COVER_FROM_POS  (0x75AC2B60386D89F2)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param duration number
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function TaskSeekCoverFromPos(ped, x, y, z, duration, p5, p6, p7) end
+
+-- TASK_SEEK_COVER_TO_COORDS  (0x39246A6958EF072C)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function TaskSeekCoverToCoords(ped, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- TASK_SEEK_COVER_TO_COVER_POINT  (0xD43D95C7A869447F)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function TaskSeekCoverToCoverPoint(ped, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- TASK_SET_BLOCKING_OF_NON_TEMPORARY_EVENTS  (0x90D2156198831D69)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function TaskSetBlockingOfNonTemporaryEvents(ped, toggle) end
+
+-- TASK_SET_CROUCH_MOVEMENT  (0x17293C633C8AC019)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 any
+---@param p3 boolean
+function TaskSetCrouchMovement(ped, p1, p2, p3) end
+
+-- TASK_SET_SPHERE_DEFENSIVE_AREA  (0x933C06518B52A9A4)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function TaskSetSphereDefensiveArea(ped, p1, p2, p3, p4) end
+
+-- TASK_SET_STEALTH_MOVEMENT  (0x4C3FA937B44A90FA)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 any
+---@param p3 boolean
+function TaskSetStealthMovement(ped, p1, p2, p3) end
+
+-- TASK_SHOCKING_EVENT_REACT  (0x452419CBD838065B)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+function TaskShockingEventReact(ped, p1, p2) end
+
+-- TASK_SHOOT_AT_COORD  (0x46A6CC01E0826106)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param duration number
+---@param firingPattern number
+---@param p6 any
+function TaskShootAtCoord(ped, x, y, z, duration, firingPattern, p6) end
+
+-- TASK_SHOOT_AT_ENTITY  (0x08DA95E8298AE772)
+-- min build: 1207
+---@param entity number
+---@param targetEntity number
+---@param duration number
+---@param firingPattern number
+---@param affectCockedState boolean
+function TaskShootAtEntity(entity, targetEntity, duration, firingPattern, affectCockedState) end
+
+-- TASK_SHOOT_WITH_WEAPON  (0x08AA95E8298AE772)
+-- min build: 1207
+---@param ped number
+---@return any
+function TaskShootWithWeapon(ped) end
+
+-- TASK_SHUFFLE_TO_NEXT_VEHICLE_SEAT  (0x7AA80209BDA643EB)
+-- Makes the specified ped shuffle to the next vehicle seat.
+-- The ped MUST be in a vehicle and the vehicle parameter MUST be the ped's current vehicle.
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+function TaskShuffleToNextVehicleSeat(ped, vehicle) end
+
+-- TASK_SMART_FLEE_COORD  (0x94587F17E9C365D5)
+-- Makes the specified ped flee the specified distance from the specified position.
+-- fleeType: see TASK_FLEE_COORD
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param time number
+---@param fleeType number
+---@param fleeSpeed number
+function TaskSmartFleeCoord(ped, x, y, z, distance, time, fleeType, fleeSpeed) end
+
+-- TASK_SMART_FLEE_PED  (0x22B0D0E37CCB840D)
+-- Makes a ped run away from another ped (fleeFromTarget)
+-- 
+-- fleeDistance = ped will flee this distance
+-- fleeTime = ped will flee for this amount of time, set to "-1" to flee forever
+-- fleeType = see TASK_FLEE_COORD, can be 0, R* Scripts: fm_mission/race_controller: 66048; fme_escaped_convicts: 2260992, 2523136, 2359296; la_alligator/fox: 2097152; net_fetch: 17301536; net_stable_mount: 540928
+-- fleeSpeed = mostly 3f, rarely 1f in R* Scripts
+-- min build: 1207
+---@param ped number
+---@param fleeFromTarget number
+---@param fleeDistance number
+---@param fleeTime number
+---@param fleeType number
+---@param fleeSpeed number
+---@param targetPed number
+function TaskSmartFleePed(ped, fleeFromTarget, fleeDistance, fleeTime, fleeType, fleeSpeed, targetPed) end
+
+-- TASK_STAND_GUARD  (0xAE032F8BBA959E90)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param scenarioName string
+function TaskStandGuard(ped, x, y, z, heading, scenarioName) end
+
+-- TASK_STAND_STILL  (0x919BE13EED931959)
+-- Makes the specified ped stand still for (time) milliseconds.
+-- min build: 1207
+---@param ped number
+---@param time number
+function TaskStandStill(ped, time) end
+
+-- TASK_START_SCENARIO_AT_POSITION  (0x4D1F61FC34AF3CD1)
+-- min build: 1207
+---@param ped number
+---@param scenarioHash number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param duration number
+---@param sittingScenario boolean
+---@param teleport boolean
+---@param p9 string
+---@param p10 number
+---@param p11 boolean
+function TaskStartScenarioAtPosition(ped, scenarioHash, x, y, z, heading, duration, sittingScenario, teleport, p9, p10, p11) end
+
+-- TASK_START_SCENARIO_IN_PLACE_HASH  (0x524B54361229154F)
+-- https://github.com/femga/rdr3_discoveries/blob/master/animations/scenarios
+-- Params: duration in milliseconds
+-- 
+-- conditionalHash (optionally):
+-- 0 = play random conditional anim.
+-- Every conditional anim has requirements to play it.
+-- If requirements are not met, ped plays random allowed conditional anim or can be stuck.
+-- For example, this scenario type has possible conditional anim WORLD_HUMAN_LEAN_BACK_WALL_SMOKING_MALE_D, but it can not be played by player, because condition is set to NOT be CAIConditionIsPlayer (check file amb_rest.meta and amb_rest_CA.meta with OPENIV to clarify requirements).
+-- min build: 1207
+---@param ped number
+---@param scenarioHash number
+---@param duration number
+---@param playEnterAnim boolean
+---@param conditionalHash number
+---@param heading number
+---@param p6 boolean
+function TaskStartScenarioInPlaceHash(ped, scenarioHash, duration, playEnterAnim, conditionalHash, heading, p6) end
+
+-- TASK_STAY_IN_COVER  (0xE5DA8615A6180789)
+-- Makes the ped run to take cover
+-- min build: 1207
+---@param ped number
+function TaskStayInCover(ped) end
+
+-- TASK_STOP_LEADING_HORSE  (0xED27560703F37258)
+-- min build: 1207
+---@param ped number
+function TaskStopLeadingHorse(ped) end
+
+-- TASK_SWAP_FISHING_BAIT  (0x2C28AC30A72722DA)
+-- Baits: see 0x9B0C7FA063E67629
+-- min build: 1207
+---@param ped number
+---@param bait string
+---@param withoutBuoy boolean
+function TaskSwapFishingBait(ped, bait, withoutBuoy) end
+
+-- TASK_SWAP_WEAPON  (0xA21C51255B205245)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function TaskSwapWeapon(ped, p1, p2, p3, p4) end
+
+-- TASK_THROW_PROJECTILE  (0x7285951DBF6B5A51)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function TaskThrowProjectile(ped, p1, p2, p3) end
+
+-- TASK_TURN_PED_TO_FACE_COORD  (0x1DDA930A0AC38571)
+-- duration in milliseconds
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param duration number
+function TaskTurnPedToFaceCoord(ped, x, y, z, duration) end
+
+-- TASK_TURN_PED_TO_FACE_ENTITY  (0x5AD23D40115353AC)
+-- duration: the amount of time in milliseconds to do the task. -1 will keep the task going until either another task is applied, or CLEAR_ALL_TASKS() is called with the ped
+-- min build: 1207
+---@param ped number
+---@param targetEntity number
+---@param duration number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+function TaskTurnPedToFaceEntity(ped, targetEntity, duration, p3, p4, p5) end
+
+-- TASK_TURN_TO_FACE_CLOSEST_PED  (0x84179419DBDD36F2)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+function TaskTurnToFaceClosestPed(ped, p1, p2, p3) end
+
+-- TASK_USE_NEAREST_SCENARIO_CHAIN_TO_COORD  (0x9FDA1B3D7E7028B3)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+function TaskUseNearestScenarioChainToCoord(ped, x, y, z, distance, p5, p6, p7, p8) end
+
+-- TASK_USE_NEAREST_SCENARIO_CHAIN_TO_COORD_WARP  (0x97A28E63F0BA5631)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param p5 boolean
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+function TaskUseNearestScenarioChainToCoordWarp(ped, x, y, z, distance, p5, p6, p7, p8) end
+
+-- TASK_USE_NEAREST_SCENARIO_TO_COORD_WARP  (0x58E2E0F23F6B76C3)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param duration number
+---@param p6 boolean
+---@param p7 boolean
+---@param p8 boolean
+---@param p9 boolean
+function TaskUseNearestScenarioToCoordWarp(ped, x, y, z, distance, duration, p6, p7, p8, p9) end
+
+-- TASK_USE_NEAREST_TRAIN_SCENARIO_TO_COORD_WARP  (0x3774B03456DD6106)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+function TaskUseNearestTrainScenarioToCoordWarp(ped, x, y, z, distance) end
+
+-- TASK_USE_RANDOM_SCENARIO_IN_GROUP  (0x14747F4A5971DE4E)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function TaskUseRandomScenarioInGroup(ped, p1, p2, p3, p4) end
+
+-- TASK_USE_SCENARIO_POINT  (0xCCDAE6324B6A821C)
+-- min build: 1207
+---@param ped number
+---@param scenario number
+---@param conditionalAnim string
+---@param p3 number
+---@param p4 boolean
+---@param p5 boolean
+---@param p6 number
+---@param p7 boolean
+---@param p8 number
+---@param p9 boolean
+function TaskUseScenarioPoint(ped, scenario, conditionalAnim, p3, p4, p5, p6, p7, p8, p9) end
+
+-- TASK_VEHICLE_AIM_AT_COORD  (0x447C1E9EF844BC0F)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+function TaskVehicleAimAtCoord(ped, x, y, z) end
+
+-- TASK_VEHICLE_AIM_AT_PED  (0xE41885592B08B097)
+-- min build: 1207
+---@param ped number
+---@param target number
+function TaskVehicleAimAtPed(ped, target) end
+
+-- TASK_VEHICLE_DRIVE_STRAIGHT_TO_POINT  (0x089FF2FB965F0A29)
+-- Old name: _TASK_VEHICLE_DRIVE_TO_POINT
+-- flag: 524419 and 0 in shop_horse_shop R* Script
+-- min build: 1207
+---@param driver number
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@param p5 number
+---@param p6 number
+---@param flag number
+function TaskVehicleDriveStraightToPoint(driver, vehicle, x, y, z, p5, p6, flag) end
+
+-- TASK_VEHICLE_DRIVE_TO_COORD  (0xE2A2AA2F659D77A7)
+-- stopRange: how close vehicle will get to destination before stopping, default 4.0
+-- straightLineDist: distance at which AI switches to heading for target directly instead of following nodes, default -1
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@param speed number
+---@param drivingStyle number
+---@param vehicleModel number
+---@param drivingMode number
+---@param stopRange number
+---@param straightLineDist number
+function TaskVehicleDriveToCoord(ped, vehicle, x, y, z, speed, drivingStyle, vehicleModel, drivingMode, stopRange, straightLineDist) end
+
+-- TASK_VEHICLE_DRIVE_TO_DESTINATION  (0x7F241A0D14354583)
+-- flags: 67108864, 2097152, 524564, 524675 (eDrivingFlags)
+-- p7 = 6 or 3
+-- p8 = x coordinate
+-- p9 - 8.f
+-- p10 = false
+-- min build: 1207
+---@param driver number
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@param speed number
+---@param drivingFlags number
+---@param p7 number
+---@param stoppingRange1 number
+---@param stoppingRange2 number
+---@param p10 boolean
+function TaskVehicleDriveToDestination(driver, vehicle, x, y, z, speed, drivingFlags, p7, stoppingRange1, stoppingRange2, p10) end
+
+-- TASK_VEHICLE_DRIVE_WANDER  (0x480142959D337D00)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param speed number
+---@param drivingStyle number
+function TaskVehicleDriveWander(ped, vehicle, speed, drivingStyle) end
+
+-- TASK_VEHICLE_ESCORT  (0x0FA6E4B75F302400)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param targetVehicle number
+---@param mode number
+---@param speed number
+---@param drivingStyle number
+---@param minDistance number
+---@param p7 number
+---@param noRoadsDistance number
+function TaskVehicleEscort(ped, vehicle, targetVehicle, mode, speed, drivingStyle, minDistance, p7, noRoadsDistance) end
+
+-- TASK_VEHICLE_FOLLOW_WAYPOINT_RECORDING  (0x3123FAA6DB1CF7ED)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param waypointRecording string
+---@param drivingMode number
+---@param p4 any
+---@param eWaypoint number
+---@param flag number
+---@param p7 number
+---@param p8 boolean
+---@param stoppingDist number
+---@param p10 any
+function TaskVehicleFollowWaypointRecording(ped, vehicle, waypointRecording, drivingMode, p4, eWaypoint, flag, p7, p8, stoppingDist, p10) end
+
+-- TASK_VEHICLE_GOTO_NAVMESH  (0x195AEEB13CEFE2EE)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+---@param speed number
+---@param behaviorFlag number
+---@param stoppingRange number
+function TaskVehicleGotoNavmesh(ped, vehicle, x, y, z, speed, behaviorFlag, stoppingRange) end
+
+-- TASK_VEHICLE_MISSION  (0x659427E0EF36BCDE)
+-- min build: 1207
+---@param driver number
+---@param vehicle number
+---@param vehicleTarget number
+---@param missionType number
+---@param p4 number
+---@param p5 any
+---@param p6 number
+---@param p7 number
+---@param DriveAgainstTraffic boolean
+function TaskVehicleMission(driver, vehicle, vehicleTarget, missionType, p4, p5, p6, p7, DriveAgainstTraffic) end
+
+-- TASK_VEHICLE_MISSION_PED_TARGET  (0x9454528DF15D657A)
+-- See TASK_VEHICLE_MISSION
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param pedTarget number
+---@param mode number
+---@param maxSpeed number
+---@param drivingStyle number
+---@param minDistance number
+---@param p7 number
+---@param DriveAgainstTraffic boolean
+function TaskVehicleMissionPedTarget(ped, vehicle, pedTarget, mode, maxSpeed, drivingStyle, minDistance, p7, DriveAgainstTraffic) end
+
+-- TASK_VEHICLE_SHOOT_AT_COORD  (0x5190796ED39C9B6D)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 number
+function TaskVehicleShootAtCoord(ped, x, y, z, p4) end
+
+-- TASK_VEHICLE_SHOOT_AT_PED  (0x10AB107B887214D8)
+-- min build: 1207
+---@param ped number
+---@param target number
+---@param p2 number
+function TaskVehicleShootAtPed(ped, target, p2) end
+
+-- TASK_VEHICLE_TEMP_ACTION  (0xC429DCEEB339E129)
+-- Documentation from GTA V, might be the same in RDR:
+-- 
+-- '1 - brake
+-- '3 - brake + reverse
+-- '4 - turn left 90 + braking
+-- '5 - turn right 90 + braking
+-- '6 - brake strong (handbrake?) until time ends
+-- '7 - turn left + accelerate
+-- '7 - turn right + accelerate
+-- '9 - weak acceleration
+-- '10 - turn left + restore wheel pos to center in the end
+-- '11 - turn right + restore wheel pos to center in the end
+-- '13 - turn left + go reverse
+-- '14 - turn left + go reverse
+-- '16 - crash the game after like 2 seconds :)
+-- '17 - keep actual state, game crashed after few tries
+-- '18 - game crash
+-- '19 - strong brake + turn left/right
+-- '20 - weak brake + turn left then turn right
+-- '21 - weak brake + turn right then turn left
+-- '22 - brake + reverse
+-- '23 - accelerate fast
+-- '24 - brake
+-- '25 - brake turning left then when almost stopping it turns left more
+-- '26 - brake turning right then when almost stopping it turns right more
+-- '27 - brake until car stop or until time ends
+-- '28 - brake + strong reverse acceleration
+-- '30 - performs a burnout (brake until stop + brake and accelerate)
+-- '31 - accelerate + handbrake
+-- '32 - accelerate very strong
+-- 
+-- Seems to be this:
+-- Works on NPCs, but overrides their current task. If inside a task sequence (and not being the last task), "time" will work, otherwise the task will be performed forever until tasked with something else
+-- min build: 1207
+---@param driver number
+---@param vehicle number
+---@param action number
+---@param time number
+function TaskVehicleTempAction(driver, vehicle, action, time) end
+
+-- TASK_WALK_AWAY  (0x04ACFAC71E6858F9)
+-- min build: 1207
+---@param ped number
+---@param entity number
+function TaskWalkAway(ped, entity) end
+
+-- TASK_WANDER_AND_CONVERSE_WITH_PED  (0x8AC76D1408731732)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function TaskWanderAndConverseWithPed(ped, p1, p2, p3) end
+
+-- TASK_WANDER_IN_AREA  (0xE054346CA3A0F315)
+-- min build: 1207
+---@param ped number
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+function TaskWanderInArea(ped, x, y, z, radius, p5, p6, p7) end
+
+-- TASK_WANDER_IN_VOLUME  (0x9FDA168777B28424)
+-- min build: 1207
+---@param ped number
+---@param volume number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+function TaskWanderInVolume(ped, volume, p2, p3, p4) end
+
+-- TASK_WANDER_STANDARD  (0xBB9CE077274F6A1B)
+-- Makes ped walk around the area.
+-- 
+-- set p1 to 10.0f and p2 to 10 if you want the ped to walk anywhere without a duration.
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function TaskWanderStandard(ped, p1, p2) end
+
+-- TASK_WANDER_SWIM  (0x527EA3DB8BC7F03B)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+function TaskWanderSwim(ped, p1) end
+
+-- TASK_WARP_PED_INTO_VEHICLE  (0x9A7D091411C5F684)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param seat number
+function TaskWarpPedIntoVehicle(ped, vehicle, seat) end
+
+-- TASK_WEAPON  (0x7157B82D60E4BC46)
+-- min build: 1207
+---@param ped number
+function TaskWeapon(ped) end
+
+-- TASK_WHISTLE_ANIM  (0xD6401A1B2F63BED6)
+-- https://github.com/femga/rdr3_discoveries/blob/master/AI/EVENTS/aud_ped_whistle_types.lua
+-- p2: UNSPECIFIED
+-- min build: 1207
+---@param ped number
+---@param audPedWhistleType number
+---@param p2 number
+function TaskWhistleAnim(ped, audPedWhistleType, p2) end
+
+-- UNCUFF_PED  (0x67406F2C8F87FC4F)
+-- min build: 1207
+---@param ped number
+function UncuffPed(ped) end
+
+-- UNHOGTIE_PED  (0x79559BAD83CCD038)
+-- getupSetHash: see nm_blend_out_sets.meta
+-- min build: 1207
+---@param ped number
+---@param flags number
+---@param getupSetHash number
+---@param p3 string
+---@param p4 string
+---@param p5 number
+function UnhogtiePed(ped, flags, getupSetHash, p3, p4, p5) end
+
+-- UPDATE_TASK_HANDS_UP_DURATION  (0xA98FCAFD7893C834)
+-- min build: 1207
+---@param ped number
+---@param duration number
+function UpdateTaskHandsUpDuration(ped, duration) end
+
+-- USE_WAYPOINT_RECORDING_AS_ASSISTED_MOVEMENT_ROUTE  (0x5A353B8E6B1095B5)
+-- min build: 1207
+---@param waypointRecording string
+---@param p1 boolean
+---@param p2 number
+---@param p3 number
+---@param p4 boolean
+function UseWaypointRecordingAsAssistedMovementRoute(waypointRecording, p1, p2, p3, p4) end
+
+-- VEHICLE_WAYPOINT_PLAYBACK_GET_IS_PAUSED  (0x4D6D30AB18B0B089)
+-- min build: 1207
+---@param p0 any
+---@return any
+function VehicleWaypointPlaybackGetIsPaused(p0) end
+
+-- VEHICLE_WAYPOINT_PLAYBACK_OVERRIDE_SPEED  (0x121F0593E0A431D7)
+-- min build: 1207
+---@param vehicle number
+---@param speed number
+function VehicleWaypointPlaybackOverrideSpeed(vehicle, speed) end
+
+-- VEHICLE_WAYPOINT_PLAYBACK_PAUSE  (0x8A4E6AC373666BC5)
+-- min build: 1207
+---@param vehicle number
+function VehicleWaypointPlaybackPause(vehicle) end
+
+-- VEHICLE_WAYPOINT_PLAYBACK_RESUME  (0xDC04FCAA7839D492)
+-- min build: 1207
+---@param vehicle number
+function VehicleWaypointPlaybackResume(vehicle) end
+
+-- VEHICLE_WAYPOINT_PLAYBACK_USE_DEFAULT_SPEED  (0x5CEB25A7D2848963)
+-- min build: 1207
+---@param vehicle number
+function VehicleWaypointPlaybackUseDefaultSpeed(vehicle) end
+
+-- WAYPOINT_PLAYBACK_GET_IS_AIMING  (0xD73A5D1F0325C71C)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function WaypointPlaybackGetIsAiming(ped) end
+
+-- WAYPOINT_PLAYBACK_GET_IS_PAUSED  (0x701375A7D43F01CB)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function WaypointPlaybackGetIsPaused(ped) end
+
+-- WAYPOINT_PLAYBACK_GET_IS_SHOOTING  (0xA5B94DF8AF058F46)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function WaypointPlaybackGetIsShooting(ped) end
+
+-- WAYPOINT_PLAYBACK_OVERRIDE_SPEED  (0x7D7D2B47FA788E85)
+-- min build: 1207
+---@param ped number
+---@param speed number
+---@param p2 any
+---@param p3 number
+---@param p4 any
+function WaypointPlaybackOverrideSpeed(ped, speed, p2, p3, p4) end
+
+-- WAYPOINT_PLAYBACK_PAUSE  (0x0F342546AA06FED5)
+-- min build: 1207
+---@param ped number
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function WaypointPlaybackPause(ped, p1, p2, p3) end
+
+-- WAYPOINT_PLAYBACK_RESUME  (0x244F70C84C547D2D)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 number
+---@param p3 number
+function WaypointPlaybackResume(ped, p1, p2, p3) end
+
+-- WAYPOINT_PLAYBACK_START_AIMING_AT_COORD  (0x8968400D900ED8B3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function WaypointPlaybackStartAimingAtCoord(p0, p1, p2, p3, p4, p5) end
+
+-- WAYPOINT_PLAYBACK_START_AIMING_AT_ENTITY  (0x4F158205E0C74385)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function WaypointPlaybackStartAimingAtEntity(p0, p1, p2, p3) end
+
+-- WAYPOINT_PLAYBACK_START_AIMING_AT_PED  (0x20E330937C399D29)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function WaypointPlaybackStartAimingAtPed(p0, p1, p2, p3) end
+
+-- WAYPOINT_PLAYBACK_START_SHOOTING_AT_COORD  (0x057A25CFCC9DB671)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function WaypointPlaybackStartShootingAtCoord(p0, p1, p2, p3, p4, p5, p6) end
+
+-- WAYPOINT_PLAYBACK_START_SHOOTING_AT_ENTITY  (0x4AF458F71C1196D2)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function WaypointPlaybackStartShootingAtEntity(p0, p1, p2, p3, p4) end
+
+-- WAYPOINT_PLAYBACK_START_SHOOTING_AT_PED  (0xE70BA7B90F8390DC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function WaypointPlaybackStartShootingAtPed(p0, p1, p2, p3, p4) end
+
+-- WAYPOINT_PLAYBACK_STOP_AIMING_OR_SHOOTING  (0x47EFA040EBB8E2EA)
+-- min build: 1207
+---@param p0 any
+function WaypointPlaybackStopAimingOrShooting(p0) end
+
+-- WAYPOINT_PLAYBACK_USE_DEFAULT_SPEED  (0x6599D834B12D0800)
+-- min build: 1207
+---@param ped number
+function WaypointPlaybackUseDefaultSpeed(ped) end
+
+-- WAYPOINT_RECORDING_GET_CLOSEST_WAYPOINT  (0xB629A298081F876F)
+-- min build: 1207
+---@param waypointRecording string
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return number
+function WaypointRecordingGetClosestWaypoint(waypointRecording, x, y, z) end
+
+-- WAYPOINT_RECORDING_GET_COORD  (0x2FB897405C90B361)
+-- min build: 1207
+---@param waypointRecording string
+---@param point number
+---@return boolean
+---@return vector3
+function WaypointRecordingGetCoord(waypointRecording, point) end
+
+-- WAYPOINT_RECORDING_GET_NUM_POINTS  (0x5343532C01A07234)
+-- min build: 1207
+---@param waypointRecording string
+---@return boolean
+---@return number
+function WaypointRecordingGetNumPoints(waypointRecording) end
+
+-- WAYPOINT_RECORDING_GET_SPEED_AT_POINT  (0x005622AEBC33ACA9)
+-- min build: 1207
+---@param waypointRecording string
+---@param point number
+---@return number
+function WaypointRecordingGetSpeedAtPoint(waypointRecording, point) end

--- a/.luals/redm-natives/TELEMETRY.lua
+++ b/.luals/redm-natives/TELEMETRY.lua
@@ -1,0 +1,599 @@
+---@meta
+
+-- RDR3 namespace: TELEMETRY -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x6F5BC5C4EAB42B15  (0x6F5BC5C4EAB42B15)
+-- Note: this native was added in build 1491.50
+-- min build: 1491
+---@param linkID number
+---@param type number
+---@param contentId string
+function N_0x6F5BC5C4EAB42B15(linkID, type, contentId) end
+
+-- _0xEC0BD8736DCAF841  (0xEC0BD8736DCAF841)
+-- min build: 1207
+---@param toggle boolean
+function N_0xEC0BD8736DCAF841(toggle) end
+
+-- _CLEAR_TELEMETRY_SHOP_UI  (0x32D5898C4898CD95)
+-- min build: 1207
+function _ClearTelemetryShopUi() end
+
+-- _TELEMETRY_AMBIENT_VIGNETTE  (0x3145044F3990D321)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function _TelemetryAmbientVignette(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _TELEMETRY_ANIMAL_SKINNED  (0x7581972ADF5D699A)
+-- min build: 1207
+---@param type number
+---@return any
+function _TelemetryAnimalSkinned(type) end
+
+-- _TELEMETRY_BOUNTY_TARGET  (0x52FA31DB8F3AD25D)
+-- min build: 1207
+---@return any
+function _TelemetryBountyTarget() end
+
+-- _TELEMETRY_CAMP_CREATED  (0x565EAA726B2CE3B7)
+-- min build: 1207
+---@param p0 any
+function _TelemetryCampCreated(p0) end
+
+-- _TELEMETRY_CAMP_SUPPLIES  (0x217F47761376E16E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function _TelemetryCampSupplies(p0, p1, p2, p3, p4) end
+
+-- _TELEMETRY_CHAR_CREATOR  (0x7207AD471BC9278C)
+-- min build: 1355
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function _TelemetryCharCreator(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _TELEMETRY_COLLECT  (0xD6CB05DDAEE43AFD)
+-- min build: 1207
+---@param transactionId any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function _TelemetryCollect(transactionId, p1, p2, p3, p4, p5, p6) end
+
+-- _TELEMETRY_COUPON  (0x621D719C4836292B)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function _TelemetryCoupon(p0, p1, p2, p3, p4, p5) end
+
+-- _TELEMETRY_CRAFT_ITEM  (0x78C2E029DB205A3A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param quantity any
+function _TelemetryCraftItem(p0, p1, p2, quantity) end
+
+-- _TELEMETRY_CREATE_UUID  (0xE692D336F8A2A97F)
+-- Works in MP only.
+-- min build: 1207
+---@return boolean
+---@return any
+function _TelemetryCreateUuid() end
+
+-- _TELEMETRY_CUSTOM  (0x40914CCF2A1AB531)
+-- min build: 1207
+---@return any
+function _TelemetryCustom() end
+
+-- _TELEMETRY_DEFENSIVE  (0xE57529D23541D2DD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function _TelemetryDefensive(p0, p1, p2) end
+
+-- _TELEMETRY_DISCOVERABLE  (0xF5EAD898EF387E73)
+-- min build: 1207
+---@param p0 any
+function _TelemetryDiscoverable(p0) end
+
+-- _TELEMETRY_EMOTE_ADD_CATEGORY_TO_SAVE  (0x2C24AF8EEEEF8A55)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param emote number
+function _TelemetryEmoteAddCategoryToSave(p0, p1, emote) end
+
+-- _TELEMETRY_FAST_TRAVEL  (0x7CEF4AC79F7E7FAD)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function _TelemetryFastTravel(p0, p1, p2, p3, p4) end
+
+-- _TELEMETRY_FAVOR_EMOTE  (0x16B23D4F7A1F50D9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function _TelemetryFavorEmote(p0, p1, p2) end
+
+-- _TELEMETRY_GAME_PROGRESS  (0x51EC204A6E5B5A1A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function _TelemetryGameProgress(p0, p1) end
+
+-- _TELEMETRY_GANG_SHARES  (0xE6DC9B21AC7A8729)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryGangShares(p0, p1, p2, p3) end
+
+-- _TELEMETRY_GOLD_STORE  (0x536B6025E94AC48F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryGoldStore(p0, p1, p2, p3) end
+
+-- _TELEMETRY_GUN_LOCKER  (0x415FE28ED44BFF14)
+-- min build: 1207
+function _TelemetryGunLocker() end
+
+-- _TELEMETRY_GUN_LOCKER_WEAPON_REMOVED  (0x317D9C9560529CC2)
+-- min build: 1207
+---@param p0 number
+function _TelemetryGunLockerWeaponRemoved(p0) end
+
+-- _TELEMETRY_GUN_LOCKER_WEAPON_STORED  (0xC3ADF4880784FA9C)
+-- min build: 1207
+---@param p0 number
+function _TelemetryGunLockerWeaponStored(p0) end
+
+-- _TELEMETRY_HERB_PICKED  (0xAE693EC3A178F6C2)
+-- min build: 1207
+---@param herbType number
+function _TelemetryHerbPicked(herbType) end
+
+-- _TELEMETRY_HONOR  (0xE6B763C7F4902201)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function _TelemetryHonor(p0, p1) end
+
+-- _TELEMETRY_HUB_NAVIGATION  (0x25CC50EC1A6F3A96)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryHubNavigation(p0, p1, p2, p3) end
+
+-- _TELEMETRY_HUB_OFFERS  (0x37AA282163B0D2C4)
+-- min build: 1232
+---@param couponItem any
+---@param p1 any
+function _TelemetryHubOffers(couponItem, p1) end
+
+-- _TELEMETRY_INTRO_SKIP  (0x1B554723799245F4)
+-- min build: 1355
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function _TelemetryIntroSkip(p0, p1, p2) end
+
+-- _TELEMETRY_LOBBY_PROGRESSION  (0xECD67E9FA677CCCF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryLobbyProgression(p0, p1, p2, p3) end
+
+-- _TELEMETRY_LOOT  (0xCF63EF77B0DF0397)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryLoot(p0, p1, p2, p3) end
+
+-- _TELEMETRY_MATCH_NOMINATION  (0x330029E121380CEB)
+-- min build: 1355
+---@return any
+function _TelemetryMatchNomination() end
+
+-- _TELEMETRY_MATCH_OVER  (0xA2058154357726BB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function _TelemetryMatchOver(p0, p1, p2, p3, p4) end
+
+-- _TELEMETRY_MATCH_QUEUE  (0x4C08D2B6D8BE17E4)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function _TelemetryMatchQueue(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _TELEMETRY_MATCH_STARTED  (0xF620F47B4F4A78C4)
+-- min build: 1207
+---@return any
+---@return any
+function _TelemetryMatchStarted() end
+
+-- _TELEMETRY_MATCH_VOTE  (0xEF3C68F56BAD7B69)
+-- min build: 1207
+---@return any
+---@return any
+function _TelemetryMatchVote() end
+
+-- _TELEMETRY_MENU_NAVIGATION  (0x3255D4D2082C6339)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryMenuNavigation(p0, p1, p2, p3) end
+
+-- _TELEMETRY_MISSION_CHECKPOINT  (0x8EC7890D446BD9C1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function _TelemetryMissionCheckpoint(p0, p1, p2) end
+
+-- _TELEMETRY_MISSION_FAILED_TO_LAUNCH  (0x6571E4327390EC0B)
+-- _TELEMETRY_C* - _TELEMETRY_G*
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param x number
+---@param y number
+---@param z number
+---@param reason number
+function _TelemetryMissionFailedToLaunch(p0, p1, x, y, z, reason) end
+
+-- _TELEMETRY_MISSION_ILO_OPTION  (0xEA323F5E1A4DA2F1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function _TelemetryMissionIloOption(p0, p1) end
+
+-- _TELEMETRY_MISSION_OVER  (0xD894437E12C17AEC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function _TelemetryMissionOver(p0, p1) end
+
+-- _TELEMETRY_MISSION_STARTED  (0x15B0CC1B36F1DE29)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryMissionStarted(p0, p1, p2, p3) end
+
+-- _TELEMETRY_MOONSHINE_BREW  (0xB5013EFBB5516867)
+-- min build: 1232
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function _TelemetryMoonshineBrew(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- _TELEMETRY_NET_CAMP  (0xA72773C3134F9A57)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function _TelemetryNetCamp(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _TELEMETRY_NOTORIETY  (0xE26970A7AE0F28E9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryNotoriety(p0, p1, p2, p3) end
+
+-- _TELEMETRY_PARLEY_FEUD  (0xF37A2149BC9A8A27)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function _TelemetryParleyFeud(p0, p1, p2, p3, p4) end
+
+-- _TELEMETRY_PERSONAL_VEHICLE_WAGON  (0xE67AF24C5A3B6058)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function _TelemetryPersonalVehicleWagon(p0, p1, p2) end
+
+-- _TELEMETRY_PHOTO  (0xED22BE4C5A399E63)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryPhoto(p0, p1, p2, p3) end
+
+-- _TELEMETRY_PHOTO_CAM  (0x0777D65EE8A17517)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+function _TelemetryPhotoCam(p0, p1, p2, p3, p4, p5, p6, p7, p8) end
+
+-- _TELEMETRY_PLAYER_SPAWNED  (0x5DA4718DF897EB25)
+-- min build: 1207
+---@param ped number
+function _TelemetryPlayerSpawned(ped) end
+
+-- _TELEMETRY_POKER_OVER  (0x8127C5AA05C5A210)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function _TelemetryPokerOver(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _TELEMETRY_PRISON  (0xB204BF9F30298D77)
+-- min build: 1207
+---@param transactionId any
+---@param bountyAmount any
+---@param ped number
+---@param completionType any
+---@param jailTimeServed any
+---@param jailTimeLeft any
+---@param posseRole any
+function _TelemetryPrison(transactionId, bountyAmount, ped, completionType, jailTimeServed, jailTimeLeft, posseRole) end
+
+-- _TELEMETRY_REGION  (0xCD6F8A0335D821F9)
+-- min build: 1207
+---@param regionHash number
+function _TelemetryRegion(regionHash) end
+
+-- _TELEMETRY_ROLE_BOUNTY  (0xAB43D1C80B5E9500)
+-- min build: 1207
+---@param p0 any
+function _TelemetryRoleBounty(p0) end
+
+-- _TELEMETRY_ROLE_COLLECTOR  (0x4AC38DFD286DAD14)
+-- min build: 1207
+---@param transactionId any
+---@param collectible any
+---@param category any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+function _TelemetryRoleCollector(transactionId, collectible, category, p3, p4, p5, p6) end
+
+-- _TELEMETRY_ROLE_MOONSHINER  (0x99D40C5D74BC88E9)
+-- min build: 1232
+---@param p0 any
+---@param transactionId any
+function _TelemetryRoleMoonshiner(p0, transactionId) end
+
+-- _TELEMETRY_ROLE_NATURALIST  (0x6FB9EA308F302922)
+-- min build: 1311
+---@param transactionId any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+function _TelemetryRoleNaturalist(transactionId, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _TELEMETRY_ROLE_TOKEN_TRANSACTION  (0x32C2939564D74BFF)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function _TelemetryRoleTokenTransaction(p0, p1, p2, p3, p4, p5) end
+
+-- _TELEMETRY_ROLE_TRADER  (0x476038B5A0734C10)
+-- min build: 1207
+---@param p0 any
+---@param transactionId any
+function _TelemetryRoleTrader(p0, transactionId) end
+
+-- _TELEMETRY_RPG_GLOBAL_CALCULATE_ATTRIBUTE_CORE_DELTA  (0x7E002A36AEFCFB55)
+-- Creation of the metric is related to attribute filling, i. e. at camp fires, when the ped is resting.
+-- _TELEMETRY_C* - _TELEMETRY_P*
+-- min build: 1207
+function _TelemetryRpgGlobalCalculateAttributeCoreDelta() end
+
+-- _TELEMETRY_SAMPLE  (0x61559675D23D8BD1)
+-- min build: 1311
+---@param transactionId any
+---@param animal any
+---@param p2 any
+---@param bSampled any
+---@param bTranq boolean
+function _TelemetrySample(transactionId, animal, p2, bSampled, bTranq) end
+
+-- _TELEMETRY_SET_IS_FLOW  (0x9BEE018A63FFFAD9)
+-- min build: 1207
+---@param toggle boolean
+function _TelemetrySetIsFlow(toggle) end
+
+-- _TELEMETRY_SET_SHOP_FOR_TRANSACTION  (0xCA9E42F437625A85)
+-- min build: 1232
+---@param transactionId number
+---@param p1 number
+---@param p2 number
+function _TelemetrySetShopForTransaction(transactionId, p1, p2) end
+
+-- _TELEMETRY_SHOP_CUTSCENE  (0xB0B19B56697836F5)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _TelemetryShopCutscene(p0, p1, p2, p3) end
+
+-- _TELEMETRY_SHOP_ENTRY  (0x775B2ED944E44973)
+-- min build: 1207
+---@param shopType any
+---@param shopRegion any
+---@param region any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function _TelemetryShopEntry(shopType, shopRegion, region, p3, p4, p5) end
+
+-- _TELEMETRY_SHOP_EXIT  (0xF78E669FDC202E73)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function _TelemetryShopExit(p0, p1) end
+
+-- _TELEMETRY_SHOP_PURCHASE  (0x2A374E6F0075EE81)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function _TelemetryShopPurchase(p0, p1, p2, p3, p4) end
+
+-- _TELEMETRY_SHOP_SELL  (0x9BD8A9D0A774A6F8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param centSalePrice number
+function _TelemetryShopSell(p0, p1, p2, p3, centSalePrice) end
+
+-- _TELEMETRY_SLEEP  (0xF9F14080D80937BD)
+-- min build: 1207
+---@param p0 any
+function _TelemetrySleep(p0) end
+
+-- _TELEMETRY_START_GUN_LOCKER_INTERACTION  (0xF0D54E0651DD7E07)
+-- min build: 1207
+function _TelemetryStartGunLockerInteraction() end
+
+-- _TELEMETRY_TRIGGER_TRANSACTION_REQUEST  (0x80A02D9F948A8BCA)
+-- Returns false when transaction request is failing
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _TelemetryTriggerTransactionRequest() end
+
+-- _TRY_GET_TELEMETRY_ID_FROM_TRANSACTION_ID  (0xF184B3ECE36219CF)
+-- min build: 1207
+---@return boolean
+---@return any
+---@return any
+function _TryGetTelemetryIdFromTransactionId() end
+
+-- ANALYTICS_PLAYTIME_FREEMODE_END  (0x3180E991D4B8F248)
+-- min build: 1207
+function AnalyticsPlaytimeFreemodeEnd() end
+
+-- ANALYTICS_PLAYTIME_FREEMODE_START  (0xE9F24081D84931B8)
+-- min build: 1207
+function AnalyticsPlaytimeFreemodeStart() end
+
+-- TELEMETRY_CAMP_DONATE  (0xDF516E598D966D06)
+-- min build: 1207
+---@param transactionId any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param slotId number
+---@param p6 number
+---@param p7 any
+---@param p8 boolean
+function TelemetryCampDonate(transactionId, p1, p2, p3, p4, slotId, p6, p7, p8) end
+
+-- TELEMETRY_PERSONAL_VEHICLE_MOUNT  (0xFF9052BC7A3B7D33)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function TelemetryPersonalVehicleMount(p0, p1, p2, p3) end
+
+-- TELEMETRY_PLAYER_MENU_PIN  (0x076C5843371EB889)
+-- min build: 1311
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function TelemetryPlayerMenuPin(p0, p1, p2, p3) end

--- a/.luals/redm-natives/TXD.lua
+++ b/.luals/redm-natives/TXD.lua
@@ -1,0 +1,50 @@
+---@meta
+
+-- RDR3 namespace: TXD -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- DOES_STREAMED_TEXTURE_DICT_EXIST  (0x7332461FC59EB7EC)
+-- min build: 1207
+---@param textureDict string
+---@return boolean
+function DoesStreamedTextureDictExist(textureDict) end
+
+-- DOES_STREAMED_TXD_EXIST  (0xBA0163B277C2D2D0)
+-- min build: 1207
+---@param txdHash number
+---@return boolean
+function DoesStreamedTxdExist(txdHash) end
+
+-- HAS_STREAMED_TEXTURE_DICT_LOADED  (0x54D6900929CCF162)
+-- min build: 1207
+---@param textureDict string
+---@return boolean
+function HasStreamedTextureDictLoaded(textureDict) end
+
+-- HAS_STREAMED_TXD_LOADED  (0xBE72591D1509FFE4)
+-- min build: 1207
+---@param txdHash number
+---@return boolean
+function HasStreamedTxdLoaded(txdHash) end
+
+-- REQUEST_STREAMED_TEXTURE_DICT  (0xC1BA29DF5631B0F8)
+-- min build: 1207
+---@param textureDict string
+---@param p1 boolean
+function RequestStreamedTextureDict(textureDict, p1) end
+
+-- REQUEST_STREAMED_TXD  (0xDB1BD07FB464584D)
+-- min build: 1207
+---@param txdHash number
+---@param p1 boolean
+function RequestStreamedTxd(txdHash, p1) end
+
+-- SET_STREAMED_TEXTURE_DICT_AS_NO_LONGER_NEEDED  (0x4ACA10A91F66F1E2)
+-- min build: 1207
+---@param textureDict string
+function SetStreamedTextureDictAsNoLongerNeeded(textureDict) end
+
+-- SET_STREAMED_TXD_AS_NO_LONGER_NEEDED  (0x8232F37DF762ACB2)
+-- min build: 1207
+---@param txdHash number
+function SetStreamedTxdAsNoLongerNeeded(txdHash) end

--- a/.luals/redm-natives/UIAPPS.lua
+++ b/.luals/redm-natives/UIAPPS.lua
@@ -1,0 +1,112 @@
+---@meta
+
+-- RDR3 namespace: UIAPPS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _CLOSE_ALL_UIAPPS  (0xAD7B70F7230C5A12)
+-- min build: 1207
+function _CloseAllUiapps() end
+
+-- _CLOSE_ALL_UIAPPS_IMMEDIATE  (0x12769EEB8DBD7A7B)
+-- min build: 1207
+function _CloseAllUiappsImmediate() end
+
+-- _CLOSE_UIAPP  (0x818C6CA9B659E8EC)
+-- min build: 1207
+---@param appName string
+function _CloseUiapp(appName) end
+
+-- _CLOSE_UIAPP_BY_HASH  (0x2FF10C9C3F92277E)
+-- min build: 1207
+---@param appNameHash number
+function _CloseUiappByHash(appNameHash) end
+
+-- _CLOSE_UIAPP_BY_HASH_IMMEDIATE  (0x04428420A248A354)
+-- min build: 1207
+---@param appNameHash number
+function _CloseUiappByHashImmediate(appNameHash) end
+
+-- _CLOSE_UIAPP_IMMEDIATE  (0x3015635426D1B17C)
+-- min build: 1207
+---@param appName string
+function _CloseUiappImmediate(appName) end
+
+-- _GET_UIAPP_CURRENT_ACTIVITY_BY_HASH  (0x96FD694FE5BE55DC)
+-- min build: 1207
+---@param appNameHash number
+---@return number
+function _GetUiappCurrentActivityByHash(appNameHash) end
+
+-- CAN_LAUNCH_UIAPP_BY_HASH  (0xE555EC27D65EDE80)
+-- min build: 1207
+---@param appNameHash number
+---@return boolean
+function CanLaunchUiappByHash(appNameHash) end
+
+-- CAN_LAUNCH_UIAPP_BY_HASH_WITH_ENTRY  (0x16F47D434B6086BF)
+-- min build: 1207
+---@param appNameHash number
+---@param entryHash number
+---@return boolean
+function CanLaunchUiappByHashWithEntry(appNameHash, entryHash) end
+
+-- IS_ANY_UIAPP_ACTIVE  (0xAC959AB99AAF3D9F)
+-- min build: 1207
+---@return boolean
+function IsAnyUiappActive() end
+
+-- IS_ANY_UIAPP_RUNNING  (0xDB30BEC7A7A5CBD3)
+-- min build: 1207
+---@return boolean
+function IsAnyUiappRunning() end
+
+-- IS_UIAPP_ACTIVE_BY_HASH  (0x25B7A0206BDFAC76)
+-- min build: 1207
+---@param appNameHash number
+---@return boolean
+function IsUiappActiveByHash(appNameHash) end
+
+-- IS_UIAPP_RUNNING  (0xDE4A9B35D028979F)
+-- min build: 1232
+---@param appName string
+---@return boolean
+function IsUiappRunning(appName) end
+
+-- IS_UIAPP_RUNNING_BY_HASH  (0x4E511D093A86AD49)
+-- min build: 1207
+---@param appNameHash number
+---@return boolean
+function IsUiappRunningByHash(appNameHash) end
+
+-- IS_UIAPP_TRANSITIONING_BY_HASH  (0x42095B886D30DE66)
+-- min build: 1232
+---@param appNameHash number
+---@return boolean
+function IsUiappTransitioningByHash(appNameHash) end
+
+-- LAUNCH_UIAPP_BY_HASH  (0xC8FC7F4E4CF4F581)
+-- min build: 1207
+---@param appNameHash number
+---@return number
+function LaunchUiappByHash(appNameHash) end
+
+-- LAUNCH_UIAPP_BY_HASH_WITH_ENTRY  (0xC1BCF31E975B3195)
+-- min build: 1207
+---@param appNameHash number
+---@param entryHash number
+---@return number
+function LaunchUiappByHashWithEntry(appNameHash, entryHash) end
+
+-- LAUNCH_UIAPP_WITH_ENTRY  (0x7B2027BAC5C8EC89)
+-- min build: 1207
+---@param appName string
+---@param entry string
+---@return number
+function LaunchUiappWithEntry(appName, entry) end
+
+-- REQUEST_UIAPP_TRANSITION_BY_HASH  (0x7689CD255655BFD7)
+-- min build: 1207
+---@param appNameHash number
+---@param transitionHash number
+---@return boolean
+function RequestUiappTransitionByHash(appNameHash, transitionHash) end

--- a/.luals/redm-natives/UIDEBUG.lua
+++ b/.luals/redm-natives/UIDEBUG.lua
@@ -1,0 +1,27 @@
+---@meta
+
+-- RDR3 namespace: UIDEBUG -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _BG_DISPLAY_TEXT  (0x16794E044C9EFB58)
+-- Note: you must use VAR_STRING
+-- min build: 1355
+---@param text string
+---@param x number
+---@param y number
+function _BgDisplayText(text, x, y) end
+
+-- _BG_SET_TEXT_COLOR  (0x16FA5CE47F184F1E)
+-- https://github.com/femga/rdr3_discoveries/tree/master/useful_info_from_rpfs/colours
+-- min build: 1355
+---@param red number
+---@param green number
+---@param blue number
+---@param alpha number
+function _BgSetTextColor(red, green, blue, alpha) end
+
+-- _BG_SET_TEXT_SCALE  (0xA1253A3C870B6843)
+-- min build: 1355
+---@param scaleX number
+---@param scaleY number
+function _BgSetTextScale(scaleX, scaleY) end

--- a/.luals/redm-natives/UIEVENTS.lua
+++ b/.luals/redm-natives/UIEVENTS.lua
@@ -1,0 +1,44 @@
+---@meta
+
+-- RDR3 namespace: UIEVENTS -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- EVENTS_UI_GET_MESSAGE  (0xE24E957294241444)
+-- eventData:
+-- struct UI_SCRIPT_EVENT
+-- {
+-- 	alignas(8) eUIScriptEventType eventType; // https://alloc8or.re/rdr3/doc/enums/eUIScriptEventType.txt
+-- 	alignas(8) int intParam;
+-- 	alignas(8) Hash hashParam;
+-- 	alignas(8) Hash datastoreParam;
+-- };
+-- 
+-- Old name: _EVENT_MANAGER_GET_EVENT
+-- min build: 1207
+---@param hash number
+---@return boolean
+---@return any
+function EventsUiGetMessage(hash) end
+
+-- EVENTS_UI_IS_PENDING  (0x67ED5A7963F2F722)
+-- Old name: _EVENT_MANAGER_IS_EVENT_PENDING
+-- min build: 1207
+---@param hash number
+---@return boolean
+function EventsUiIsPending(hash) end
+
+-- EVENTS_UI_PEEK_MESSAGE  (0x90237103F27F7937)
+-- eventData: see EVENTS_UI_GET_MESSAGE
+-- 
+-- Old name: _EVENT_MANAGER_PEEK_EVENT
+-- min build: 1207
+---@param hash number
+---@return boolean
+---@return any
+function EventsUiPeekMessage(hash) end
+
+-- EVENTS_UI_POP_MESSAGE  (0x8E8A2369F48EC839)
+-- Old name: _EVENT_MANAGER_POP_EVENT
+-- min build: 1207
+---@param hash number
+function EventsUiPopMessage(hash) end

--- a/.luals/redm-natives/UIFEED.lua
+++ b/.luals/redm-natives/UIFEED.lua
@@ -1,0 +1,232 @@
+---@meta
+
+-- RDR3 namespace: UIFEED -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x0FD07141AD048AAE  (0x0FD07141AD048AAE)
+-- Only used in R* SP Script beat_animal_attack
+-- Returns feedMessage
+-- min build: 1207
+---@param p1 boolean
+---@return number
+---@return any
+function N_0x0FD07141AD048AAE(p1) end
+
+-- _0x18D6869FBFFEC0F8  (0x18D6869FBFFEC0F8)
+-- Only used in R* SP Scripts
+-- min build: 1207
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+---@return any
+---@return any
+function N_0x18D6869FBFFEC0F8(p2, p3) end
+
+-- _0x4E88A65968A55C78  (0x4E88A65968A55C78)
+-- Returns feedMessage
+-- min build: 1207
+---@param p1 boolean
+---@return number
+---@return any
+function N_0x4E88A65968A55C78(p1) end
+
+-- _0x6D85126F6CCF02C9  (0x6D85126F6CCF02C9)
+-- min build: 1207
+---@param feedChannel number
+---@param p1 number
+---@param p2 boolean
+function N_0x6D85126F6CCF02C9(feedChannel, p1, p2) end
+
+-- _0xAFF5BE9BA496CE40  (0xAFF5BE9BA496CE40)
+-- min build: 1207
+---@param p2 boolean
+---@param p3 boolean
+---@param collectableCategory number
+---@return number
+---@return any
+---@return any
+function N_0xAFF5BE9BA496CE40(p2, p3, collectableCategory) end
+
+-- _0xB7223B91CD6B7E07  (0xB7223B91CD6B7E07)
+-- min build: 1207
+---@param feedChannel number
+---@return boolean
+function N_0xB7223B91CD6B7E07(feedChannel) end
+
+-- _UI_FEED_CLEAR_ALL_CHANNELS  (0x6035E8FBCA32AC5E)
+-- Hides Toast Notifications
+-- min build: 1207
+function _UiFeedClearAllChannels() end
+
+-- _UI_FEED_CLEAR_HELP_TEXT_FEED  (0x2F901291EF177B02)
+-- Clears help text
+-- min build: 1207
+---@param feedMessage number
+---@param p1 boolean
+function _UiFeedClearHelpTextFeed(feedMessage, p1) end
+
+-- _UI_FEED_GET_MESSAGE_STATE  (0x59FA676177DBE4C9)
+-- Returns messageState, see https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eUIMessageState
+-- min build: 1207
+---@param feedMessage number
+---@return number
+function _UiFeedGetMessageState(feedMessage) end
+
+-- _UI_FEED_POST_FEED_TICKER  (0xB2920B9760F0F36B)
+-- Display text on right of the screen, Example : https://pastebin.com/n1YmNe25
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostFeedTicker(p2) end
+
+-- _UI_FEED_POST_GAME_UPDATE_SHARD  (0x8D1249BD28791878)
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostGameUpdateShard(p2) end
+
+-- _UI_FEED_POST_HELP_TEXT  (0x049D5C615BD38BAD)
+-- Example : https://pastebin.com/GvdBp8Dh
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostHelpText(p2) end
+
+-- _UI_FEED_POST_LOCATION_SHARD  (0xD05590C1AB38F068)
+-- Example : https://pastebin.com/h1YzycuR
+-- min build: 1207
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostLocationShard(p2, p3) end
+
+-- _UI_FEED_POST_MISSION_NAME  (0x2024F4F333095FB1)
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostMissionName(p2) end
+
+-- _UI_FEED_POST_OBJECTIVE  (0xCEDBF17EFCC0E4A4)
+-- Example : https://pastebin.com/13tuRa63
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostObjective(p2) end
+
+-- _UI_FEED_POST_ONE_TEXT_SHARD  (0x860DDFE97CC94DF0)
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostOneTextShard(p2) end
+
+-- _UI_FEED_POST_RANKUP_TOAST  (0x3F9FDDBA79117C69)
+-- min build: 1207
+---@param p2 number
+---@param p3 number
+---@return number
+---@return any
+---@return any
+function _UiFeedPostRankupToast(p2, p3) end
+
+-- _UI_FEED_POST_RETICLE_MESSAGE  (0x893128CDB4B81FBB)
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostReticleMessage(p2) end
+
+-- _UI_FEED_POST_SAMPLE_NOTIFICATION  (0xC927890AA64E9661)
+-- Example : https://pastebin.com/kAtEMQTD
+-- min build: 1207
+---@param p2 number
+---@param p3 number
+---@return number
+---@return any
+---@return any
+function _UiFeedPostSampleNotification(p2, p3) end
+
+-- _UI_FEED_POST_SAMPLE_TOAST  (0x26E87218390E6729)
+-- Example : https://pastebin.com/YZMBkAmW
+-- min build: 1207
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostSampleToast(p2, p3) end
+
+-- _UI_FEED_POST_SAMPLE_TOAST_RIGHT  (0xB249EBCB30DD88E0)
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostSampleToastRight(p2) end
+
+-- _UI_FEED_POST_SAMPLE_TOAST_WITH_APP_LINK  (0x38838A646FB30AAE)
+-- min build: 1311
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostSampleToastWithAppLink(p2, p3, p4) end
+
+-- _UI_FEED_POST_THREE_TEXT_SHARD  (0x02BCC0FE9EBA3529)
+-- min build: 1207
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostThreeTextShard(p2, p3, p4) end
+
+-- _UI_FEED_POST_TWO_TEXT_SHARD  (0xA6F4216AB10EB08E)
+-- min build: 1207
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostTwoTextShard(p2, p3) end
+
+-- _UI_FEED_POST_VOICE_CHAT_FEED  (0xC48152BC6B3E821C)
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiFeedPostVoiceChatFeed(p2) end
+
+-- UI_FEED_CLEAR_CHANNEL  (0xDD1232B332CBB9E7)
+-- feedChannel: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eUIFeedChannel
+-- min build: 1207
+---@param feedChannel number
+---@param p1 boolean
+---@param p2 boolean
+function UiFeedClearChannel(feedChannel, p1, p2) end
+
+-- UI_FEED_GET_CURRENT_MESSAGE  (0xC17F69E1418CD11F)
+-- feedChannel: see UI_FEED_CLEAR_CHANNEL
+-- Returns feedMessage
+-- min build: 1207
+---@param feedChannel number
+---@return number
+function UiFeedGetCurrentMessage(feedChannel) end

--- a/.luals/redm-natives/UILOG.lua
+++ b/.luals/redm-natives/UILOG.lua
@@ -1,0 +1,206 @@
+---@meta
+
+-- RDR3 namespace: UILOG -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x2A4765812202E671  (0x2A4765812202E671)
+-- min build: 1207
+---@return any
+function N_0x2A4765812202E671() end
+
+-- _0x763637F9B838B0A7  (0x763637F9B838B0A7)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 string
+function N_0x763637F9B838B0A7(p0, p1, p2) end
+
+-- _0xA20398536B7F1134  (0xA20398536B7F1134)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function N_0xA20398536B7F1134(p0, p1, p2, p3, p4, p5) end
+
+-- _0xA49D6D503E3EA847  (0xA49D6D503E3EA847)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0xA49D6D503E3EA847(p0, p1, p2, p3, p4) end
+
+-- _0xDA0A30153FCC0FFD  (0xDA0A30153FCC0FFD)
+-- min build: 1207
+function N_0xDA0A30153FCC0FFD() end
+
+-- _UILOG_ADD_ENTRY_HASH  (0x69D5479982355D8F)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param x number
+---@param y number
+---@param z number
+---@param p5 number
+---@param p6 number
+---@param p7 any
+function _UilogAddEntryHash(p0, p1, x, y, z, p5, p6, p7) end
+
+-- _UILOG_ADD_ITEM_TO_TASK_LIST  (0x49C63FDF69744A27)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+function _UilogAddItemToTaskList(p0, p1, p2, p3, p4, p5, p6, p7) end
+
+-- _UILOG_ADD_OR_UPDATE_OBJECTIVE  (0xB43163388484CC87)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 string
+---@param p4 boolean
+---@param p5 boolean
+---@param p6 boolean
+function _UilogAddOrUpdateObjective(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _UILOG_ADD_TOTAL_TAKE_ENTRY  (0x60C59968E8E87E6B)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 string
+---@param p3 string
+---@param p4 number
+function _UilogAddTotalTakeEntry(p0, p1, p2, p3, p4) end
+
+-- _UILOG_CLEAR_ALL_ENTRIES  (0xB95B4EA6B1EDF035)
+-- min build: 1207
+function _UilogClearAllEntries() end
+
+-- _UILOG_CLEAR_CACHED_OBJECTIVE  (0xDFF0D417277B41F8)
+-- min build: 1207
+function _UilogClearCachedObjective() end
+
+-- _UILOG_CLEAR_HAS_DISPLAYED_CACHED_OBJECTIVE  (0xA3108D6981A5CADB)
+-- min build: 1207
+function _UilogClearHasDisplayedCachedObjective() end
+
+-- _UILOG_GET_CACHED_OBJECTIVE  (0x15A4461BEB788096)
+-- min build: 1207
+---@return string
+function _UilogGetCachedObjective() end
+
+-- _UILOG_HAS_DISPLAYED_CACHED_OBJECTIVE  (0xCC48FFBB45B54F71)
+-- min build: 1207
+---@return boolean
+function _UilogHasDisplayedCachedObjective() end
+
+-- _UILOG_IS_ENTRY_REGISTERED  (0xB8188CCF52202475)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return boolean
+function _UilogIsEntryRegistered(p0, p1) end
+
+-- _UILOG_MARK_ALL_ENTRIES_AVAILABILITY  (0x3920574CF0A2B7B6)
+-- min build: 1207
+---@param p0 number
+---@param p1 string
+function _UilogMarkAllEntriesAvailability(p0, p1) end
+
+-- _UILOG_MARK_ENTRY_AVAILABILITY  (0x13E8D7DD08543482)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 number
+---@param p3 string
+function _UilogMarkEntryAvailability(p0, p1, p2, p3) end
+
+-- _UILOG_MARK_MISSION_COMPLETED  (0xDE31D66D1E54C471)
+-- min build: 1207
+---@param p0 number
+function _UilogMarkMissionCompleted(p0) end
+
+-- _UILOG_POST_NOTIFICATION  (0x49E58FE6EF40B987)
+-- min build: 1207
+---@return number
+---@return any
+function _UilogPostNotification() end
+
+-- _UILOG_PRINT_CACHED_OBJECTIVE  (0xE9990552DEC71600)
+-- min build: 1207
+function _UilogPrintCachedObjective() end
+
+-- _UILOG_REMOVE_ENTRY  (0xD594A19BE09A75C6)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function _UilogRemoveEntry(p0, p1) end
+
+-- _UILOG_SET_CACHED_OBJECTIVE  (0xFA233F8FE190514C)
+-- min build: 1207
+---@param p0 string
+function _UilogSetCachedObjective(p0) end
+
+-- _UILOG_SET_DISPLAY_COMPLETION_RATING  (0xA31013798FADCADC)
+-- min build: 1207
+---@param logEntryType number
+---@param p1 number
+---@param p2 boolean
+function _UilogSetDisplayCompletionRating(logEntryType, p1, p2) end
+
+-- _UILOG_SET_ENTRY_BRIEF_TEXTURE  (0x69684D9936958D8F)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param texture number
+---@param textureDictionary number
+function _UilogSetEntryBriefTexture(p0, p1, texture, textureDictionary) end
+
+-- _UILOG_SET_ENTRY_ICON_TEXTURE  (0x6965469934958D8F)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param icon number
+---@param iconDictionary number
+function _UilogSetEntryIconTexture(p0, p1, icon, iconDictionary) end
+
+-- _UILOG_SET_ENTRY_PINNED  (0x72A5CD214B342568)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 boolean
+function _UilogSetEntryPinned(p0, p1, p2) end
+
+-- _UILOG_SET_HAS_DISPLAYED_CACHED_OBJECTIVE  (0xA3108D6981A5CADC)
+-- min build: 1207
+function _UilogSetHasDisplayedCachedObjective() end
+
+-- _UILOG_SET_PENDING_DETAILS_ID  (0x136A027CF37B0A4F)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@return any
+function _UilogSetPendingDetailsId(p0, p1) end
+
+-- _UILOG_SET_TOTAL_TAKE_SUMMARY  (0xD106B211EF1B8F04)
+-- min build: 1207
+---@param p0 string
+---@param p1 string
+function _UilogSetTotalTakeSummary(p0, p1) end
+
+-- _UILOG_UPDATE_ENTRY_SUBHEADER  (0x80D6524190258C3E)
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+---@param p2 string
+function _UilogUpdateEntrySubheader(p0, p1, p2) end

--- a/.luals/redm-natives/UIPINNING.lua
+++ b/.luals/redm-natives/UIPINNING.lua
@@ -1,0 +1,10 @@
+---@meta
+
+-- RDR3 namespace: UIPINNING -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _UIPINNING_GET_TOOLTIP_TEXT  (0x3138582E0A13BFAB)
+-- min build: 1207
+---@param hash number
+---@return string
+function _UipinningGetTooltipText(hash) end

--- a/.luals/redm-natives/UISTATEMACHINE.lua
+++ b/.luals/redm-natives/UISTATEMACHINE.lua
@@ -1,0 +1,77 @@
+---@meta
+
+-- RDR3 namespace: UISTATEMACHINE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _UI_STATE_MACHINE_IS_EXITED  (0x11E73195E735B25B)
+-- It's either EXITED or EXITING
+-- min build: 1207
+---@param p0 number
+---@return boolean
+function _UiStateMachineIsExited(p0) end
+
+-- _UIFLOWBLOCK_ENTER  (0x3B7519720C9DCB45)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function _UiflowblockEnter(p0, p1) end
+
+-- _UIFLOWBLOCK_IS_LOADED  (0x10A93C057B6BD944)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _UiflowblockIsLoaded(p0) end
+
+-- _UIFLOWBLOCK_RELEASE  (0xF320A77DD5F781DF)
+-- min build: 1207
+---@param p0 any
+function _UiflowblockRelease(p0) end
+
+-- _UIFLOWBLOCK_REQUEST  (0xC0081B34E395CE48)
+-- min build: 1207
+---@param p0 any
+---@return any
+function _UiflowblockRequest(p0) end
+
+-- UI_STATE_MACHINE_CAN_REQUEST_TRANSITION  (0xF7C180F57F85D0B8)
+-- min build: 1207
+---@param p0 any
+---@return any
+function UiStateMachineCanRequestTransition(p0) end
+
+-- UI_STATE_MACHINE_CREATE  (0x4C6F2C4B7A03A266)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function UiStateMachineCreate(p0, p1) end
+
+-- UI_STATE_MACHINE_DESTROY  (0x4EB122210A90E2D8)
+-- min build: 1207
+---@param p0 any
+function UiStateMachineDestroy(p0) end
+
+-- UI_STATE_MACHINE_DESTROY_AND_CLEAR  (0x2738D68D2B4E09E7)
+-- min build: 1207
+---@return any
+function UiStateMachineDestroyAndClear() end
+
+-- UI_STATE_MACHINE_EXISTS  (0x5D15569C0FEBF757)
+-- min build: 1207
+---@param p0 any
+---@return any
+function UiStateMachineExists(p0) end
+
+-- UI_STATE_MACHINE_REQUEST_EXIT  (0x6B9FE4F0BA521A19)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function UiStateMachineRequestExit(p0, p1) end
+
+-- UI_STATE_MACHINE_REQUEST_TRANSITION  (0x7EA9C3547E80350E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function UiStateMachineRequestTransition(p0, p1) end

--- a/.luals/redm-natives/UISTICKYFEED.lua
+++ b/.luals/redm-natives/UISTICKYFEED.lua
@@ -1,0 +1,64 @@
+---@meta
+
+-- RDR3 namespace: UISTICKYFEED -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _UI_STICKY_FEED_CLEAR_MESSAGE  (0x00A15B94CBA4F76F)
+-- min build: 1207
+---@param msgId number
+function _UiStickyFeedClearMessage(msgId) end
+
+-- _UI_STICKY_FEED_CREATE_DEATH_FAIL_MESSAGE  (0x815C4065AE6E6071)
+-- Example: https://pastebin.com/JygJShNU
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiStickyFeedCreateDeathFailMessage(p2) end
+
+-- _UI_STICKY_FEED_CREATE_ERROR_MESSAGE  (0x9F2CC2439A04E7BA)
+-- Example: https://pastebin.com/EJD7ytnz
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiStickyFeedCreateErrorMessage(p2) end
+
+-- _UI_STICKY_FEED_CREATE_WARNING_MESSAGE  (0x339E16B41780FC35)
+-- Example: https://pastebin.com/6mLtee2S
+-- min build: 1207
+---@param p2 boolean
+---@return number
+---@return any
+---@return any
+function _UiStickyFeedCreateWarningMessage(p2) end
+
+-- _UI_STICKY_FEED_GET_MESSAGE_STATE  (0x07954320D77F6A3D)
+-- Returns state of sticky feed message, see 0x59FA676177DBE4C9
+-- min build: 1207
+---@param msgId number
+---@return number
+function _UiStickyFeedGetMessageState(msgId) end
+
+-- _UI_STICKY_FEED_IS_ALERT_SCREEN_ACTIVE  (0xF8806EC3FF840FDC)
+-- min build: 1207
+---@return boolean
+function _UiStickyFeedIsAlertScreenActive() end
+
+-- _UI_STICKY_FEED_IS_CHANNEL_ACTIVE  (0xC5C395C60B542A3C)
+-- stickyFeedChannel: https://github.com/Halen84/RDR3-Native-Flags-And-Enums/tree/main/eUIStickyFeedChannel
+-- min build: 1207
+---@param stickyFeedChannel number
+---@return boolean
+function _UiStickyFeedIsChannelActive(stickyFeedChannel) end
+
+-- _UI_STICKY_FEED_UPDATE_MESSAGE  (0xBC6F454E310124DA)
+-- Seems to only update _UI_STICKY_FEED_CREATE_ERROR_MESSAGE(0x9F2CC2439A04E7BA) and _UI_STICKY_FEED_CREATE_DEATH_FAIL_MESSAGE(0x815C4065AE6E6071) message.
+-- Example: https://pastebin.com/nDrJyWq2
+-- min build: 1207
+---@param msgId number
+---@param p2 boolean
+---@return any
+function _UiStickyFeedUpdateMessage(msgId, p2) end

--- a/.luals/redm-natives/UITUTORIAL.lua
+++ b/.luals/redm-natives/UITUTORIAL.lua
@@ -1,0 +1,43 @@
+---@meta
+
+-- RDR3 namespace: UITUTORIAL -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _UITUTORIAL_GET_IS_THREAT_INDICATOR_CAPABLE_RADAR_SHOWN  (0x2CC24A2A7A1489C4)
+-- min build: 1207
+---@return boolean
+function _UitutorialGetIsThreatIndicatorCapableRadarShown() end
+
+-- _UITUTORIAL_GET_IS_THREAT_INDICATOR_ON  (0xFC2E0A5E9ED4E1B4)
+-- min build: 1207
+---@return boolean
+function _UitutorialGetIsThreatIndicatorOn() end
+
+-- _UITUTORIAL_SET_RPG_ICON_VISIBILITY  (0xC116E6DF68DCE667)
+-- enum eRpgIcons
+-- {
+-- 	ICON_STAMINA,
+-- 	ICON_STAMINA_CORE,
+-- 	ICON_DEADEYE,
+-- 	ICON_DEADEYE_CORE,
+-- 	ICON_HEALTH,
+-- 	ICON_HEALTH_CORE,
+-- 	ICON_HORSE_HEALTH,
+-- 	ICON_HORSE_HEALTH_CORE,
+-- 	ICON_HORSE_STAMINA,
+-- 	ICON_HORSE_STAMINA_CORE,
+-- 	ICON_HORSE_COURAGE,
+-- 	ICON_HORSE_COURAGE_CORE
+-- };
+-- 
+-- enum eRpgIconVisibility
+-- {
+-- 	ICON_VISIBILITY_WAIT_TO_HIDE,
+-- 	ICON_VISIBILITY_ALWAYS_SHOW,
+-- 	ICON_VISIBILITY_ALWAYS_HIDE,
+-- 	ICON_VISIBILITY_ALWAYS_BLINK
+-- };
+-- min build: 1207
+---@param rpgIcon number
+---@param visibility number
+function _UitutorialSetRpgIconVisibility(rpgIcon, visibility) end

--- a/.luals/redm-natives/UNLOCK.lua
+++ b/.luals/redm-natives/UNLOCK.lua
@@ -1,0 +1,59 @@
+---@meta
+
+-- RDR3 namespace: UNLOCK -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _UNLOCK_GET_ITEM_ROLE_UNLOCK_INFO  (0x7C1C2062CFAD06FE)
+-- min build: 1207
+---@param unlockHash number
+---@return any
+function _UnlockGetItemRoleUnlockInfo(unlockHash) end
+
+-- _UNLOCK_IS_LOOTABLE  (0x66BF197E066050DE)
+-- min build: 1207
+---@param unlockHash number
+---@return boolean
+function _UnlockIsLootable(unlockHash) end
+
+-- _UNLOCK_IS_NEW  (0x644166BA7AA49DEA)
+-- min build: 1207
+---@param unlockHash number
+---@return boolean
+function _UnlockIsNew(unlockHash) end
+
+-- _UNLOCK_IS_UNLOCK_FLAG_SET  (0x6B6369647F26F09F)
+-- min build: 1207
+---@param unlockHash number
+---@param flag number
+---@return boolean
+function _UnlockIsUnlockFlagSet(unlockHash, flag) end
+
+-- _UNLOCK_SET_NEW  (0xA6D79C7AEF870A99)
+-- min build: 1207
+---@param unlockHash number
+---@param toggle boolean
+function _UnlockSetNew(unlockHash, toggle) end
+
+-- UNLOCK_IS_UNLOCKED  (0xC4B660C7B6040E75)
+-- min build: 1207
+---@param unlockHash number
+---@return boolean
+function UnlockIsUnlocked(unlockHash) end
+
+-- UNLOCK_IS_VISIBLE  (0x8588A14B75AF096B)
+-- min build: 1207
+---@param unlockHash number
+---@return boolean
+function UnlockIsVisible(unlockHash) end
+
+-- UNLOCK_SET_UNLOCKED  (0x1B7C5ADA8A6910A0)
+-- min build: 1207
+---@param unlockHash number
+---@param toggle boolean
+function UnlockSetUnlocked(unlockHash, toggle) end
+
+-- UNLOCK_SET_VISIBLE  (0x46B901A8ECDB5A61)
+-- min build: 1207
+---@param unlockHash number
+---@param toggle boolean
+function UnlockSetVisible(unlockHash, toggle) end

--- a/.luals/redm-natives/VEHICLE.lua
+++ b/.luals/redm-natives/VEHICLE.lua
@@ -1,0 +1,2862 @@
+---@meta
+
+-- RDR3 namespace: VEHICLE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x012701ED938B85DE  (0x012701ED938B85DE)
+-- Only used in SP Scripts.
+-- Related to Vehicle Speed.
+-- min build: 1207
+---@param p0 number
+---@param p1 number
+function N_0x012701ED938B85DE(p0, p1) end
+
+-- _0x0355FE37240E2C77  (0x0355FE37240E2C77)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0355FE37240E2C77(p0, p1) end
+
+-- _0x04F0579DBDD32F34  (0x04F0579DBDD32F34)
+-- _SET_VEHICLE_*
+-- min build: 1207
+---@param vehicle number
+function N_0x04F0579DBDD32F34(vehicle) end
+
+-- _0x0516FAE561276EFC  (0x0516FAE561276EFC)
+-- Takes value returned from 0x45853F4E17D847D5
+-- min build: 1207
+---@param trackIndex number
+---@return boolean
+function N_0x0516FAE561276EFC(trackIndex) end
+
+-- _0x0794199B25E499E1  (0x0794199B25E499E1)
+-- _SET_VEHICLE_S*
+-- min build: 1207
+---@param wagon number
+---@param p1 boolean
+function N_0x0794199B25E499E1(wagon, p1) end
+
+-- _0x0CD7914D17A970AB  (0x0CD7914D17A970AB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x0CD7914D17A970AB(p0, p1) end
+
+-- _0x0D5FDF0D36FA10CD  (0x0D5FDF0D36FA10CD)
+-- min build: 1207
+---@param trackIndex number
+function N_0x0D5FDF0D36FA10CD(trackIndex) end
+
+-- _0x0F7F603BDE08C4D3  (0x0F7F603BDE08C4D3)
+-- min build: 1207
+---@param p0 any
+function N_0x0F7F603BDE08C4D3(p0) end
+
+-- _0x0FDDEE66E3465726  (0x0FDDEE66E3465726)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x0FDDEE66E3465726(p0) end
+
+-- _0x104D9A7B1C0D0783  (0x104D9A7B1C0D0783)
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+function N_0x104D9A7B1C0D0783(vehicle, p1) end
+
+-- _0x1180A2974D251B7B  (0x1180A2974D251B7B)
+-- Returns p1 for 0xBA958F68031DDBFC (stationIndex)
+-- _GET_N* (NEAREST_STATION_FOR_TRAIN?)
+-- min build: 1207
+---@param train number
+---@return number
+function N_0x1180A2974D251B7B(train) end
+
+-- _0x13EB275BF81636D1  (0x13EB275BF81636D1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x13EB275BF81636D1(p0, p1) end
+
+-- _0x14DA8C4BC2CCD90A  (0x14DA8C4BC2CCD90A)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x14DA8C4BC2CCD90A(p0) end
+
+-- _0x15206E88FF7617DF  (0x15206E88FF7617DF)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x15206E88FF7617DF(trackIndex, p1) end
+
+-- _0x15CC8C33D7FFCC4A  (0x15CC8C33D7FFCC4A)
+-- min build: 1436
+---@param vehicle number
+---@param p1 number
+function N_0x15CC8C33D7FFCC4A(vehicle, p1) end
+
+-- _0x160C1B5AB48AB87C  (0x160C1B5AB48AB87C)
+-- min build: 1207
+---@param train number
+---@param p1 number
+function N_0x160C1B5AB48AB87C(train, p1) end
+
+-- _0x165BE2001E5E4B75  (0x165BE2001E5E4B75)
+-- min build: 1207
+---@param p0 any
+function N_0x165BE2001E5E4B75(p0) end
+
+-- _0x16B86A49E072AA85  (0x16B86A49E072AA85)
+-- min build: 1207
+function N_0x16B86A49E072AA85() end
+
+-- _0x172E9DD35858DCD7  (0x172E9DD35858DCD7)
+-- min build: 1207
+---@param p0 any
+function N_0x172E9DD35858DCD7(p0) end
+
+-- _0x1A861F899EBBE17C  (0x1A861F899EBBE17C)
+-- min build: 1207
+---@param train number
+---@param p1 boolean
+function N_0x1A861F899EBBE17C(train, p1) end
+
+-- _0x2045429505158D1A  (0x2045429505158D1A)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x2045429505158D1A(p0) end
+
+-- _0x27E3F2B57209FA54  (0x27E3F2B57209FA54)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x27E3F2B57209FA54(p0, p1) end
+
+-- _0x2A7413168F6CD5A8  (0x2A7413168F6CD5A8)
+-- min build: 1207
+function N_0x2A7413168F6CD5A8() end
+
+-- _0x2BB2B5BCF0DF8008  (0x2BB2B5BCF0DF8008)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x2BB2B5BCF0DF8008(p0, p1) end
+
+-- _0x2C46D2A591D8C322  (0x2C46D2A591D8C322)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x2C46D2A591D8C322(p0, p1, p2) end
+
+-- _0x3053064F909B5F42  (0x3053064F909B5F42)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3053064F909B5F42(p0, p1) end
+
+-- _0x3137EDC899E6DAE4  (0x3137EDC899E6DAE4)
+-- min build: 1355
+---@param p0 any
+---@param p1 any
+function N_0x3137EDC899E6DAE4(p0, p1) end
+
+-- _0x331CBD247FC5DAA8  (0x331CBD247FC5DAA8)
+-- Returns trackIndex
+-- min build: 1207
+---@param configHash number
+---@param x number
+---@param y number
+---@param z number
+---@param direction boolean
+---@param p5 boolean
+---@return number
+function N_0x331CBD247FC5DAA8(configHash, x, y, z, direction, p5) end
+
+-- _0x34BCF6209B9668A7  (0x34BCF6209B9668A7)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 any
+function N_0x34BCF6209B9668A7(trackIndex, p1) end
+
+-- _0x37D238BE69F7378A  (0x37D238BE69F7378A)
+-- min build: 1207
+---@param trackIndex number
+---@return boolean
+function N_0x37D238BE69F7378A(trackIndex) end
+
+-- _0x38E7DD70A242D5CB  (0x38E7DD70A242D5CB)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x38E7DD70A242D5CB(trackIndex, p1) end
+
+-- _0x3ABFA128F5BF5A70  (0x3ABFA128F5BF5A70)
+-- Called together with 0xE6C5E2125EB210C1 in R* Script medium_update.
+-- trainTrack: see 0x09034479E6E3E269.
+-- min build: 1207
+---@param trainTrack number
+---@param junctionIndex number
+---@param enabled boolean
+function N_0x3ABFA128F5BF5A70(trainTrack, junctionIndex, enabled) end
+
+-- _0x3D86997A86FEEF0D  (0x3D86997A86FEEF0D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x3D86997A86FEEF0D(p0, p1) end
+
+-- _0x41365DB586CD9E8E  (0x41365DB586CD9E8E)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x41365DB586CD9E8E(trackIndex, p1) end
+
+-- _0x41F0B254DDF71473  (0x41F0B254DDF71473)
+-- _H*
+-- min build: 1207
+---@param wagon number
+function N_0x41F0B254DDF71473(wagon) end
+
+-- _0x427C919E9809E370  (0x427C919E9809E370)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x427C919E9809E370(trackIndex, p1) end
+
+-- _0x485B05EF05B9AEE9  (0x485B05EF05B9AEE9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x485B05EF05B9AEE9(p0, p1) end
+
+-- _0x4C05B42A8D937796  (0x4C05B42A8D937796)
+-- min build: 1207
+function N_0x4C05B42A8D937796() end
+
+-- _0x4C60C333F9CCA2B6  (0x4C60C333F9CCA2B6)
+-- Params: p1 usually true in R* Scripts
+-- _SET_DRAFT_VEHICLE_*
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0x4C60C333F9CCA2B6(vehicle, p1) end
+
+-- _0x5AADC7BBBB1BCEEB  (0x5AADC7BBBB1BCEEB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+function N_0x5AADC7BBBB1BCEEB(p0, p1, p2, p3, p4) end
+
+-- _0x615B3B8E73634509  (0x615B3B8E73634509)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x615B3B8E73634509(trackIndex, p1) end
+
+-- _0x63509DDF102E08E8  (0x63509DDF102E08E8)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x63509DDF102E08E8(trackIndex, p1) end
+
+-- _0x6355602C02EDC6DF  (0x6355602C02EDC6DF)
+-- Only used in R* Script beat_train_holdup: p1 = 1
+-- min build: 1207
+---@param entity number
+---@param p1 any
+function N_0x6355602C02EDC6DF(entity, p1) end
+
+-- _0x6703872EC09BC158  (0x6703872EC09BC158)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x6703872EC09BC158(p0, p1) end
+
+-- _0x68830738A6BFB370  (0x68830738A6BFB370)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x68830738A6BFB370(p0, p1) end
+
+-- _0x6B34BE961F639E21  (0x6B34BE961F639E21)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0x6B34BE961F639E21(trackIndex, p1) end
+
+-- _0x6B53F4B811E583D2  (0x6B53F4B811E583D2)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function N_0x6B53F4B811E583D2(vehicle, toggle) end
+
+-- _0x6C87F49BFA181DB5  (0x6C87F49BFA181DB5)
+-- Returns trackIndex
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function N_0x6C87F49BFA181DB5(x, y, z) end
+
+-- _0x6DE072AC8A95FFC1  (0x6DE072AC8A95FFC1)
+-- _SET_INSTANTLY_* - _SET_MISSION_TRAIN*
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0x6DE072AC8A95FFC1(vehicle, p1) end
+
+-- _0x6EA1273D525427F4  (0x6EA1273D525427F4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x6EA1273D525427F4(p0, p1, p2) end
+
+-- _0x6FD7BDF10304363A  (0x6FD7BDF10304363A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x6FD7BDF10304363A(p0, p1) end
+
+-- _0x703D4FB366DA4452  (0x703D4FB366DA4452)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x703D4FB366DA4452(p0, p1) end
+
+-- _0x718EB706B6E998A0  (0x718EB706B6E998A0)
+-- min build: 1207
+---@param trackIndex number
+function N_0x718EB706B6E998A0(trackIndex) end
+
+-- _0x73118A3EE9C9B6DB  (0x73118A3EE9C9B6DB)
+-- _SET_VEHICLE_WHEELS_*
+-- min build: 1207
+---@param wagon number
+---@param p1 number
+---@param p2 boolean
+function N_0x73118A3EE9C9B6DB(wagon, p1, p2) end
+
+-- _0x7408B5C66BA31ADB  (0x7408B5C66BA31ADB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+function N_0x7408B5C66BA31ADB(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- _0x750D42C013F64AE7  (0x750D42C013F64AE7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x750D42C013F64AE7(p0, p1) end
+
+-- _0x762FDC4C19E5A981  (0x762FDC4C19E5A981)
+-- Seems to be related while setting a (door) state of specific trains (midlandboxcar05x, privateboxcar01x, privateboxcar02x, midlandrefrigeratorCar, privateArmoured, armoredCar01x)
+-- min build: 1207
+---@param trainCarriage number
+---@param p1 boolean
+function N_0x762FDC4C19E5A981(trainCarriage, p1) end
+
+-- _0x7840576C50A13DBA  (0x7840576C50A13DBA)
+-- min build: 1207
+---@param train number
+---@param p1 boolean
+function N_0x7840576C50A13DBA(train, p1) end
+
+-- _0x7BE0746539DEF0C8  (0x7BE0746539DEF0C8)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x7BE0746539DEF0C8(p0, p1) end
+
+-- _0x8379E05871AD24E0  (0x8379E05871AD24E0)
+-- min build: 1207
+function N_0x8379E05871AD24E0() end
+
+-- _0x850CE59DEC2028F3  (0x850CE59DEC2028F3)
+-- min build: 1207
+---@param vehicle number
+---@param p1 any
+function N_0x850CE59DEC2028F3(vehicle, p1) end
+
+-- _0x873AAF600CC36DAC  (0x873AAF600CC36DAC)
+-- min build: 1207
+---@param p0 any
+function N_0x873AAF600CC36DAC(p0) end
+
+-- _0x87B974E54C71BA7B  (0x87B974E54C71BA7B)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0x87B974E54C71BA7B(vehicle, p1) end
+
+-- _0x8878FF3EEE2868A9  (0x8878FF3EEE2868A9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8878FF3EEE2868A9(p0, p1) end
+
+-- _0x8DECD262602548B9  (0x8DECD262602548B9)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x8DECD262602548B9(p0, p1) end
+
+-- _0x9868C0D0134855F7  (0x9868C0D0134855F7)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+function N_0x9868C0D0134855F7(p0) end
+
+-- _0x98A7598C579EE871  (0x98A7598C579EE871)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x98A7598C579EE871(p0, p1, p2) end
+
+-- _0x9E8711C81AA17876  (0x9E8711C81AA17876)
+-- Forcing high LOD buoyancy for vehicle: p1 = false
+-- _SET_A*
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0x9E8711C81AA17876(vehicle, p1) end
+
+-- _0xA230A5DDE12ED374  (0xA230A5DDE12ED374)
+-- min build: 1207
+---@param p0 any
+function N_0xA230A5DDE12ED374(p0) end
+
+-- _0xA72B1BF3857B94D7  (0xA72B1BF3857B94D7)
+-- min build: 1207
+---@param train number
+---@param p1 boolean
+function N_0xA72B1BF3857B94D7(train, p1) end
+
+-- _0xA7966807953A18EE  (0xA7966807953A18EE)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0xA7966807953A18EE(trackIndex, p1) end
+
+-- _0xA9E185D498B9AC67  (0xA9E185D498B9AC67)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xA9E185D498B9AC67(p0, p1) end
+
+-- _0xAE7E66A61E7C17A5  (0xAE7E66A61E7C17A5)
+-- _SET_TRAIN_*
+-- min build: 1207
+---@param train number
+---@param p1 boolean
+function N_0xAE7E66A61E7C17A5(train, p1) end
+
+-- _0xB4241AD8F5AEE9ED  (0xB4241AD8F5AEE9ED)
+-- min build: 1207
+---@param trackIndex number
+---@return boolean
+function N_0xB4241AD8F5AEE9ED(trackIndex) end
+
+-- _0xB961DD799A837BD7  (0xB961DD799A837BD7)
+-- min build: 1207
+function N_0xB961DD799A837BD7() end
+
+-- _0xC325A6BAA62CF8A2  (0xC325A6BAA62CF8A2)
+-- Used in Script Function MC_LOCAL_SETUP_VEH - enabling transitions
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0xC325A6BAA62CF8A2(vehicle, p1) end
+
+-- _0xC351394B932A6A50  (0xC351394B932A6A50)
+-- min build: 1207
+---@param p0 any
+function N_0xC351394B932A6A50(p0) end
+
+-- _0xC399CC89FBA05DA0  (0xC399CC89FBA05DA0)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0xC399CC89FBA05DA0(vehicle, p1) end
+
+-- _0xC4A2C11FC0D41916  (0xC4A2C11FC0D41916)
+-- _SET_DRAFT_VEHICLE_(STOP?)*
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0xC4A2C11FC0D41916(vehicle, p1) end
+
+-- _0xCACAB2B123BBDBD6  (0xCACAB2B123BBDBD6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xCACAB2B123BBDBD6(p0, p1, p2) end
+
+-- _0xCAFF2C9747103C02  (0xCAFF2C9747103C02)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0xCAFF2C9747103C02(p0, p1, p2) end
+
+-- _0xCBC7B6F9A56B79F6  (0xCBC7B6F9A56B79F6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCBC7B6F9A56B79F6(p0, p1) end
+
+-- _0xCBF88256E44D5D39  (0xCBF88256E44D5D39)
+-- Used in Script Function MC_LOCAL_SETUP_VEH - enabling transitions
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0xCBF88256E44D5D39(vehicle, p1) end
+
+-- _0xCEB1F1EED484A5B4  (0xCEB1F1EED484A5B4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xCEB1F1EED484A5B4(p0, p1) end
+
+-- _0xCF342503CA4C8DF1  (0xCF342503CA4C8DF1)
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+function N_0xCF342503CA4C8DF1(vehicle, p1) end
+
+-- _0xD0116DF21E6C7B36  (0xD0116DF21E6C7B36)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xD0116DF21E6C7B36(p0, p1) end
+
+-- _0xD0AABE5B9F8FA589  (0xD0AABE5B9F8FA589)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 number
+function N_0xD0AABE5B9F8FA589(trackIndex, p1) end
+
+-- _0xD0BA1853D76683C8  (0xD0BA1853D76683C8)
+-- min build: 1207
+---@param trackIndex number
+---@param x number
+---@param y number
+---@param z number
+---@param p4 any
+function N_0xD0BA1853D76683C8(trackIndex, x, y, z, p4) end
+
+-- _0xD1DF5E54F4ACBE1A  (0xD1DF5E54F4ACBE1A)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0xD1DF5E54F4ACBE1A(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0xD21A3D421E7F09F7  (0xD21A3D421E7F09F7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xD21A3D421E7F09F7(p0, p1) end
+
+-- _0xD4907EF4334C7602  (0xD4907EF4334C7602)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xD4907EF4334C7602(p0, p1) end
+
+-- _0xD826690B5CF3BEFF  (0xD826690B5CF3BEFF)
+-- min build: 1207
+---@param vehicle number
+---@param p1 any
+function N_0xD826690B5CF3BEFF(vehicle, p1) end
+
+-- _0xD9BF3ED8EFB67EA3  (0xD9BF3ED8EFB67EA3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return any
+function N_0xD9BF3ED8EFB67EA3(p0, p1, p2, p3, p4) end
+
+-- _0xDC0556D0F484ECAA  (0xDC0556D0F484ECAA)
+-- min build: 1207
+---@param p0 any
+function N_0xDC0556D0F484ECAA(p0) end
+
+-- _0xDC69F6913CCA0B99  (0xDC69F6913CCA0B99)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDC69F6913CCA0B99(p0, p1) end
+
+-- _0xDD100CE1EBBF37E3  (0xDD100CE1EBBF37E3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xDD100CE1EBBF37E3(p0, p1) end
+
+-- _0xDE8C5B9F65017FA1  (0xDE8C5B9F65017FA1)
+-- min build: 1207
+---@param train number
+---@return any
+function N_0xDE8C5B9F65017FA1(train) end
+
+-- _0xE12F5ED49F44D40D  (0xE12F5ED49F44D40D)
+-- min build: 1207
+---@param p0 any
+function N_0xE12F5ED49F44D40D(p0) end
+
+-- _0xE1C0F8781BF130C2  (0xE1C0F8781BF130C2)
+-- Only used in R* SP Script rcm_abigail31: p1 = 5
+-- _GET_VEHICLE_T* - _GET_VO*
+-- min build: 1207
+---@param wagon number
+---@param p1 number
+---@return boolean
+function N_0xE1C0F8781BF130C2(wagon, p1) end
+
+-- _0xE682002DB1F30669  (0xE682002DB1F30669)
+-- min build: 1207
+---@param p0 any
+function N_0xE682002DB1F30669(p0) end
+
+-- _0xE777DDF3E78397E8  (0xE777DDF3E78397E8)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xE777DDF3E78397E8(p0) end
+
+-- _0xE78993FF9022C064  (0xE78993FF9022C064)
+-- min build: 1207
+---@param p0 any
+function N_0xE78993FF9022C064(p0) end
+
+-- _0xEF28A614B4B264B8  (0xEF28A614B4B264B8)
+-- _SET_TRAIN_*
+-- min build: 1207
+---@param train number
+---@param p1 boolean
+function N_0xEF28A614B4B264B8(train, p1) end
+
+-- _0xF57DB8E83DCD8349  (0xF57DB8E83DCD8349)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF57DB8E83DCD8349(p0) end
+
+-- _0xF5EA41C1408695FB  (0xF5EA41C1408695FB)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@return any
+function N_0xF5EA41C1408695FB(p0, p1, p2, p3) end
+
+-- _0xF8F7DA13CFBD4532  (0xF8F7DA13CFBD4532)
+-- min build: 1207
+---@param trackIndex number
+---@param p1 boolean
+function N_0xF8F7DA13CFBD4532(trackIndex, p1) end
+
+-- _0xFC4F15A7DDDC47B1  (0xFC4F15A7DDDC47B1)
+-- _SET_DRAFT_VEHICLE_*
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0xFC4F15A7DDDC47B1(vehicle, p1) end
+
+-- _0xFF2B1F59FB892F14  (0xFF2B1F59FB892F14)
+-- min build: 1207
+---@param p0 any
+function N_0xFF2B1F59FB892F14(p0) end
+
+-- _0xFFFE15B433300B8C  (0xFFFE15B433300B8C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xFFFE15B433300B8C(p0, p1, p2) end
+
+-- _ADD_TRAIN_TEMPORARY_STOP  (0x41503629D1139ABC)
+-- min build: 1207
+---@param train number
+---@param trackIndex number
+---@param x number
+---@param y number
+---@param z number
+function _AddTrainTemporaryStop(train, trackIndex, x, y, z) end
+
+-- _ARE_ANY_VEHICLE_WHEELS_DESTROYED  (0x18714953CCED17D3)
+-- Returns true if any wheel is destroyed
+-- IS_VEHICLE_DRIVEABLE will still return true even though a wheel is destroyed, like vehicles with 4 wheels.
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _AreAnyVehicleWheelsDestroyed(vehicle) end
+
+-- _ATTACH_DRAFT_VEHICLE_HARNESS_PED  (0x316CDB5B6E8F4110)
+-- min build: 1207
+---@param mount number
+---@param draft number
+---@param harnessId number
+---@return boolean
+function _AttachDraftVehicleHarnessPed(mount, draft, harnessId) end
+
+-- _BALLOON_ATTACH_CHAIN_TO_PILOT  (0x23F66C36F8E5EAAB)
+-- Attaches a chain from the balloon to the pilot hand bone.
+-- Uses SKEL_R_Finger02 by default, or SKEL_L_Finger43 when attachToLeftHand is true.
+-- min build: 1207
+---@param balloon number
+---@param attachToLeftHand boolean
+function _BalloonAttachChainToPilot(balloon, attachToLeftHand) end
+
+-- _BALLOON_DETACH_CHAIN_FROM_PILOT  (0x697DF68F3A761A50)
+-- Detaches the pilot hand chain from the balloon.
+-- min build: 1207
+---@param balloon number
+function _BalloonDetachChainFromPilot(balloon) end
+
+-- _BREAK_LOCKS_ON_VEHICLE  (0x9D12796EF4BF9EA9)
+-- Instantly pops/destroys breakable lock objects attached to the vehicle and swings open the corresponding doors or compartments.
+-- min build: 1207
+---@param vehicle number
+function _BreakLocksOnVehicle(vehicle) end
+
+-- _BREAK_OFF_DRAFT_WHEEL  (0xC372B6A88F6E4AD8)
+-- Params: destroyingForce is usually 100f in R* Scripts
+-- Similar to 0xD4F5EFB55769D272, _A*
+-- min build: 1207
+---@param vehicle number
+---@param wheelIndex number
+---@param destroyingForce number
+function _BreakOffDraftWheel(vehicle, wheelIndex, destroyingForce) end
+
+-- _BREAK_OFF_VEHICLE_WHEEL  (0xD4F5EFB55769D272)
+-- wheelIndex 0: left, wheelIndex 1: right, 4 & 5: unknown
+-- min build: 1207
+---@param vehicle number
+---@param wheelIndex number
+---@return number
+function _BreakOffVehicleWheel(vehicle, wheelIndex) end
+
+-- _BREAK_VEHICLE_STRAPS  (0xD1EFA8D68BF5D63D)
+-- Only used to break draft vehicle log straps. Coords is always equal to the vehicle coords.
+-- min build: 1207
+---@param vehicle number
+---@param x number
+---@param y number
+---@param z number
+function _BreakVehicleStraps(vehicle, x, y, z) end
+
+-- _CREATE_DRAFT_VEHICLE  (0x214651FB1DFEBA89)
+-- Identical to CREATE_VEHICLE but allows to set draftAnimalPopGroup (see popgroups.#mt for DRAFT_HORSES_*)
+-- min build: 1207
+---@param modelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param isNetwork boolean
+---@param bScriptHostVeh boolean
+---@param bDontAutoCreateDraftAnimals boolean
+---@param draftAnimalPopGroup number
+---@param p9 boolean
+---@return number
+function _CreateDraftVehicle(modelHash, x, y, z, heading, isNetwork, bScriptHostVeh, bDontAutoCreateDraftAnimals, draftAnimalPopGroup, p9) end
+
+-- _CREATE_MISSION_TRAIN  (0xC239DBD9A57D2A71)
+-- configHash: https://alloc8or.re/rdr3/doc/enums/eTrainConfig.txt
+-- For more information, see trainconfigs.ymt
+-- To make the train AI controlled, set conductor to true and set the speed once.
+-- min build: 1207
+---@param configHash number
+---@param x number
+---@param y number
+---@param z number
+---@param direction boolean
+---@param passengers boolean
+---@param p6 boolean
+---@param conductor boolean
+---@return number
+function _CreateMissionTrain(configHash, x, y, z, direction, passengers, p6, conductor) end
+
+-- _DELETE_VEHICLE_LANTERNS  (0xE1A83D4A3B5D7938)
+-- Spawn without lanterns set
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _DeleteVehicleLanterns(vehicle) end
+
+-- _DETACH_DRAFT_VEHICLE_HARNESS_FROM_INDEX  (0x4402960666000E62)
+-- min build: 1207
+---@param draft number
+---@param harnessId number
+---@return boolean
+function _DetachDraftVehicleHarnessFromIndex(draft, harnessId) end
+
+-- _DETACH_DRAFT_VEHICLE_HARNESS_PED  (0xB36D3EC70963BE60)
+-- min build: 1207
+---@param draft number
+---@param ped number
+---@return boolean
+function _DetachDraftVehicleHarnessPed(draft, ped) end
+
+-- _DETACH_WAGON_ENTITY_FROM_TRAIN  (0x54CBDD6E1B4CB4DF)
+-- Only used in train_robbery4 R* Script
+-- _C* - _DEL*
+-- min build: 1207
+---@param entity number
+function _DetachWagonEntityFromTrain(entity) end
+
+-- _DETERMINE_VEHICLE_COMPARTMENT_STATE  (0x877EA24EB1614495)
+-- Determines the interaction/storage state of a vehicle rear compartment or storage area.
+-- Returns whether the query succeeded and writes a state value to outState.
+-- 
+-- Observed states:
+-- - 1 = compartment available / unopened
+-- - 57 = vehicle has no valid compartment/storage
+-- - 72 = compartment opened, resolved or depleted
+-- 
+-- Used by wagons with rear storage and prison wagons with breakable locks.
+-- min build: 1207
+---@param vehicle number
+---@param ped number
+---@return boolean
+---@return any
+function _DetermineVehicleCompartmentState(vehicle, ped) end
+
+-- _DOES_TRAIN_EXIST_ON_TRACK  (0xC29996A337BDD099)
+-- min build: 1207
+---@param trackIndex number
+---@return boolean
+function _DoesTrainExistOnTrack(trackIndex) end
+
+-- _FADE_AND_DESTROY_VEHICLE  (0x35DC1877312FBA0F)
+-- min build: 1207
+---@return number
+function _FadeAndDestroyVehicle() end
+
+-- _GET_ALL_WAGON_PASSENGERS  (0x0E558D3A49D759D6)
+-- Collects all passenger peds (excluding the driver) from the specified wagon-type vehicle (train wagon) and appends them to itemSet as indexed items. Returns the number of passengers added (0 if none / invalid / non-wagon).
+-- 
+-- Notes:
+-- 	- Only works on wagon entities (train wagons). Regular vehicles/coaches typically return 0.
+-- 	- Clear the itemset before calling.
+-- 	- If you also need the driver, query GET_DRIVER_OF_VEHICLE(wagon) and handle/add it separately (see scripts).
+-- 	- Resolve returned entries via indexed item helpers:
+-- 		Ped p = MISC::_GET_PED_FROM_INDEXED_ITEM(ITEMSET::GET_INDEXED_ITEM_IN_ITEMSET(i, itemSet));
+-- 		(or: Entity e = MISC::_GET_ENTITY_FROM_ITEM(...); then ENTITY::GET_PED_INDEX_FROM_ENTITY_INDEX(e)).
+-- 	- Wagon auto-population can be toggled via ENTITY::_0x119A5714578F4E05(wagon, bool); scripts disable it in some flows.
+-- 
+-- Example image: https://imgur.com/a/2V8Uk2K
+-- 
+-- Example (C++):
+-- 	ItemSet set = ITEMSET::CREATE_ITEMSET(true);
+-- 	ITEMSET::_CLEAR_ITEMSET(set);
+-- 	int count = VEHICLE::_GET_ALL_WAGON_PASSENGERS(wagon, set);
+-- 	for (int i = 0; i < count; ++i) {
+-- 		Ped p = MISC::_GET_PED_FROM_INDEXED_ITEM(ITEMSET::GET_INDEXED_ITEM_IN_ITEMSET(i, set));
+-- 		if (ENTITY::DOES_ENTITY_EXIST(p) && !ENTITY::IS_ENTITY_DEAD(p)) {
+-- 			// ...
+-- 		}
+-- 	}
+-- 	ITEMSET::DESTROY_ITEMSET(set);
+-- min build: 1207
+---@param wagon number
+---@param itemSet number
+---@return number
+function _GetAllWagonPassengers(wagon, itemSet) end
+
+-- _GET_BALLOON_OBJECT_FROM_VEHICLE  (0x0BA4250D20007C2E)
+-- Returns the balloon OBJECT entity attached to a hot air balloon vehicle.
+-- 
+-- Returns 0 if:
+-- 	- vehicle is not a hot air balloon type, or
+-- 	- the balloon object is not present.
+-- 
+-- Notes:
+-- 	- Returned handle is typically an OBJECT (not a ped/vehicle).
+-- 	- Always validate with ENTITY::DOES_ENTITY_EXIST before use.
+-- 	- Example image: https://imgur.com/a/YWDUJ56
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetBalloonObjectFromVehicle(vehicle) end
+
+-- _GET_BREAKABLE_VEHICLE_LOCK_OBJECT  (0x58F2244C1286D09A)
+-- min build: 1207
+---@param vehicle number
+---@param index number
+---@return number
+function _GetBreakableVehicleLockObject(vehicle, index) end
+
+-- _GET_BREAKABLE_VEHICLE_LOCKS_STATE  (0xE015CF1F2C0959D8)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetBreakableVehicleLocksState(vehicle) end
+
+-- _GET_CHECKPOINT_TRAIN_SPAWN_LOCATION  (0x35D302397E524939)
+-- min build: 1207
+---@param trackIndex number
+---@param x number
+---@param y number
+---@param z number
+---@param distance number
+---@param direction boolean
+---@return vector3
+function _GetCheckpointTrainSpawnLocation(trackIndex, x, y, z, distance, direction) end
+
+-- _GET_CURRENT_TRACK_FOR_TRAIN  (0xAF787E081AC4A8EE)
+-- Returns p0 for 0xBA958F68031DDBFC (trackIndex)
+-- min build: 1207
+---@param train number
+---@return number
+function _GetCurrentTrackForTrain(train) end
+
+-- _GET_DRAFT_VEHICLE_DESIRED_SPEED  (0xC6D7DDC843176701)
+-- Returns rage::NumericLimits<float>::kMax (3.402823466e+38) if vehicle is not a valid vehicle of type VEHICLE_TYPE_DRAFT.
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetDraftVehicleDesiredSpeed(vehicle) end
+
+-- _GET_JUNCTION_COORDS_FOR_TRAIN_TRACK  (0x785639D89F8451AB)
+-- Returns the world coordinates of a junction node for the given train track configuration.
+-- trainTrack: see 0x09034479E6E3E269.
+-- min build: 1207
+---@param trainTrack number
+---@param junctionIndex number
+---@return vector3
+function _GetJunctionCoordsForTrainTrack(trainTrack, junctionIndex) end
+
+-- _GET_NEAREST_TRAIN_TRACK_POSITION  (0x6DE03BCC15E81710)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return vector3
+function _GetNearestTrainTrackPosition(x, y, z) end
+
+-- _GET_NUM_BREAKABLE_VEHICLE_LOCK_OBJECTS  (0x2FA86833E3617E2D)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetNumBreakableVehicleLockObjects(vehicle) end
+
+-- _GET_NUM_CARS_FROM_TRAIN_CONFIG  (0x635423D55CA84FC8)
+-- Returns amount for CAN_REGISTER_MISSION_VEHICLES
+-- min build: 1207
+---@param trainConfig number
+---@return number
+function _GetNumCarsFromTrainConfig(trainConfig) end
+
+-- _GET_NUM_DRAFT_VEHICLE_HARNESS_PED  (0x5B1A26BB18E7D451)
+-- Returns number of horses a wagon can have
+-- min build: 1207
+---@param modelHash number
+---@return number
+function _GetNumDraftVehicleHarnessPed(modelHash) end
+
+-- _GET_NUM_DRAFT_VEHICLE_LOGS  (0x288CBB414C3C2FBB)
+-- Return the number of logs on a draft vehicle.
+-- Video demo: https://imgur.com/a/5JEeOij
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetNumDraftVehicleLogs(vehicle) end
+
+-- _GET_NUM_DRAFT_VEHICLE_STRAPS  (0x1121B07088ED3013)
+-- Return the number of straps that hold the logs of a draft vehicle.
+-- Video demo: https://imgur.com/a/5JEeOij
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetNumDraftVehicleStraps(vehicle) end
+
+-- _GET_PED_IN_DRAFT_HARNESS  (0xA8BA0BAE0173457B)
+-- enum eDraftHarness
+-- {
+-- 	DRAFT_HARNESS_LR,
+-- 	DRAFT_HARNESS_RR,
+-- 	DRAFT_HARNESS_LM,
+-- 	DRAFT_HARNESS_RM,
+-- 	DRAFT_HARNESS_LF,
+-- 	DRAFT_HARNESS_RF,
+-- 	DRAFT_HARNESS_COUNT
+-- };
+-- min build: 1207
+---@param vehicle number
+---@param harnessId number
+---@return number
+function _GetPedInDraftHarness(vehicle, harnessId) end
+
+-- _GET_ROWING_OARS  (0xA6E210FB4283B767)
+-- Returns handles of boat paddles entities.
+-- min build: 1207
+---@param vehicle number
+---@return number
+---@return number
+function _GetRowingOars(vehicle) end
+
+-- _GET_STATION_AT_INDEX  (0x9CC94A948EAF5372)
+-- Returns the station hash for a given train track and station index.
+-- Notes:
+-- - trackIndex is typically 0..24 and stationIndex 0..7.
+-- - Returns 0 if the pair is invalid/out of range.
+-- min build: 1207
+---@param trackIndex number
+---@param stationIndex number
+---@return number
+function _GetStationAtIndex(trackIndex, stationIndex) end
+
+-- _GET_STATION_COORDS_FROM_TRAIN_STATION_DATA  (0xBA958F68031DDBFC)
+-- Returns Coords of vStation
+-- p0 - NET_TRAIN_MANAGER_GET_TRAIN_STATION_DATA
+-- _GET_P* - _GET_T*
+-- min build: 1207
+---@param trackIndex number
+---@param stationIndex number
+---@return vector3
+function _GetStationCoordsFromTrainStationData(trackIndex, stationIndex) end
+
+-- _GET_TRACK_AMOUNT_OF_VISIBLE_PIXELS  (0x13C190302369308B)
+-- Requires a visibility tracker on the vehicle (TRACK_VEHICLE_VISIBILITY)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetTrackAmountOfVisiblePixels(vehicle) end
+
+-- _GET_TRACK_INDEX_FROM_COORDS  (0x85D39F5E3B6D7EB0)
+-- Returns trackIndex
+-- _E* - _F*
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function _GetTrackIndexFromCoords(x, y, z) end
+
+-- _GET_TRAIN_CAR  (0x671A07C9A1CD50A5)
+-- Returns train car, use GET_TRAIN_CARRIAGE when trailerNumber is bigger than 0
+-- min build: 1207
+---@param train number
+---@return number
+function _GetTrainCar(train) end
+
+-- _GET_TRAIN_CARRIAGE_TRAILER_NUMBER  (0x60B7D1DCC312697D)
+-- Returns iNumCars - to be used with GET_TRAIN_CARRIAGE (trailerNumber)
+-- _C* (O, P, Q, R)
+-- min build: 1207
+---@param train number
+---@return number
+function _GetTrainCarriageTrailerNumber(train) end
+
+-- _GET_TRAIN_DIRECTION  (0x3C9628A811CBD724)
+-- min build: 1207
+---@param train number
+---@return boolean
+function _GetTrainDirection(train) end
+
+-- _GET_TRAIN_DIRECTION_FROM_INDEX  (0x67995318F5FAA496)
+-- https://i.imgur.com/1rHibjW.jpg
+-- min build: 1207
+---@param trackIndex number
+---@return boolean
+function _GetTrainDirectionFromIndex(trackIndex) end
+
+-- _GET_TRAIN_MODEL_FROM_TRAIN_CONFIG_BY_CAR_INDEX  (0x8DF5F6A19F99F0D5)
+-- Returns modelHash
+-- min build: 1207
+---@param trainConfig number
+---@param trainCarIndex number
+---@return number
+function _GetTrainModelFromTrainConfigByCarIndex(trainConfig, trainCarIndex) end
+
+-- _GET_TRAIN_POSITION_ON_TRACK  (0x1E8A921112891651)
+-- min build: 1207
+---@param trackIndex number
+---@return vector3
+function _GetTrainPositionOnTrack(trackIndex) end
+
+-- _GET_TRAIN_TRACK_FROM_TRAIN_VEHICLE  (0x45853F4E17D847D5)
+-- Returns trackIndex
+-- min build: 1207
+---@param train number
+---@return number
+function _GetTrainTrackFromTrainVehicle(train) end
+
+-- _GET_TRAIN_TRACK_JUNCTION_AT_COORDS  (0x86AFC343CF7F0B34)
+-- Outputs junctionIndex, to be used with 0xE6C5E2125EB210C1.
+-- trainTrack: see 0x09034479E6E3E269.
+-- min build: 1207
+---@param trainTrack number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return number
+function _GetTrainTrackJunctionAtCoords(trainTrack, x, y, z) end
+
+-- _GET_TRAIN_VEHICLE_FROM_TRACK_INDEX  (0x6E585A616ABB8401)
+-- Returns train
+-- min build: 1207
+---@param trackIndex number
+---@return number
+function _GetTrainVehicleFromTrackIndex(trackIndex) end
+
+-- _GET_VEHICLE_DOORS_LOCKED_FOR_TEAM  (0xDD1E1393D966D39A)
+-- min build: 1207
+---@param vehicle number
+---@param team number
+---@return boolean
+function _GetVehicleDoorsLockedForTeam(vehicle, team) end
+
+-- _GET_VEHICLE_IS_PROP_SET_APPLIED  (0xD798DF5DB67B1659)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _GetVehicleIsPropSetApplied(vehicle) end
+
+-- _GET_VEHICLE_LIVERY  (0xBB765B8FD49A796C)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetVehicleLivery(vehicle) end
+
+-- _GET_VEHICLE_OWNER  (0xB729679356A889AE)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetVehicleOwner(vehicle) end
+
+-- _GET_VEHICLE_TINT  (0xA44D65E6C624526F)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _GetVehicleTint(vehicle) end
+
+-- _GET_VEHICLE_TURRET_SEAT  (0xFF5791B7639C2A46)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+---@return number
+function _GetVehicleTurretSeat(vehicle) end
+
+-- _HAS_TRAIN_LOADED  (0xBD3C4A2ED509205E)
+-- min build: 1207
+---@param train number
+---@return boolean
+function _HasTrainLoaded(train) end
+
+-- _HIDE_HORSE_REINS  (0x201B8ED4FF7FE9F5)
+-- min build: 1207
+---@param vehicle number
+function _HideHorseReins(vehicle) end
+
+-- _IS_BOAT_GROUNDED  (0x30D86B2B7622D0EB)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsBoatGrounded(vehicle) end
+
+-- _IS_PED_EXCLUSIVE_DRIVER_OF_VEHICLE  (0xB213D2A560B2E48B)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@return boolean
+---@return number
+function _IsPedExclusiveDriverOfVehicle(ped, vehicle) end
+
+-- _IS_POSITION_VALID_FOR_TRAIN  (0xF05DFAF1ADFEF2CD)
+-- Returns whether the specified train config can be spawned at the given coordinates.
+-- The engine snaps the coordinates to the nearest track and checks the requested direction, matching the direction parameter used by CREATE_MISSION_TRAIN.
+-- min build: 1207
+---@param trainConfig number
+---@param x number
+---@param y number
+---@param z number
+---@param direction boolean
+---@param p5 boolean
+---@return boolean
+function _IsPositionValidForTrain(trainConfig, x, y, z, direction, p5) end
+
+-- _IS_THIS_MODEL_A_DRAFT_VEHICLE  (0xB9D5BDDA88E1BB66)
+-- min build: 1207
+---@param model number
+---@return boolean
+function _IsThisModelADraftVehicle(model) end
+
+-- _IS_VEHICLE_BROUGHT_TO_HALT  (0x404527BC03DA0E6C)
+-- Only returns true if BRING_VEHICLE_TO_HALT is called on vehicle beforehand
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehicleBroughtToHalt(vehicle) end
+
+-- _IS_VEHICLE_DOOR_BROKEN  (0xE979BB5602AD3402)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@return boolean
+function _IsVehicleDoorBroken(vehicle, doorId) end
+
+-- _IS_VEHICLE_FADING_OUT  (0x5136B284B67B35C7)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehicleFadingOut(vehicle) end
+
+-- _IS_VEHICLE_ON_FIRE  (0x0E3BF7ED4169EC43)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehicleOnFire(vehicle) end
+
+-- _IS_VEHICLE_TOUCHING_VEGETATION  (0x51C7694E140FAE43)
+-- Returns whether the vehicle is currently touching dense vegetation/foliage collision or physics materials such as bushes, reeds, or thick shrubs.
+-- Observed behavior suggests this is driven by the vehicle's collision bounds or wheels interacting with vegetation.
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function _IsVehicleTouchingVegetation(vehicle) end
+
+-- _IS_VEHICLE_WHEEL_DESTROYED  (0xCB2CA620C48BC875)
+-- min build: 1207
+---@param vehicle number
+---@param wheel number
+---@return boolean
+function _IsVehicleWheelDestroyed(vehicle, wheel) end
+
+-- _RECOVER_DRAFT_VEHICLE_FALLING_LOG  (0x42404D57D621601A)
+-- Returns the log prop entity that is currently detaching/falling from a draft (log) wagon. Returns 0 if no log is in the falling phase.
+-- R* scripts call this repeatedly to fetch each fallen piece, then apply forces to it.
+-- Video demo: https://imgur.com/a/5JEeOij
+-- min build: 1207
+---@param vehicle number
+---@return number
+function _RecoverDraftVehicleFallingLog(vehicle) end
+
+-- _REQUEST_VEHICLE_ASSET_ANIMS  (0xCF9DA72002FC16BF)
+-- min build: 1207
+---@param ped number
+---@param entity number
+---@param vehicleAsset number
+function _RequestVehicleAssetAnims(ped, entity, vehicleAsset) end
+
+-- _RETURN_TRAIN_INFO_FROM_HANDLE  (0x09034479E6E3E269)
+-- Outputs track hash and junction index on given train vehicle handle.
+-- trainTrack: https://pastebin.com/mhy0dTXs
+-- min build: 1207
+---@param train number
+---@return boolean
+---@return number
+---@return number
+function _ReturnTrainInfoFromHandle(train) end
+
+-- _SET_ALL_JUNCTIONS_CLEARED  (0x138398153824E332)
+-- min build: 1207
+function _SetAllJunctionsCleared() end
+
+-- _SET_ALL_VEHICLE_GENERATORS_DISABLED_FOR_VOLUME  (0x424FFCB9F0D2D4B5)
+-- min build: 1207
+---@param volume number
+---@param toggle boolean
+function _SetAllVehicleGeneratorsDisabledForVolume(volume, toggle) end
+
+-- _SET_BALLOON_FACE_COORD  (0xB42C87521D1BDD2F)
+-- Forces a hot air balloon to rotate/yaw toward a world coordinate.
+-- 
+-- Notes:
+-- - Balloon-only: gated to VEHICLE_TYPE_BALLOON.
+-- - Used in update loops during balloon navigation so the basket keeps facing its destination instead of flying sideways or backwards.
+-- - Must be called every frame while the heading should be maintained.
+-- - Fits the dump order with _SET_BALLOON_GO_TO_COORD followed by _SET_BALLOON_HOVER_STATE.
+-- min build: 1207
+---@param balloon number
+---@param x number
+---@param y number
+---@param z number
+function _SetBalloonFaceCoord(balloon, x, y, z) end
+
+-- _SET_BALLOON_GO_TO_COORD  (0x2200AB13CBD10F4E)
+-- Commands a hot air balloon to navigate toward a target world coordinate.
+-- 
+-- Notes:
+-- - Balloon-only: gated to VEHICLE_TYPE_BALLOON.
+-- - Must be called every frame while travelling; if called only once, the physics/momentum can stop on the next frame.
+-- - autoPower controls whether the balloon applies its own movement toward the target.
+-- - speed acts as a speed/throttle multiplier; community testing suggests 1.0 as a safe baseline.
+-- - The balloon does not perform obstacle avoidance and may collide with terrain/objects on a straight route.
+-- - Usually paired with _SET_BALLOON_FACE_COORD so the basket faces the destination, and with _SET_BALLOON_HOVER_STATE for arrival/holding behavior.
+-- 
+-- Lua example: https://pastebin.com/6Ev872RE
+-- Video demo: https://imgur.com/a/rMKmRfC
+-- min build: 1207
+---@param balloon number
+---@param x number
+---@param y number
+---@param z number
+---@param autoPower boolean
+---@param speed number
+function _SetBalloonGoToCoord(balloon, x, y, z, autoPower, speed) end
+
+-- _SET_BALLOON_HOVER_STATE  (0x7C9E45A4CED2E8DA)
+-- Params: 1.0f will make balloon hover
+-- min build: 1207
+---@param balloon number
+---@param p1 number
+function _SetBalloonHoverState(balloon, p1) end
+
+-- _SET_BATCH_TARP_HEIGHT  (0x31F343383F19C987)
+-- Total height is calculated using: cargo ratio + pelt ratio (by pelt count)
+-- Screenshot: https://imgur.com/a/nsomtiv
+-- min build: 1207
+---@param vehicle number
+---@param height number
+---@param immediately boolean
+function _SetBatchTarpHeight(vehicle, height, immediately) end
+
+-- _SET_CARGO_COMPARTMENT_OPEN  (0xF6E3D38869D0F7AD)
+-- Forces open a vehicle's primary cargo access point, such as dropping a wagon tailgate, opening a built-in lockbox, or revealing a hidden compartment.
+-- One-way trigger: calling this again does not close the compartment.
+-- min build: 1207
+---@param vehicle number
+function _SetCargoCompartmentOpen(vehicle) end
+
+-- _SET_DRAFT_ANIMAL_RANDOM_SEED  (0x8C6D9A399126C194)
+-- min build: 1207
+---@param vehicle number
+---@param seed number
+function _SetDraftAnimalRandomSeed(vehicle, seed) end
+
+-- _SET_DRAFT_VEHICLE_ALLOW_DRAFT_ANIMAL_AUTO_CREATION  (0x87344305778E5415)
+-- min build: 1207
+---@param vehicle number
+---@param allow boolean
+function _SetDraftVehicleAllowDraftAnimalAutoCreation(vehicle, allow) end
+
+-- _SET_DRAFT_VEHICLE_ANIMALS_CAN_DETACH  (0x6090A031C69F384E)
+-- min build: 1207
+---@param draft number
+---@param canDetach boolean
+function _SetDraftVehicleAnimalsCanDetach(draft, canDetach) end
+
+-- _SET_DRAFT_VEHICLE_DESIRED_SPEED  (0x0C3F0F7F92CA847C)
+-- min build: 1207
+---@param vehicle number
+---@param speed number
+function _SetDraftVehicleDesiredSpeed(vehicle, speed) end
+
+-- _SET_DRAFT_VEHICLE_YOKE_CAN_BREAK  (0x226C6A4E3346D288)
+-- min build: 1207
+---@param draft number
+---@param canBreak boolean
+function _SetDraftVehicleYokeCanBreak(draft, canBreak) end
+
+-- _SET_FORCE_COACH_ROBBERY_LOOT  (0xF489F94BFEE12BB0)
+-- Hashes: COACH2_BOOT_LOOT_ITEMS_COACHROB_RSC, COACH2_BOOT_LOOT_ITEMS_COACHROB, COACH2_MARY3
+-- min build: 1207
+---@param vehicle number
+---@param coachrobberyLoot number
+function _SetForceCoachRobberyLoot(vehicle, coachrobberyLoot) end
+
+-- _SET_FORCE_HIGH_LOD_VEHICLE  (0x1098CDA477890165)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function _SetForceHighLodVehicle(vehicle, p1) end
+
+-- _SET_HORSE_TRAFFIC_GROUPING_DISTRIBUTION  (0xF5FFB08976911B50)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function _SetHorseTrafficGroupingDistribution(p0, p1, p2, p3) end
+
+-- _SET_MISSION_TRAIN_WARP_TO_COORDS  (0xC9EA26893C9E4024)
+-- Notice: BOOL p4 was wrongly named takePassengers (?)
+-- Can be used to rotate the train by setting the BOOL direction
+-- min build: 1207
+---@param train number
+---@param x number
+---@param y number
+---@param z number
+---@param direction boolean
+function _SetMissionTrainWarpToCoords(train, x, y, z, direction) end
+
+-- _SET_OARS_ROWING_SPEED  (0x6835AFEA10E186F4)
+-- Sets rowing speed for boats with oars, such as rowboats or paddle boats.
+-- speed is an enum-like value in the observed range 1..3, where higher values row faster.
+-- min build: 1207
+---@param boat number
+---@param speed number
+function _SetOarsRowingSpeed(boat, speed) end
+
+-- _SET_RANDOM_TRAINS_WHISTLE_ENABLED  (0x1BFBAFCC6760FF02)
+-- Enables/disables the whistle on a specific train entity.
+-- min build: 1207
+---@param train number
+---@param enabled boolean
+function _SetRandomTrainsWhistleEnabled(train, enabled) end
+
+-- _SET_TRAIN_COLLISION_AVOIDANCE_ENABLED  (0xE6BD7DD3FD474415)
+-- Enables or disables collision-avoidance behavior for AI-controlled trains.
+-- When enabled, the train can automatically stop if an obstacle or possible collision is detected ahead on the track. When disabled, it continues moving without reacting to those obstacles.
+-- min build: 1207
+---@param train number
+---@param toggle boolean
+function _SetTrainCollisionAvoidanceEnabled(train, toggle) end
+
+-- _SET_TRAIN_DESTRUCTION_ENABLED  (0x07E2E21E799080A0)
+-- Trains only. Enables/disables damage/explosion flags on the engine and all attached cars; typically set true before EXPLODE_VEHICLE.
+-- min build: 1207
+---@param train number
+---@param enabled boolean
+function _SetTrainDestructionEnabled(train, enabled) end
+
+-- _SET_TRAIN_HALT  (0x3660BCAB3A6BB734)
+-- min build: 1207
+---@param train number
+function _SetTrainHalt(train) end
+
+-- _SET_TRAIN_LEAVE_STATION  (0x787E43477746876F)
+-- Restarts the train
+-- min build: 1207
+---@param train number
+function _SetTrainLeaveStation(train) end
+
+-- _SET_TRAIN_MAX_SPEED  (0x9F29999DFDF2AEB8)
+-- Maximum possible speed is 30.0 (108 km/h)
+-- min build: 1207
+---@param train number
+---@param speed number
+function _SetTrainMaxSpeed(train, speed) end
+
+-- _SET_TRAIN_REVERSE_ENABLED  (0x06A09A6E0C6D2A84)
+-- Enables or disables reverse movement for a train.
+-- min build: 1207
+---@param train number
+---@param enable boolean
+function _SetTrainReverseEnabled(train, enable) end
+
+-- _SET_TRAIN_STOPS_FOR_STATIONS  (0x4182C037AA1F0091)
+-- min build: 1207
+---@param train number
+---@param toggle boolean
+function _SetTrainStopsForStations(train, toggle) end
+
+-- _SET_TRAIN_TRACK_JUNCTION_SWITCH  (0xE6C5E2125EB210C1)
+-- trainTrack: see 0x09034479E6E3E269.
+-- min build: 1207
+---@param trainTrack number
+---@param junctionIndex number
+---@param enabled boolean
+function _SetTrainTrackJunctionSwitch(trainTrack, junctionIndex, enabled) end
+
+-- _SET_VEHICLE_DETERIORATION  (0x8E5DA070BAD3279E)
+-- min build: 1207
+---@param vehicle number
+---@param amount number
+---@param p2 number
+---@param p3 boolean
+function _SetVehicleDeterioration(vehicle, amount, p2, p3) end
+
+-- _SET_VEHICLE_DIRT_LEVEL_2  (0xBAE0EEDF93F05EAA)
+-- dirtLevel: 0.0 - 1.0
+-- min build: 1207
+---@param vehicle number
+---@param dirtLevel number
+function _SetVehicleDirtLevel2(vehicle, dirtLevel) end
+
+-- _SET_VEHICLE_IS_IN_HURRY  (0xCE1531927AD6C9F8)
+-- min build: 1207
+---@param vehicle number
+---@param enabled boolean
+function _SetVehicleIsInHurry(vehicle, enabled) end
+
+-- _SET_VEHICLE_LIVERY  (0xF89D82A0582E46ED)
+-- https://github.com/femga/rdr3_discoveries/blob/master/vehicles/vehicle_modding/vehicle_liveries.lua
+-- min build: 1207
+---@param vehicle number
+---@param liveryIndex number
+function _SetVehicleLivery(vehicle, liveryIndex) end
+
+-- _SET_VEHICLE_LOD_LEVEL  (0x3FA7D7D1E0EA809E)
+-- Ranges from -1 to 2? (internal type is int8)
+-- https://imgur.com/a/bPzHcft
+-- min build: 1207
+---@param vehicle number
+---@param lodLevel number
+function _SetVehicleLodLevel(vehicle, lodLevel) end
+
+-- _SET_VEHICLE_MUD_LEVEL  (0x4D15E49764CB328A)
+-- mudLevel: 0.0 - 1.0
+-- min build: 1207
+---@param vehicle number
+---@param mudLevel number
+function _SetVehicleMudLevel(vehicle, mudLevel) end
+
+-- _SET_VEHICLE_ROAD_LINK_FORCED  (0xC2E62678D602853C)
+-- Picks the road/path link nearest (start to end) and stores it on the vehicle's driving component (used by R* Scripts to choose an exit link).
+-- min build: 1207
+---@param vehicle number
+---@param startX number
+---@param startY number
+---@param startZ number
+---@param endX number
+---@param endY number
+---@param endZ number
+function _SetVehicleRoadLinkForced(vehicle, startX, startY, startZ, endX, endY, endZ) end
+
+-- _SET_VEHICLE_SNOW_LEVEL  (0x6F73EFAB11651D7F)
+-- snowLevel: 0.0 - 1.0
+-- min build: 1207
+---@param vehicle number
+---@param snowLevel number
+function _SetVehicleSnowLevel(vehicle, snowLevel) end
+
+-- _SET_VEHICLE_STOP_DISTANCE_BUFFER  (0xA13028E22564A1BD)
+-- Adds a forward buffer to the AI stopping distance for a specific vehicle.
+-- Important for long vehicles such as wagons with draft horses. The AI normally calculates stopping distance from the front bounds of the vehicle; this extends that forward collision/stopping sphere.
+-- min build: 1207
+---@param vehicle number
+---@param bufferDistance number
+function _SetVehicleStopDistanceBuffer(vehicle, bufferDistance) end
+
+-- _SET_VEHICLE_TINT  (0x8268B098F6FCA4E2)
+-- https://github.com/femga/rdr3_discoveries/blob/master/vehicles/vehicle_modding/vehicle_tints.lua
+-- min build: 1207
+---@param vehicle number
+---@param tintId number
+function _SetVehicleTint(vehicle, tintId) end
+
+-- _SET_VEHICLE_WET_LEVEL  (0x5AABB09F6FBD1F87)
+-- wetLevel: 0.0 - 1.0
+-- min build: 1207
+---@param vehicle number
+---@param wetLevel number
+function _SetVehicleWetLevel(vehicle, wetLevel) end
+
+-- _SET_VELOCITY_FOR_BALLOON  (0x12F6C6ED3EFF42DE)
+-- Sets a hot air balloon velocity vector.
+-- 
+-- Notes:
+-- - Balloon-only: gated to VEHICLE_TYPE_BALLOON.
+-- - Scripts pass GET_ENTITY_VELOCITY(...) from another entity to copy/match its motion.
+-- - Used together with _SET_BALLOON_ROUTE and _SET_BALLOON_SECONDARY_TARGET as part of scripted balloon movement/control.
+-- min build: 1207
+---@param balloon number
+---@param x number
+---@param y number
+---@param z number
+function _SetVelocityForBalloon(balloon, x, y, z) end
+
+-- _SHOW_HORSE_REINS  (0x41CDA90EE3450921)
+-- min build: 1207
+---@param vehicle number
+function _ShowHorseReins(vehicle) end
+
+-- _TRIGGER_TRAIN_WHISTLE  (0xCFE122EC635CC2B2)
+-- whistleSequence: ACKNOWLEDGE, BACKING_UP, CROSSING, DANGER, MOVING, NEXT_STATION, PASSING, STOPPED
+-- p2 = true seems to mute the sound
+-- min build: 1207
+---@param train number
+---@param whistleSequence string
+---@param p2 boolean
+---@param p3 boolean
+function _TriggerTrainWhistle(train, whistleSequence, p2, p3) end
+
+-- ADD_ROAD_NODE_SPEED_ZONE  (0x4C221BAC54D735C3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@return number
+function AddRoadNodeSpeedZone(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) end
+
+-- ARE_ANY_VEHICLE_SEATS_FREE  (0xA0A424505A1B6429)
+-- Returns false if every seat is occupied.
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function AreAnyVehicleSeatsFree(vehicle) end
+
+-- BRING_VEHICLE_TO_HALT  (0x260BE8F09E326A20)
+-- This native makes the vehicle stop immediately
+-- 
+-- distance defines how far it will travel until stopping.
+-- min build: 1207
+---@param vehicle number
+---@param distance number
+---@param duration number
+---@param unknown boolean
+function BringVehicleToHalt(vehicle, distance, duration, unknown) end
+
+-- CAN_ANCHOR_BOAT_HERE  (0xC075176CFB8B4128)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function CanAnchorBoatHere(vehicle) end
+
+-- CAN_SHUFFLE_SEAT  (0xF8B2D32A2231FD24)
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param vehicle number
+---@param seatIndex number
+---@return boolean
+function CanShuffleSeat(vehicle, seatIndex) end
+
+-- CLEAR_LAST_DRIVEN_VEHICLE  (0x0EFC5DC62E67609B)
+-- min build: 1207
+function ClearLastDrivenVehicle() end
+
+-- COPY_VEHICLE_DAMAGES  (0xDBC28A8C683CD80B)
+-- Copies sourceVehicle's damage (broken bumpers, broken lights, etc.) to targetVehicle.
+-- min build: 1207
+---@param sourceVehicle number
+---@param targetVehicle number
+function CopyVehicleDamages(sourceVehicle, targetVehicle) end
+
+-- CREATE_VEHICLE  (0xAF35D0D2583051B0)
+-- min build: 1207
+---@param modelHash number
+---@param x number
+---@param y number
+---@param z number
+---@param heading number
+---@param isNetwork boolean
+---@param bScriptHostVeh boolean
+---@param bDontAutoCreateDraftAnimals boolean
+---@param p8 boolean
+---@return number
+function CreateVehicle(modelHash, x, y, z, heading, isNetwork, bScriptHostVeh, bDontAutoCreateDraftAnimals, p8) end
+
+-- DELETE_ALL_TRAINS  (0xA3120A1385F17FF7)
+-- min build: 1207
+function DeleteAllTrains() end
+
+-- DELETE_MISSION_TRAIN  (0x0D3630FB07E8B570)
+-- min build: 1207
+---@return number
+function DeleteMissionTrain() end
+
+-- DELETE_VEHICLE  (0xE20A909D8C4A70F8)
+-- Deletes a vehicle.
+-- The vehicle must be a mission entity to delete, so call this before deleting: SET_ENTITY_AS_MISSION_ENTITY(vehicle, true, true);
+-- 
+-- eg how to use:
+-- SET_ENTITY_AS_MISSION_ENTITY(vehicle, true, true);
+-- DELETE_VEHICLE(&vehicle);
+-- 
+-- Deletes the specified vehicle, then sets the handle pointed to by the pointer to NULL.
+-- min build: 1207
+---@return number
+function DeleteVehicle() end
+
+-- DISABLE_VEHICLE_WEAPON  (0x94B1E71B144356A5)
+-- min build: 1207
+---@param disabled boolean
+---@param weaponHash number
+---@param vehicle number
+---@param owner number
+function DisableVehicleWeapon(disabled, weaponHash, vehicle, owner) end
+
+-- DOES_EXTRA_EXIST  (0xAF5E7E9A7620FFB5)
+-- min build: 1207
+---@param vehicle number
+---@param extraId number
+---@return boolean
+function DoesExtraExist(vehicle, extraId) end
+
+-- EXPLODE_VEHICLE  (0x75DCED9EEC5769D7)
+-- Explodes a selected vehicle.
+-- 
+-- Vehicle vehicle = Vehicle you want to explode.
+-- BOOL isAudible = If explosion makes a sound.
+-- BOOL isInvisible = If the explosion is invisible or not.
+-- 
+-- First BOOL does not give any visual explosion, the vehicle just falls apart completely but slowly and starts to burn.
+-- min build: 1207
+---@param vehicle number
+---@param isAudible boolean
+---@param isInvisible boolean
+---@param p3 any
+---@param p4 any
+function ExplodeVehicle(vehicle, isAudible, isInvisible, p3, p4) end
+
+-- FORCE_PLAYBACK_RECORDED_VEHICLE_UPDATE  (0x59ECA796021B0539)
+-- Often called after START_PLAYBACK_RECORDED_VEHICLE and SKIP_TIME_IN_PLAYBACK_RECORDED_VEHICLE; similar in use to FORCE_ENTITY_AI_AND_ANIMATION_UPDATE.
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function ForcePlaybackRecordedVehicleUpdate(vehicle, p1) end
+
+-- GET_CLOSEST_VEHICLE  (0x52F45D033645181B)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param modelHash number
+---@param flags number
+---@return number
+function GetClosestVehicle(x, y, z, radius, modelHash, flags) end
+
+-- GET_CURRENT_STATION_FOR_TRAIN  (0x86FA6D8B48667D75)
+-- Returns p1 for 0xBA958F68031DDBFC (stationIndex)
+-- min build: 1207
+---@param train number
+---@return number
+function GetCurrentStationForTrain(train) end
+
+-- GET_DRAFT_ANIMAL_COUNT  (0xA19447D83294E29F)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+---@return number
+---@return number
+function GetDraftAnimalCount(vehicle) end
+
+-- GET_DRIVER_OF_VEHICLE  (0x2963B5C1637E8A27)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetDriverOfVehicle(vehicle) end
+
+-- GET_LAST_DRIVEN_VEHICLE  (0xA94F3E0AB9695E19)
+-- min build: 1207
+---@return number
+function GetLastDrivenVehicle() end
+
+-- GET_LAST_PED_IN_VEHICLE_SEAT  (0x74583B19FEEAFDA7)
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param vehicle number
+---@param seatIndex number
+---@return number
+function GetLastPedInVehicleSeat(vehicle, seatIndex) end
+
+-- GET_PED_IN_VEHICLE_SEAT  (0xBB40DD2270B65366)
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param vehicle number
+---@param seatIndex number
+---@return number
+function GetPedInVehicleSeat(vehicle, seatIndex) end
+
+-- GET_POSITION_OF_VEHICLE_RECORDING_AT_TIME  (0x1A00961A1BE94E5E)
+-- This native does no interpolation between pathpoints. The same position will be returned for all times up to the next pathpoint in the recording.
+-- 
+-- See REQUEST_VEHICLE_RECORDING
+-- min build: 1207
+---@param recording number
+---@param time number
+---@param script string
+---@return vector3
+function GetPositionOfVehicleRecordingAtTime(recording, time, script) end
+
+-- GET_ROTATION_OF_VEHICLE_RECORDING_AT_TIME  (0x61787DD28B8CC0D5)
+-- This native does no interpolation between pathpoints. The same rotation will be returned for all times up to the next pathpoint in the recording.
+-- 
+-- See REQUEST_VEHICLE_RECORDING
+-- min build: 1207
+---@param recording number
+---@param time number
+---@param script string
+---@return vector3
+function GetRotationOfVehicleRecordingAtTime(recording, time, script) end
+
+-- GET_TIME_POSITION_IN_RECORDING  (0x233B51C7913FA031)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetTimePositionInRecording(vehicle) end
+
+-- GET_TRACK_INDEX_OF_TRAIN  (0x865FEC2FA899F29C)
+-- min build: 1207
+---@param train number
+---@return number
+function GetTrackIndexOfTrain(train) end
+
+-- GET_TRAIN_CARRIAGE  (0xD0FB093A4CDB932C)
+-- min build: 1207
+---@param train number
+---@param trailerNumber number
+---@return number
+function GetTrainCarriage(train, trailerNumber) end
+
+-- GET_VEHICLE_BODY_HEALTH  (0x42113B857E33C16E)
+-- Seems related to vehicle health, like the one in IV.
+-- Max 1000, min 0.
+-- Vehicle does not necessarily explode or become undrivable at 0.
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleBodyHealth(vehicle) end
+
+-- GET_VEHICLE_DOOR_LOCK_STATUS  (0xC867FD144F2469D3)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleDoorLockStatus(vehicle) end
+
+-- GET_VEHICLE_DOORS_LOCKED_FOR_PLAYER  (0xFA2CDDFEB8BC898B)
+-- min build: 1207
+---@param vehicle number
+---@param player number
+---@return boolean
+function GetVehicleDoorsLockedForPlayer(vehicle, player) end
+
+-- GET_VEHICLE_ENGINE_HEALTH  (0x90DBFFAC43B22081)
+-- Returns 1000.0 if the function is unable to get the address of the specified vehicle or if it's not a vehicle.
+-- 
+-- Minimum: -4000
+-- Maximum: 1000
+-- 
+-- -4000: Engine is destroyed
+-- 0 and below: Engine catches fire and health rapidly declines
+-- 300: Engine is smoking and losing functionality
+-- 1000: Engine is perfect
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleEngineHealth(vehicle) end
+
+-- GET_VEHICLE_ESTIMATED_MAX_SPEED  (0xFE52F34491529F0B)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleEstimatedMaxSpeed(vehicle) end
+
+-- GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS  (0xA9C55F1C15E62E06)
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleMaxNumberOfPassengers(vehicle) end
+
+-- GET_VEHICLE_MODEL_NUMBER_OF_SEATS  (0x9A578736FF3A17C3)
+-- min build: 1207
+---@param modelHash number
+---@return number
+function GetVehicleModelNumberOfSeats(modelHash) end
+
+-- GET_VEHICLE_NUMBER_OF_PASSENGERS  (0x59F3F16577CD79B2)
+-- Gets the number of passengers, NOT including the driver. Use IS_VEHICLE_SEAT_FREE(Vehicle, -1) to also check for the driver
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehicleNumberOfPassengers(vehicle) end
+
+-- GET_VEHICLE_PETROL_TANK_HEALTH  (0x1E5A9B356D5098BE)
+-- 1000 is max health
+-- min build: 1207
+---@param vehicle number
+---@return number
+function GetVehiclePetrolTankHealth(vehicle) end
+
+-- GET_VEHICLE_TRAILER_VEHICLE  (0xCF867A239EC30741)
+-- Gets the trailer of a vehicle and puts it into the trailer parameter.
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+---@return number
+function GetVehicleTrailerVehicle(vehicle) end
+
+-- HAS_INSTANT_FILL_VEHICLE_POPULATION_FINISHED  (0x2701D01D5E18FC31)
+-- min build: 1207
+---@return boolean
+function HasInstantFillVehiclePopulationFinished() end
+
+-- HAS_VEHICLE_ASSET_LOADED  (0xB935F3154BC913C8)
+-- min build: 1207
+---@param vehicleAsset number
+---@return boolean
+function HasVehicleAssetLoaded(vehicleAsset) end
+
+-- HAS_VEHICLE_RECORDING_BEEN_LOADED  (0xBA9325BE372AB6EA)
+-- See REQUEST_VEHICLE_RECORDING
+-- min build: 1207
+---@param recording number
+---@param script string
+---@return boolean
+function HasVehicleRecordingBeenLoaded(recording, script) end
+
+-- INSTANTLY_FILL_VEHICLE_POPULATION  (0x1FF00DB43026B12F)
+-- min build: 1207
+function InstantlyFillVehiclePopulation() end
+
+-- IS_ANY_VEHICLE_NEAR_POINT  (0x5698BA4FD04D39C4)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@return boolean
+function IsAnyVehicleNearPoint(x, y, z, radius) end
+
+-- IS_DRAFT_VEHICLE  (0xEA44E97849E9F3DD)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsDraftVehicle(vehicle) end
+
+-- IS_ENTRY_POINT_FOR_SEAT_CLEAR  (0x80DDCCB2F4A3EB57)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+---@param seatIndex number
+---@param side boolean
+---@param onEnter boolean
+---@return boolean
+function IsEntryPointForSeatClear(ped, vehicle, seatIndex, side, onEnter) end
+
+-- IS_PLAYBACK_GOING_ON_FOR_VEHICLE  (0x02774B3A9034278F)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsPlaybackGoingOnForVehicle(vehicle) end
+
+-- IS_PLAYBACK_USING_AI_GOING_ON_FOR_VEHICLE  (0x5A7472606EC5B7C1)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsPlaybackUsingAiGoingOnForVehicle(vehicle) end
+
+-- IS_SEAT_WARP_ONLY  (0x7892685BF6D9775E)
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- min build: 1207
+---@param vehicle number
+---@param seatIndex number
+---@return boolean
+function IsSeatWarpOnly(vehicle, seatIndex) end
+
+-- IS_THIS_MODEL_A_BOAT  (0x799CFC7C5B743B15)
+-- min build: 1207
+---@param model number
+---@return boolean
+function IsThisModelABoat(model) end
+
+-- IS_THIS_MODEL_A_TRAIN  (0xFC08C8F8C1EDF174)
+-- min build: 1207
+---@param model number
+---@return boolean
+function IsThisModelATrain(model) end
+
+-- IS_TRAIN_WAITING_AT_STATION  (0xE887BD31D97793F6)
+-- min build: 1207
+---@param train number
+---@return boolean
+function IsTrainWaitingAtStation(train) end
+
+-- IS_VEHICLE_DOOR_FULLY_OPEN  (0x7AE191143C7A9107)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@return boolean
+function IsVehicleDoorFullyOpen(vehicle, doorId) end
+
+-- IS_VEHICLE_DRIVEABLE  (0xB86D29B10F627379)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+---@param p2 boolean
+---@return boolean
+function IsVehicleDriveable(vehicle, p1, p2) end
+
+-- IS_VEHICLE_EXTRA_TURNED_ON  (0xFA9A55D9C4351625)
+-- min build: 1207
+---@param vehicle number
+---@param extraId number
+---@return boolean
+function IsVehicleExtraTurnedOn(vehicle, extraId) end
+
+-- IS_VEHICLE_IN_BURNOUT  (0x3F5029A8FC060C48)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsVehicleInBurnout(vehicle) end
+
+-- IS_VEHICLE_MODEL  (0x0045A54EC7A22455)
+-- min build: 1207
+---@param vehicle number
+---@param model number
+---@return boolean
+function IsVehicleModel(vehicle, model) end
+
+-- IS_VEHICLE_ON_ALL_WHEELS  (0x0D5D119529654EE0)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsVehicleOnAllWheels(vehicle) end
+
+-- IS_VEHICLE_SEAT_FREE  (0xE052C1B1CAA4ECE4)
+-- seatIndex: see CREATE_PED_INSIDE_VEHICLE
+-- Use GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS(vehicle) - 1 for last seat index.
+-- min build: 1207
+---@param vehicle number
+---@param seatIndex number
+---@return boolean
+function IsVehicleSeatFree(vehicle, seatIndex) end
+
+-- IS_VEHICLE_STOPPED  (0x78C3311A73135241)
+-- Returns true if the vehicle's current speed is less than, or equal to 0.0025f.
+-- 
+-- For some vehicles it returns true if the current speed is <= 0.00039999999.
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsVehicleStopped(vehicle) end
+
+-- IS_VEHICLE_STUCK_TIMER_UP  (0x1ABA9753939503C5)
+-- VEH_STUCK_ON_ROOF = 0,
+-- VEH_STUCK_ON_SIDE,
+-- VEH_STUCK_HUNG_UP,
+-- VEH_STUCK_JAMMED
+-- min build: 1207
+---@param vehicle number
+---@param stuckType number
+---@param ms number
+---@return boolean
+function IsVehicleStuckTimerUp(vehicle, stuckType, ms) end
+
+-- IS_VEHICLE_VISIBLE  (0x424910CD5DE8C246)
+-- Requires a visibility tracker on the vehicle (TRACK_VEHICLE_VISIBILITY)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsVehicleVisible(vehicle) end
+
+-- IS_VEHICLE_WINDOW_INTACT  (0x0E7910A63E05B12C)
+-- min build: 1436
+---@param vehicle number
+---@param windowIndex number
+---@return boolean
+function IsVehicleWindowIntact(vehicle, windowIndex) end
+
+-- IS_VEHICLE_WRECKED  (0xDDBEA5506C848227)
+-- min build: 1207
+---@param vehicle number
+---@return boolean
+function IsVehicleWrecked(vehicle) end
+
+-- LOCK_DOORS_WHEN_NO_LONGER_NEEDED  (0x1EF36558FBDE2DAA)
+-- min build: 1207
+---@param vehicle number
+function LockDoorsWhenNoLongerNeeded(vehicle) end
+
+-- MODIFY_VEHICLE_TOP_SPEED  (0x35AD938C74CACD6A)
+-- min build: 1207
+---@param vehicle number
+---@param value number
+function ModifyVehicleTopSpeed(vehicle, value) end
+
+-- REMOVE_ROAD_NODE_SPEED_ZONE  (0xFE9AB3354ACE6C9C)
+-- min build: 1207
+---@param speedzone number
+---@return boolean
+function RemoveRoadNodeSpeedZone(speedzone) end
+
+-- REMOVE_VEHICLE_ASSET  (0x888A4E675B38F5AD)
+-- min build: 1207
+---@param vehicleAsset number
+function RemoveVehicleAsset(vehicleAsset) end
+
+-- REMOVE_VEHICLE_RECORDING  (0x139E35755418F6AA)
+-- See REQUEST_VEHICLE_RECORDING
+-- min build: 1207
+---@param p0 any
+---@return any
+function RemoveVehicleRecording(p0) end
+
+-- REMOVE_VEHICLE_WINDOW  (0x745F15A215F2DDF1)
+-- windowIndex:
+-- 0 = Front Right Window
+-- 1 = Front Left Window
+-- 2 = Back Right Window
+-- 3 = Back Left Window
+-- min build: 1207
+---@param vehicle number
+---@param windowIndex number
+function RemoveVehicleWindow(vehicle, windowIndex) end
+
+-- REMOVE_VEHICLES_FROM_GENERATORS_IN_AREA  (0xC619A44639BC0CB4)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function RemoveVehiclesFromGeneratorsInArea(p0, p1, p2, p3, p4, p5) end
+
+-- REQUEST_VEHICLE_ASSET  (0x81A15811460FAB3A)
+-- min build: 1207
+---@param vehicleHash number
+---@param vehicleAsset number
+function RequestVehicleAsset(vehicleHash, vehicleAsset) end
+
+-- REQUEST_VEHICLE_HIGH_DETAIL_MODEL  (0x84B81EF78BD22357)
+-- min build: 1207
+---@param vehicle number
+function RequestVehicleHighDetailModel(vehicle) end
+
+-- REQUEST_VEHICLE_RECORDING  (0xC474CF16EDA45DC9)
+-- Request the vehicle recording defined by the lowercase format string "%s%03d.yvr". For example, REQUEST_VEHICLE_RECORDING(1, "FBIs1UBER") corresponds to fbis1uber001.yvr.
+-- For all vehicle recording/playback natives, "script" is a common prefix that usually corresponds to the script/mission the recording is used in, "recording" is its int suffix, and "id" corresponds to a unique identifier within the recording streaming module.
+-- (GTA) Note that only 24 recordings (hardcoded in multiple places) can ever active at a given time before clobbering begins.
+-- min build: 1207
+---@param recording number
+---@param script string
+function RequestVehicleRecording(recording, script) end
+
+-- RESET_VEHICLE_STUCK_TIMER  (0x23298B468F7D88B6)
+-- min build: 1207
+---@param vehicle number
+---@param nullAttributes number
+function ResetVehicleStuckTimer(vehicle, nullAttributes) end
+
+-- SET_ALL_VEHICLE_GENERATORS_ACTIVE  (0x3D596E6E88A02C24)
+-- min build: 1207
+function SetAllVehicleGeneratorsActive() end
+
+-- SET_ALL_VEHICLE_GENERATORS_ACTIVE_IN_AREA  (0xBBB134FB9D50C0CC)
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param p6 boolean
+---@param p7 boolean
+function SetAllVehicleGeneratorsActiveInArea(x1, y1, z1, x2, y2, z2, p6, p7) end
+
+-- SET_ALLOW_VEHICLE_EXPLODES_ON_CONTACT  (0x8D3230A0ED7DE39F)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetAllowVehicleExplodesOnContact(vehicle, p1) end
+
+-- SET_BOAT_ANCHOR  (0xAEAB044F05B92659)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetBoatAnchor(vehicle, toggle) end
+
+-- SET_BOAT_LOW_LOD_ANCHOR_DISTANCE  (0xE3261532550D6A9F)
+-- Value: mostly 99999.9f
+-- 
+-- Old name: _SET_BOAT_MOVEMENT_RESISTANCE
+-- min build: 1207
+---@param vehicle number
+---@param value number
+function SetBoatLowLodAnchorDistance(vehicle, value) end
+
+-- SET_BOAT_REMAINS_ANCHORED_WHILE_PLAYER_IS_DRIVER  (0x286771F3059A37A7)
+-- Old name: _SET_BOAT_FROZEN_WHEN_ANCHORED
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+---@param p2 boolean
+function SetBoatRemainsAnchoredWhilePlayerIsDriver(vehicle, p1, p2) end
+
+-- SET_BOAT_SINKS_WHEN_WRECKED  (0x62A6D317A011EA1D)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetBoatSinksWhenWrecked(vehicle, toggle) end
+
+-- SET_BREAKABLE_VEHICLE_LOCKS_UNBREAKABLE  (0xBC4735F48CD983EF)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetBreakableVehicleLocksUnbreakable(vehicle, toggle) end
+
+-- SET_DISABLE_RANDOM_TRAINS_THIS_FRAME  (0xD4288603E8766FF7)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param toggle boolean
+function SetDisableRandomTrainsThisFrame(toggle) end
+
+-- SET_DISABLE_SUPERDUMMY  (0x1716D787D9B94202)
+-- Old name: _SET_DISABLE_SUPERDUMMY_MODE
+-- min build: 1232
+---@param vehicle number
+---@param disable boolean
+function SetDisableSuperdummy(vehicle, disable) end
+
+-- SET_DISABLE_VEHICLE_ENGINE_FIRES  (0xD146EE5F2B06B95E)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetDisableVehicleEngineFires(vehicle, p1) end
+
+-- SET_DISABLE_VEHICLE_PETROL_TANK_DAMAGE  (0x5795FBE7A2001C14)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetDisableVehiclePetrolTankDamage(vehicle, toggle) end
+
+-- SET_DISABLE_VEHICLE_PETROL_TANK_FIRES  (0xB70986AB19B04AFF)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetDisableVehiclePetrolTankFires(vehicle, toggle) end
+
+-- SET_DONT_ALLOW_PLAYER_TO_ENTER_VEHICLE_IF_LOCKED_FOR_PLAYER  (0x63DC1F22C903B709)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetDontAllowPlayerToEnterVehicleIfLockedForPlayer(vehicle, p1) end
+
+-- SET_DOOR_ALLOWED_TO_BE_BROKEN_OFF  (0x081FB9D6422F804C)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- 
+-- Old name: _SET_VEHICLE_DOOR_CAN_BREAK
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param isBreakable boolean
+function SetDoorAllowedToBeBrokenOff(vehicle, doorId, isBreakable) end
+
+-- SET_ENABLE_VEHICLE_SLIPSTREAMING  (0x73F1E4F6DF26FE30)
+-- min build: 1207
+---@param p0 boolean
+function SetEnableVehicleSlipstreaming(p0) end
+
+-- SET_FORCE_HD_VEHICLE  (0x373CB1283308BD7B)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetForceHdVehicle(vehicle, toggle) end
+
+-- SET_FORCE_LOW_LOD_ANCHOR_MODE  (0x75B49ACD73617437)
+-- Sets boat to be anchored on spawn, called together with SET_BOAT_ANCHOR and _SET_BOAT_ANCHOR_BUOYANCY_COEFFICIENT
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetForceLowLodAnchorMode(vehicle, p1) end
+
+-- SET_FORCE_VEHICLE_ENGINE_DAMAGE_BY_BULLET  (0x7F8E2B131E1DCA6C)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetForceVehicleEngineDamageByBullet(vehicle, toggle) end
+
+-- SET_MISSION_TRAIN_AS_NO_LONGER_NEEDED  (0xBBE7648349B49BE8)
+-- flags = 0: DEFAULT; 1: KEEP_OLD_SPEED
+-- min build: 1207
+---@param flags number
+---@return number
+function SetMissionTrainAsNoLongerNeeded(flags) end
+
+-- SET_MISSION_TRAIN_COORDS  (0x7632755962AB9922)
+-- min build: 1207
+---@param train number
+---@param x number
+---@param y number
+---@param z number
+function SetMissionTrainCoords(train, x, y, z) end
+
+-- SET_PARKED_VEHICLE_DENSITY_MULTIPLIER_THIS_FRAME  (0xFEDFA97638D61D4A)
+-- min build: 1207
+---@param multiplier number
+function SetParkedVehicleDensityMultiplierThisFrame(multiplier) end
+
+-- SET_PED_OWNS_VEHICLE  (0x838C216C2B05A009)
+-- min build: 1207
+---@param ped number
+---@param vehicle number
+function SetPedOwnsVehicle(ped, vehicle) end
+
+-- SET_PLAYBACK_SPEED  (0xD78084EED4CD94C6)
+-- min build: 1207
+---@param vehicle number
+---@param speed number
+function SetPlaybackSpeed(vehicle, speed) end
+
+-- SET_RANDOM_BOATS  (0xF44D446D4E36DB87)
+-- min build: 1207
+---@param toggle boolean
+function SetRandomBoats(toggle) end
+
+-- SET_RANDOM_TRAINS  (0x1156C6EE7E82A98A)
+-- min build: 1207
+---@param toggle boolean
+function SetRandomTrains(toggle) end
+
+-- SET_RANDOM_VEHICLE_DENSITY_MULTIPLIER_THIS_FRAME  (0x1F91D44490E1EA0C)
+-- min build: 1207
+---@param multiplier number
+function SetRandomVehicleDensityMultiplierThisFrame(multiplier) end
+
+-- SET_TRAIN_CRUISE_SPEED  (0x01021EB2E96B793C)
+-- min build: 1207
+---@param train number
+---@param speed number
+function SetTrainCruiseSpeed(train, speed) end
+
+-- SET_TRAIN_OFFSET_FROM_STATION  (0x8EC47DD4300BF063)
+-- min build: 1207
+---@param train number
+---@param offset number
+function SetTrainOffsetFromStation(train, offset) end
+
+-- SET_TRAIN_SPEED  (0xDFBA6BBFF7CCAFBB)
+-- min build: 1207
+---@param train number
+---@param speed number
+function SetTrainSpeed(train, speed) end
+
+-- SET_VEHICLE_AI_CAN_USE_EXCLUSIVE_SEATS  (0x0893DAFBFA67110E)
+-- Used to be incorrectly named SET_VEHICLE_EXCLUSIVE_DRIVER
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleAiCanUseExclusiveSeats(vehicle, toggle) end
+
+-- SET_VEHICLE_ALLOW_HOMING_MISSLE_LOCKON  (0x1240E8596A8308B9)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleAllowHomingMissleLockon(vehicle, toggle) end
+
+-- SET_VEHICLE_ALLOW_NO_PASSENGERS_LOCKON  (0xECB9E9BC887E8060)
+-- Makes the vehicle accept no passengers.
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleAllowNoPassengersLockon(vehicle, toggle) end
+
+-- SET_VEHICLE_AUTOMATICALLY_ATTACHES  (0x501354951CD942DE)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+---@param p2 any
+---@return any
+function SetVehicleAutomaticallyAttaches(vehicle, p1, p2) end
+
+-- SET_VEHICLE_BODY_HEALTH  (0x55CCAAE4F28C67A0)
+-- min build: 1207
+---@param vehicle number
+---@param value number
+function SetVehicleBodyHealth(vehicle, value) end
+
+-- SET_VEHICLE_BROKEN_PARTS_DONT_AFFECT_AI_HANDLING  (0xCEC4CA2CAB8FA98C)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleBrokenPartsDontAffectAiHandling(vehicle, p1) end
+
+-- SET_VEHICLE_CAN_BE_TARGETTED  (0x05254BA0B44ADC16)
+-- min build: 1207
+---@param vehicle number
+---@param state boolean
+function SetVehicleCanBeTargetted(vehicle, state) end
+
+-- SET_VEHICLE_CAN_BE_USED_BY_FLEEING_PEDS  (0xE42952510F84AFDB)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleCanBeUsedByFleeingPeds(vehicle, toggle) end
+
+-- SET_VEHICLE_CAN_BE_VISIBLY_DAMAGED  (0x4BF8131AE811541C)
+-- min build: 1207
+---@param vehicle number
+---@param state boolean
+function SetVehicleCanBeVisiblyDamaged(vehicle, state) end
+
+-- SET_VEHICLE_CAN_BREAK  (0xC5ED9D59B4646611)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleCanBreak(vehicle, toggle) end
+
+-- SET_VEHICLE_CAN_EJECT_PASSENGERS_IF_LOCKED  (0x065D03A9D6B2C6B5)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleCanEjectPassengersIfLocked(vehicle, p1) end
+
+-- SET_VEHICLE_DAMAGE  (0x1D7678F81452BB41)
+-- Apply damage to vehicle at a location. Location is relative to vehicle model (not world).
+-- 
+-- Radius of effect damage applied in a sphere at impact location
+-- min build: 1207
+---@param vehicle number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param damage number
+---@param radius number
+---@param p6 boolean
+function SetVehicleDamage(vehicle, xOffset, yOffset, zOffset, damage, radius, p6) end
+
+-- SET_VEHICLE_DENSITY_MULTIPLIER_THIS_FRAME  (0x606374EBFC27B133)
+-- min build: 1207
+---@param multiplier number
+function SetVehicleDensityMultiplierThisFrame(multiplier) end
+
+-- SET_VEHICLE_DIRT_LEVEL  (0x758C3460EE915D0A)
+-- min build: 1207
+---@param vehicle number
+---@param dirtLevel number
+function SetVehicleDirtLevel(vehicle, dirtLevel) end
+
+-- SET_VEHICLE_DOOR_BROKEN  (0x9666CF20A1C6D780)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param deleteDoor boolean
+function SetVehicleDoorBroken(vehicle, doorId, deleteDoor) end
+
+-- SET_VEHICLE_DOOR_CONTROL  (0xD57F10EBBA814ECF)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param speed number
+---@param angle number
+function SetVehicleDoorControl(vehicle, doorId, speed, angle) end
+
+-- SET_VEHICLE_DOOR_LATCHED  (0x06F8A202EB312A3C)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+function SetVehicleDoorLatched(vehicle, doorId, p2, p3, p4) end
+
+-- SET_VEHICLE_DOOR_OPEN  (0x550CE392A4672412)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- Can also be used on trains and its wagons
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param loose boolean
+---@param openInstantly boolean
+function SetVehicleDoorOpen(vehicle, doorId, loose, openInstantly) end
+
+-- SET_VEHICLE_DOOR_SHUT  (0x6A3C24B91FD0EA09)
+-- doorId: enum eDoorId
+-- {
+-- 	VEH_EXT_DOOR_INVALID_ID = -1,
+-- 	VEH_EXT_DOOR_DSIDE_F,
+-- 	VEH_EXT_DOOR_DSIDE_M,
+-- 	VEH_EXT_DOOR_DSIDE_M1,
+-- 	VEH_EXT_DOOR_DSIDE_M2,
+-- 	VEH_EXT_DOOR_DSIDE_R,
+-- 	VEH_EXT_DOOR_PSIDE_F,
+-- 	VEH_EXT_DOOR_PSIDE_M,
+-- 	VEH_EXT_DOOR_PSIDE_M1,
+-- 	VEH_EXT_DOOR_PSIDE_M2,
+-- 	VEH_EXT_DOOR_PSIDE_R,
+-- 	VEH_EXT_BONNET,
+-- 	VEH_EXT_BOOT
+-- };
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param closeInstantly boolean
+function SetVehicleDoorShut(vehicle, doorId, closeInstantly) end
+
+-- SET_VEHICLE_DOORS_LOCKED  (0x96F78A6A075D55D9)
+-- min build: 1207
+---@param vehicle number
+---@param doorLockStatus number
+function SetVehicleDoorsLocked(vehicle, doorLockStatus) end
+
+-- SET_VEHICLE_DOORS_LOCKED_FOR_ALL_PLAYERS  (0x2381977DA948F8DC)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleDoorsLockedForAllPlayers(vehicle, toggle) end
+
+-- SET_VEHICLE_DOORS_LOCKED_FOR_PLAYER  (0x359A8EA1FB8D6F0F)
+-- min build: 1207
+---@param vehicle number
+---@param player number
+---@param toggle boolean
+function SetVehicleDoorsLockedForPlayer(vehicle, player, toggle) end
+
+-- SET_VEHICLE_DOORS_LOCKED_FOR_TEAM  (0xE712BC978770F105)
+-- min build: 1207
+---@param vehicle number
+---@param team number
+---@param toggle boolean
+function SetVehicleDoorsLockedForTeam(vehicle, team, toggle) end
+
+-- SET_VEHICLE_DOORS_SHUT  (0xA4FFCD645B11F25A)
+-- Closes all doors of a vehicle:
+-- min build: 1207
+---@param vehicle number
+---@param closeInstantly boolean
+function SetVehicleDoorsShut(vehicle, closeInstantly) end
+
+-- SET_VEHICLE_DOORS_TO_OPEN_AT_ANY_DISTANCE  (0x362CEDD2A41E0747)
+-- min build: 1232
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleDoorsToOpenAtAnyDistance(vehicle, toggle) end
+
+-- SET_VEHICLE_ENGINE_CAN_DEGRADE  (0x48E4C137A71C2688)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleEngineCanDegrade(vehicle, toggle) end
+
+-- SET_VEHICLE_ENGINE_HEALTH  (0x8BDC5B998B4654EF)
+-- 1000 is max health
+-- Begins leaking gas at around 650 health
+-- -999.90002441406 appears to be minimum health, although nothing special occurs <- false statement
+-- 
+-- -------------------------
+-- Minimum: -4000
+-- Maximum: 1000
+-- 
+-- -4000: Engine is destroyed
+-- 0 and below: Engine catches fire and health rapidly declines
+-- 300: Engine is smoking and losing functionality
+-- 1000: Engine is perfect
+-- min build: 1207
+---@param vehicle number
+---@param health number
+function SetVehicleEngineHealth(vehicle, health) end
+
+-- SET_VEHICLE_ENGINE_ON  (0xB64CFA14CB9A2E78)
+-- Starts or stops the engine on the specified vehicle.
+-- 
+-- vehicle: The vehicle to start or stop the engine on.
+-- value: true to turn the vehicle on; false to turn it off.
+-- instantly: if true, the vehicle will be set to the state immediately; otherwise, the current driver will physically turn on or off the engine.
+-- min build: 1207
+---@param vehicle number
+---@param value boolean
+---@param instantly boolean
+function SetVehicleEngineOn(vehicle, value, instantly) end
+
+-- SET_VEHICLE_EXCLUSIVE_DRIVER  (0xC6B9BF123B9463B6)
+-- index: 0 - 1
+-- 
+-- Used to be incorrectly named _SET_VEHICLE_EXCLUSIVE_DRIVER_2
+-- min build: 1207
+---@param vehicle number
+---@param ped number
+---@param index number
+function SetVehicleExclusiveDriver(vehicle, ped, index) end
+
+-- SET_VEHICLE_EXPLODES_ON_HIGH_EXPLOSION_DAMAGE  (0xA402939C6761E1A3)
+-- Sets a vehicle to be strongly resistant to explosions. p0 is the vehicle; set p1 to false to toggle the effect on/off.
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleExplodesOnHighExplosionDamage(vehicle, toggle) end
+
+-- SET_VEHICLE_EXTRA  (0xBB6F89150BC9D16B)
+-- Note: only some vehicle have extras
+-- https://github.com/femga/rdr3_discoveries/blob/master/vehicles/vehicle_modding/vehicle_extras.lua
+-- min build: 1207
+---@param vehicle number
+---@param extraId number
+---@param disable boolean
+function SetVehicleExtra(vehicle, extraId, disable) end
+
+-- SET_VEHICLE_FIXED  (0x79811282A9D1AE56)
+-- This fixes a vehicle.
+-- If the vehicle's engine's broken then you cannot fix it with this native.
+-- min build: 1207
+---@param vehicle number
+function SetVehicleFixed(vehicle) end
+
+-- SET_VEHICLE_FORWARD_SPEED  (0xF9F92AF49F12F6E7)
+-- min build: 1207
+---@param vehicle number
+---@param speed number
+function SetVehicleForwardSpeed(vehicle, speed) end
+
+-- SET_VEHICLE_HANDBRAKE  (0x91BE51AEC4E99710)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleHandbrake(vehicle, toggle) end
+
+-- SET_VEHICLE_HAS_BEEN_OWNED_BY_PLAYER  (0xBB5A3FA8ED3979C5)
+-- min build: 1207
+---@param vehicle number
+---@param owned boolean
+function SetVehicleHasBeenOwnedByPlayer(vehicle, owned) end
+
+-- SET_VEHICLE_HAS_STRONG_AXLES  (0x252253C8A45AA1FC)
+-- if true, axles won't bend.
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleHasStrongAxles(vehicle, toggle) end
+
+-- SET_VEHICLE_HAS_UNBREAKABLE_LIGHTS  (0xC903855E028A05F2)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleHasUnbreakableLights(vehicle, p1) end
+
+-- SET_VEHICLE_INACTIVE_DURING_PLAYBACK  (0x4EA71B4C9DB3C3F1)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleInactiveDuringPlayback(vehicle, toggle) end
+
+-- SET_VEHICLE_INDIVIDUAL_DOORS_LOCKED  (0xA9F1D75195CC40F6)
+-- doorId: see SET_VEHICLE_DOOR_SHUT
+-- min build: 1207
+---@param vehicle number
+---@param doorId number
+---@param doorLockStatus number
+function SetVehicleIndividualDoorsLocked(vehicle, doorId, doorLockStatus) end
+
+-- SET_VEHICLE_INFLUENCES_WANTED_LEVEL  (0xC1842F40FD501DA2)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleInfluencesWantedLevel(vehicle, toggle) end
+
+-- SET_VEHICLE_IS_CONSIDERED_BY_PLAYER  (0x54800D386C5825E5)
+-- Setting this to false, makes the specified vehicle to where if you press Y your character doesn't even attempt the animation to enter the vehicle. Hence it's not considered aka ignored.
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleIsConsideredByPlayer(vehicle, toggle) end
+
+-- SET_VEHICLE_IS_STOLEN  (0x6C32FC81DFF25C9A)
+-- min build: 1207
+---@param vehicle number
+---@param isStolen boolean
+function SetVehicleIsStolen(vehicle, isStolen) end
+
+-- SET_VEHICLE_KEEP_ENGINE_ON_WHEN_ABANDONED  (0x1549BA7FE83A2383)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleKeepEngineOnWhenAbandoned(vehicle, toggle) end
+
+-- SET_VEHICLE_LIGHTS  (0x629F0A0E952CAE7D)
+-- Sets the vehicle's lights state.
+-- min build: 1207
+---@param vehicle number
+---@param state number
+function SetVehicleLights(vehicle, state) end
+
+-- SET_VEHICLE_LIMIT_SPEED_WHEN_PLAYER_INACTIVE  (0x8F75941C86EEBFCA)
+-- _SET_VEHICLE_LI*
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleLimitSpeedWhenPlayerInactive(vehicle, p1) end
+
+-- SET_VEHICLE_LOD_MULTIPLIER  (0x5F5E2B1B9EAECC0F)
+-- min build: 1207
+---@param vehicle number
+---@param multiplier number
+function SetVehicleLodMultiplier(vehicle, multiplier) end
+
+-- SET_VEHICLE_MAY_BE_USED_BY_GOTO_POINT_ANY_MEANS  (0x7549B9E841940695)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleMayBeUsedByGotoPointAnyMeans(vehicle, p1) end
+
+-- SET_VEHICLE_NOT_STEALABLE_AMBIENTLY  (0x09C970AE59ABF6B2)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleNotStealableAmbiently(vehicle, p1) end
+
+-- SET_VEHICLE_ON_GROUND_PROPERLY  (0x7263332501E07F52)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+---@return boolean
+function SetVehicleOnGroundProperly(vehicle, p1) end
+
+-- SET_VEHICLE_PETROL_TANK_HEALTH  (0x6AB2918EE3BEC94C)
+-- 1000 is max health
+-- min build: 1207
+---@param vehicle number
+---@param health number
+function SetVehiclePetrolTankHealth(vehicle, health) end
+
+-- SET_VEHICLE_PROVIDES_COVER  (0x652712478F1721F4)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleProvidesCover(vehicle, toggle) end
+
+-- SET_VEHICLE_RESPECTS_LOCKS_WHEN_HAS_DRIVER  (0x33992A808DF1C1BA)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleRespectsLocksWhenHasDriver(vehicle, p1) end
+
+-- SET_VEHICLE_SHOOT_AT_TARGET  (0xB79BE78C665B3E6D)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+function SetVehicleShootAtTarget(p0, p1, p2, p3, p4, p5) end
+
+-- SET_VEHICLE_STAYS_FROZEN_WHEN_CLEANED_UP  (0x23A3AB86E0807721)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleStaysFrozenWhenCleanedUp(vehicle, toggle) end
+
+-- SET_VEHICLE_STEER_BIAS  (0x84DAAE11E9EE4FC3)
+-- Locks the vehicle's steering to the desired angle, explained below.
+-- 
+-- Requires to be called onTick. Steering is unlocked the moment the function stops being called on the vehicle.
+-- 
+-- Steer bias:
+-- -1.0 = full right
+-- 0.0 = centered steering
+-- 1.0 = full left
+-- min build: 1207
+---@param vehicle number
+---@param value number
+function SetVehicleSteerBias(vehicle, value) end
+
+-- SET_VEHICLE_STOP_INSTANTLY_WHEN_PLAYER_INACTIVE  (0xC84E138448507567)
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function SetVehicleStopInstantlyWhenPlayerInactive(vehicle, p1) end
+
+-- SET_VEHICLE_STRONG  (0xAB315515C9F8803D)
+-- If set to true, vehicle will not take crash damage, but is still susceptible to damage from bullets and explosives
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleStrong(vehicle, toggle) end
+
+-- SET_VEHICLE_TYRES_CAN_BURST  (0xEBD0A4E935106FE5)
+-- Allows you to toggle bulletproof tires.
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleTyresCanBurst(vehicle, toggle) end
+
+-- SET_VEHICLE_UNDRIVEABLE  (0x6E884BAB713A2A94)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleUndriveable(vehicle, toggle) end
+
+-- SET_VEHICLE_WHEELS_CAN_BREAK  (0x839137C40275FB77)
+-- min build: 1207
+---@param vehicle number
+---@param enabled boolean
+function SetVehicleWheelsCanBreak(vehicle, enabled) end
+
+-- SET_VEHICLE_WHEELS_CAN_BREAK_OFF_WHEN_BLOW_UP  (0xC462C79379ABBCB1)
+-- min build: 1207
+---@param vehicle number
+---@param toggle boolean
+function SetVehicleWheelsCanBreakOffWhenBlowUp(vehicle, toggle) end
+
+-- SKIP_TIME_IN_PLAYBACK_RECORDED_VEHICLE  (0x5F5E6379C59EFC56)
+-- SET_TIME_POSITION_IN_RECORDING can be emulated by: desired_time - GET_TIME_POSITION_IN_RECORDING(vehicle)
+-- min build: 1207
+---@param vehicle number
+---@param time number
+function SkipTimeInPlaybackRecordedVehicle(vehicle, time) end
+
+-- START_PLAYBACK_RECORDED_VEHICLE  (0x4932B84E3276508E)
+-- p3 is some flag related to 'trailers' (invokes CVehicle::GetTrailer).
+-- 
+-- See REQUEST_VEHICLE_RECORDING
+-- min build: 1207
+---@param vehicle number
+---@param recording number
+---@param script string
+---@param p3 boolean
+function StartPlaybackRecordedVehicle(vehicle, recording, script, p3) end
+
+-- START_VEHICLE_HORN  (0xB4E3BFC39CA16057)
+-- Sounds the horn for the specified vehicle.
+-- 
+-- vehicle: The vehicle to activate the horn for.
+-- mode: The hash of "NORMAL" or "HELDDOWN". Can be 0.
+-- duration: The duration to sound the horn, in milliseconds.
+-- 
+-- Note: If a player is in the vehicle, it will only sound briefly.
+-- min build: 1207
+---@param vehicle number
+---@param duration number
+---@param mode number
+---@param forever boolean
+function StartVehicleHorn(vehicle, duration, mode, forever) end
+
+-- STOP_BRINGING_VEHICLE_TO_HALT  (0x7C06330BFDDA182E)
+-- Old name: _STOP_BRING_VEHICLE_TO_HALT
+-- min build: 1207
+---@param vehicle number
+function StopBringingVehicleToHalt(vehicle) end
+
+-- STOP_PLAYBACK_RECORDED_VEHICLE  (0xBF9B4D6267E8C26D)
+-- min build: 1207
+---@param vehicle number
+function StopPlaybackRecordedVehicle(vehicle) end
+
+-- TRACK_VEHICLE_VISIBILITY  (0x1F3969B140DEE157)
+-- min build: 1207
+---@param vehicle number
+function TrackVehicleVisibility(vehicle) end

--- a/.luals/redm-natives/VOICE.lua
+++ b/.luals/redm-natives/VOICE.lua
@@ -1,0 +1,140 @@
+---@meta
+
+-- RDR3 namespace: VOICE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x08797A8C03868CB8  (0x08797A8C03868CB8)
+-- min build: 1207
+---@param threshold number
+function N_0x08797A8C03868CB8(threshold) end
+
+-- _0x0DED260A1958A82E  (0x0DED260A1958A82E)
+-- Returns whether the local player is muted by the specified network player.
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x0DED260A1958A82E(player) end
+
+-- _0x1C38C3577901AF1F  (0x1C38C3577901AF1F)
+-- min build: 1207
+function N_0x1C38C3577901AF1F() end
+
+-- _0x1FBF7F5BA7E4BE3A  (0x1FBF7F5BA7E4BE3A)
+-- min build: 1207
+---@param p0 number
+function N_0x1FBF7F5BA7E4BE3A(p0) end
+
+-- _0x2F82CAB262C8AE26  (0x2F82CAB262C8AE26)
+-- min build: 1207
+---@param player number
+---@return number
+function N_0x2F82CAB262C8AE26(player) end
+
+-- _0x356135B9B10A2A82  (0x356135B9B10A2A82)
+-- min build: 1207
+---@return boolean
+---@return any
+function N_0x356135B9B10A2A82() end
+
+-- _0x4791899615D70FA2  (0x4791899615D70FA2)
+-- Params: p1 = 2; p2 = 3 in R* Script net_main_offline
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@param p2 number
+function N_0x4791899615D70FA2(player, p1, p2) end
+
+-- _0x49623BCFC3A3D829  (0x49623BCFC3A3D829)
+-- min build: 1207
+---@param player number
+---@param muted boolean
+---@return boolean
+function N_0x49623BCFC3A3D829(player, muted) end
+
+-- _0x58125B691F6827D5  (0x58125B691F6827D5)
+-- min build: 1207
+---@param proximity number
+function N_0x58125B691F6827D5(proximity) end
+
+-- _0x5CA7FB7D6DE49DCC  (0x5CA7FB7D6DE49DCC)
+-- min build: 1207
+---@param player number
+---@return number
+function N_0x5CA7FB7D6DE49DCC(player) end
+
+-- _0x767931C727DF2ED7  (0x767931C727DF2ED7)
+-- Returns p2 value of 0x4791899615D70FA2
+-- min build: 1207
+---@param player number
+---@param p1 number
+---@return number
+function N_0x767931C727DF2ED7(player, p1) end
+
+-- _0x79F478FF5F9F4F05  (0x79F478FF5F9F4F05)
+-- min build: 1207
+---@param enabled boolean
+function N_0x79F478FF5F9F4F05(enabled) end
+
+-- _0x8E462DB1EAA9C47C  (0x8E462DB1EAA9C47C)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x8E462DB1EAA9C47C(player) end
+
+-- _0x919AF2D93E9AA89D  (0x919AF2D93E9AA89D)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0x919AF2D93E9AA89D(player) end
+
+-- _0xAA35FD9ABAB490A3  (0xAA35FD9ABAB490A3)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0xAA35FD9ABAB490A3(player) end
+
+-- _0xB3E8841F6BDAF83E  (0xB3E8841F6BDAF83E)
+-- min build: 1207
+function N_0xB3E8841F6BDAF83E() end
+
+-- _0xB6E79850B759A30E  (0xB6E79850B759A30E)
+-- min build: 1207
+---@param teamId number
+---@param allow boolean
+function N_0xB6E79850B759A30E(teamId, allow) end
+
+-- _0xB779F4FA19269AEC  (0xB779F4FA19269AEC)
+-- min build: 1207
+---@param flag boolean
+function N_0xB779F4FA19269AEC(flag) end
+
+-- _0xCCF71FCFA0070B1A  (0xCCF71FCFA0070B1A)
+-- min build: 1207
+---@return boolean
+function N_0xCCF71FCFA0070B1A() end
+
+-- _0xDB622ECD3DCBE078  (0xDB622ECD3DCBE078)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0xDB622ECD3DCBE078(player) end
+
+-- _0xDC9B361CB7776673  (0xDC9B361CB7776673)
+-- min build: 1207
+---@param player number
+function N_0xDC9B361CB7776673(player) end
+
+-- _0xEC8703E4536A9952  (0xEC8703E4536A9952)
+-- min build: 1207
+function N_0xEC8703E4536A9952() end
+
+-- _0xEF6F2A35FAAF2ED7  (0xEF6F2A35FAAF2ED7)
+-- min build: 1207
+---@param player number
+---@return boolean
+function N_0xEF6F2A35FAAF2ED7(player) end
+
+-- _0xF8938CF3984092A5  (0xF8938CF3984092A5)
+-- min build: 1207
+---@param player number
+function N_0xF8938CF3984092A5(player) end

--- a/.luals/redm-natives/VOLUME.lua
+++ b/.luals/redm-natives/VOLUME.lua
@@ -1,0 +1,705 @@
+---@meta
+
+-- RDR3 namespace: VOLUME -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x128FC3A893BF853A  (0x128FC3A893BF853A)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 any
+function N_0x128FC3A893BF853A(p0) end
+
+-- _0x351D71B8B72B858B  (0x351D71B8B72B858B)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x351D71B8B72B858B(p0) end
+
+-- _0x3EFABB21E14A6BD1  (0x3EFABB21E14A6BD1)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x3EFABB21E14A6BD1(p0, p1, p2) end
+
+-- _0x40F769D31A00D5A0  (0x40F769D31A00D5A0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0x40F769D31A00D5A0(p0, p1) end
+
+-- _0x4A8FEFC43FD8AC9B  (0x4A8FEFC43FD8AC9B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x4A8FEFC43FD8AC9B(p0, p1, p2) end
+
+-- _0x51E52C9687FCDEEC  (0x51E52C9687FCDEEC)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@return any
+function N_0x51E52C9687FCDEEC(p0, p1, p2, p3, p4, p5, p6) end
+
+-- _0x52572B331E693AED  (0x52572B331E693AED)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0x52572B331E693AED(p0, p1, p2) end
+
+-- _0x53D05D60E5F5B40C  (0x53D05D60E5F5B40C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0x53D05D60E5F5B40C(p0, p1, p2, p3) end
+
+-- _0x695DAC2DB928F308  (0x695DAC2DB928F308)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x695DAC2DB928F308(p0, p1) end
+
+-- _0x6D5F9E69BA1BE783  (0x6D5F9E69BA1BE783)
+-- min build: 1207
+---@param p0 any
+function N_0x6D5F9E69BA1BE783(p0) end
+
+-- _0x748C5F51A18CB8F0  (0x748C5F51A18CB8F0)
+-- nullsub, doesn't do anything
+-- min build: 1207
+---@param p0 boolean
+function N_0x748C5F51A18CB8F0(p0) end
+
+-- _0x7FD78DFD0C5D7B9B  (0x7FD78DFD0C5D7B9B)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0x7FD78DFD0C5D7B9B(p0) end
+
+-- _0x870E9981ED27C815  (0x870E9981ED27C815)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return any
+function N_0x870E9981ED27C815(p0, p1, p2, p3, p4, p5) end
+
+-- _0x998202B206872672  (0x998202B206872672)
+-- min build: 1207
+---@param p0 any
+function N_0x998202B206872672(p0) end
+
+-- _0xAA9EE2AAFC717623  (0xAA9EE2AAFC717623)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@return any
+function N_0xAA9EE2AAFC717623(p0, p1, p2, p3, p4, p5) end
+
+-- _0xAC355980681A7F89  (0xAC355980681A7F89)
+-- min build: 1207
+---@param p0 any
+function N_0xAC355980681A7F89(p0) end
+
+-- _0xB440F4E35393FC39  (0xB440F4E35393FC39)
+-- min build: 1207
+---@param volume number
+---@param p1 any
+function N_0xB440F4E35393FC39(volume, p1) end
+
+-- _0xB469CFD9E065EB99  (0xB469CFD9E065EB99)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xB469CFD9E065EB99(p0, p1) end
+
+-- _0xC4019CF9AE8E931A  (0xC4019CF9AE8E931A)
+-- min build: 1207
+---@param volLockRequestId number
+---@return vector3
+function N_0xC4019CF9AE8E931A(volLockRequestId) end
+
+-- _0xC61E2FD926DBB406  (0xC61E2FD926DBB406)
+-- min build: 1311
+function N_0xC61E2FD926DBB406() end
+
+-- _0xCA5C90D40665D5CE  (0xCA5C90D40665D5CE)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xCA5C90D40665D5CE(p0, p1) end
+
+-- _0xD460135C98940274  (0xD460135C98940274)
+-- min build: 1207
+---@param volume number
+---@param p1 any
+function N_0xD460135C98940274(volume, p1) end
+
+-- _0xD4FA73FE628FEC63  (0xD4FA73FE628FEC63)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xD4FA73FE628FEC63(p0, p1) end
+
+-- _0xD52DF30355EA7C8E  (0xD52DF30355EA7C8E)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD52DF30355EA7C8E(p0, p1, p2) end
+
+-- _0xD882C5B3991575B7  (0xD882C5B3991575B7)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@return vector3
+function N_0xD882C5B3991575B7(p0, p1, p2, p3, p4) end
+
+-- _0xEBA87B9273835CF3  (0xEBA87B9273835CF3)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0xEBA87B9273835CF3(p0, p1) end
+
+-- _0xEE1D6FF54CAF7714  (0xEE1D6FF54CAF7714)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xEE1D6FF54CAF7714(p0, p1) end
+
+-- _0xF3A2FBA5985C8CD5  (0xF3A2FBA5985C8CD5)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+function N_0xF3A2FBA5985C8CD5(p0, p1, p2, p3) end
+
+-- _0xF6CE6F9C3897804E  (0xF6CE6F9C3897804E)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF6CE6F9C3897804E(p0) end
+
+-- _0xF6F5447D418DAA82  (0xF6F5447D418DAA82)
+-- min build: 1207
+---@param p0 any
+---@return any
+function N_0xF6F5447D418DAA82(p0) end
+
+-- _0xFA15C9A320E707B0  (0xFA15C9A320E707B0)
+-- nullsub, doesn't do anything
+-- min build: 1207
+function N_0xFA15C9A320E707B0() end
+
+-- _ADD_BOUNDS_TO_AGGREGATE_VOLUME  (0x6E0D3C3F828DA773)
+-- _ADD_R* - _ADD_V(OLUME?)*
+-- min build: 1207
+---@param volume number
+---@param aggregate number
+function _AddBoundsToAggregateVolume(volume, aggregate) end
+
+-- _ADD_BOX_VOLUME_TO_VOLUME_AGGREGATE  (0x39816F6F94F385AD)
+-- min build: 1207
+---@param aggregate number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+function _AddBoxVolumeToVolumeAggregate(aggregate, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _ADD_CYLINDER_VOLUME_TO_VOLUME_AGGREGATE  (0xBCE668AAF83608BE)
+-- min build: 1207
+---@param aggregate number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+function _AddCylinderVolumeToVolumeAggregate(aggregate, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _ADD_ENTRY_VOLUME_LOCK  (0x58D3803FA639A3BB)
+-- min build: 1311
+---@return boolean
+---@return any
+function _AddEntryVolumeLock() end
+
+-- _ADD_SPHERE_VOLUME_TO_VOLUME_AGGREGATE  (0x5B7D7BF36D2DE18B)
+-- min build: 1207
+---@param aggregate number
+---@param p1 number
+---@param p2 number
+---@param p3 number
+---@param p4 number
+---@param p5 number
+---@param p6 number
+---@param p7 number
+---@param p8 number
+---@param p9 number
+function _AddSphereVolumeToVolumeAggregate(aggregate, p1, p2, p3, p4, p5, p6, p7, p8, p9) end
+
+-- _ADD_VOLUME_TO_VOLUME_AGGREGATE  (0x12FCAA23F2320422)
+-- min build: 1207
+---@param aggregate number
+---@param typeHash number
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+function _AddVolumeToVolumeAggregate(aggregate, typeHash, x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- _CREATE_ANTI_GRIEF_VOLUME  (0x0EB78C2B156635B1)
+-- min build: 1207
+---@param volumeType number
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return number
+function _CreateAntiGriefVolume(volumeType, x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- _CREATE_SPEED_VOLUME  (0xBBE768E3AE76E07C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@param p13 any
+---@param p14 any
+---@return number
+function _CreateSpeedVolume(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) end
+
+-- _CREATE_VOLUME_AGGREGATE_WITH_CUSTOM_NAME  (0x5D580DE6398BB162)
+-- min build: 1207
+---@param name string
+---@return number
+function _CreateVolumeAggregateWithCustomName(name) end
+
+-- _CREATE_VOLUME_BOX_WITH_CUSTOM_NAME  (0xF68485C7495D848E)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@param name string
+---@return number
+function _CreateVolumeBoxWithCustomName(x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, name) end
+
+-- _CREATE_VOLUME_BY_HASH  (0x502022FA1AF9DC86)
+-- min build: 1207
+---@param volumeType number
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return number
+function _CreateVolumeByHash(volumeType, x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- _CREATE_VOLUME_BY_HASH_WITH_CUSTOM_NAME  (0x1F85E4AC774A201E)
+-- min build: 1207
+---@param volumeType number
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@param name string
+---@return number
+function _CreateVolumeByHashWithCustomName(volumeType, x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, name) end
+
+-- _CREATE_VOLUME_CYLINDER_WITH_CUSTOM_NAME  (0xDF1E350EDDF06E59)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@param name string
+---@return number
+function _CreateVolumeCylinderWithCustomName(x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, name) end
+
+-- _CREATE_VOLUME_LOCK  (0x00BBF7CEAE8C666A)
+-- Params: p5 is always 0
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param flag number
+---@param p5 any
+---@return number
+function _CreateVolumeLock(x, y, z, radius, flag, p5) end
+
+-- _CREATE_VOLUME_LOCK_ATTACHED_TO_ENTITY  (0xF383E96C4904DF0C)
+-- Params: p3 is always 0
+-- min build: 1207
+---@param entity number
+---@param radius number
+---@param flag number
+---@param p3 any
+---@return number
+function _CreateVolumeLockAttachedToEntity(entity, radius, flag, p3) end
+
+-- _CREATE_VOLUME_SPHERE_WITH_CUSTOM_NAME  (0x10157BC3247FF3BA)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@param name string
+---@return number
+function _CreateVolumeSphereWithCustomName(x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, name) end
+
+-- _CREATE_WALK_AND_TALK_VOLUME  (0xFD0E389CD44434B6)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@param p3 any
+---@param p4 any
+---@param p5 any
+---@param p6 any
+---@param p7 any
+---@param p8 any
+---@param p9 any
+---@param p10 any
+---@param p11 any
+---@param p12 any
+---@return number
+function _CreateWalkAndTalkVolume(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) end
+
+-- _FIND_VOLUME_LOCK_REQUEST_ID_WITH_ARGS  (0x77A6E4AD0C496F81)
+-- min build: 1207
+---@return number
+---@return any
+function _FindVolumeLockRequestIdWithArgs() end
+
+-- _GET_VOLUME_AMOUNT_OF_INDEXED_ITEMS  (0x2B32B11520626229)
+-- Indexes items (including entyties and peds) in a set volume
+-- Counts up as its the return value of how many items it writes to given itemSet
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param itemSet number
+---@return number
+function _GetVolumeAmountOfIndexedItems(x, y, z, radius, itemSet) end
+
+-- _GET_VOLUME_BOUNDS  (0x5737199AF2DC609F)
+-- min build: 1207
+---@param volume number
+---@return vector3
+---@return vector3
+function _GetVolumeBounds(volume) end
+
+-- _GET_VOLUME_RELATIONSHIP  (0x666C2F53ABEFC952)
+-- Returns relationshipGroup Hash
+-- min build: 1207
+---@param volume number
+---@return number
+function _GetVolumeRelationship(volume) end
+
+-- _IS_AGGREGATE_VOLUME  (0xFEFF01B5725BCD22)
+-- min build: 1207
+---@param volume number
+---@return boolean
+function _IsAggregateVolume(volume) end
+
+-- _IS_POINT_NEAR_VOLUME_LOCK_CENTER  (0x769BB7626B8CDB06)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 number
+---@param p5 number
+---@param flags number
+---@return boolean
+function _IsPointNearVolumeLockCenter(x, y, z, radius, p4, p5, flags) end
+
+-- _IS_VOLUME_LOCK_REQUEST_VALID_2  (0xF6A8A652A6B186CD)
+-- min build: 1207
+---@param volLockRequestId number
+---@return boolean
+function _IsVolumeLockRequestValid2(volLockRequestId) end
+
+-- _MODIFY_VOLUME_LOCK_LOCATION  (0xEC43C2FFB70E3F30)
+-- min build: 1207
+---@param volLock number
+---@param x number
+---@param y number
+---@param z number
+function _ModifyVolumeLockLocation(volLock, x, y, z) end
+
+-- _RELEASE_LOCK_VOLUME  (0xFDFECC6EE4491E11)
+-- min build: 1207
+---@param volLockRequestId number
+function _ReleaseLockVolume(volLockRequestId) end
+
+-- _REMOVE_BOUNDS_FROM_AGGREGATE_VOLUME  (0xF92FA8890DECECF6)
+-- _REMOVE_E* - _REMOVE_R*
+-- min build: 1207
+---@param volume number
+---@param aggregate number
+function _RemoveBoundsFromAggregateVolume(volume, aggregate) end
+
+-- _SET_ANTI_GRIEF_VOLUME_BLOCKS_HORSE  (0xBE551C2CC421185D)
+-- min build: 1207
+---@param volume number
+---@param toggle boolean
+function _SetAntiGriefVolumeBlocksHorse(volume, toggle) end
+
+-- _SET_ANTI_GRIEF_VOLUME_BLOCKS_PLAYER  (0x5B23DFF8E0948BB2)
+-- min build: 1207
+---@param volume number
+---@param toggle boolean
+function _SetAntiGriefVolumeBlocksPlayer(volume, toggle) end
+
+-- _SET_VOLUME_RELATIONSHIP  (0xFD010A2154B40676)
+-- min build: 1207
+---@param volume number
+---@param relationshipGroup number
+function _SetVolumeRelationship(volume, relationshipGroup) end
+
+-- CREATE_VOLUME_AGGREGATE  (0x59F6F5C1D129F106)
+-- min build: 1207
+---@return number
+function CreateVolumeAggregate() end
+
+-- CREATE_VOLUME_BOX  (0xDF85637F22706891)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return number
+function CreateVolumeBox(x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- CREATE_VOLUME_CYLINDER  (0x0522D4774B82E3E6)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return number
+function CreateVolumeCylinder(x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- CREATE_VOLUME_SPHERE  (0xB3FB80A32BAE3065)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return number
+function CreateVolumeSphere(x, y, z, rotX, rotY, rotZ, scaleX, scaleY, scaleZ) end
+
+-- DELETE_VOLUME  (0x43F867EF5C463A53)
+-- min build: 1207
+---@param volume number
+function DeleteVolume(volume) end
+
+-- DOES_VOLUME_COLLIDE_WITH_ANY_VOLUME_LOCK  (0x397769175A7DBB30)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 boolean
+---@param p5 number
+---@param p6 number
+---@return boolean
+function DoesVolumeCollideWithAnyVolumeLock(x, y, z, radius, p4, p5, p6) end
+
+-- DOES_VOLUME_EXIST  (0x92A78D0BEDB332A3)
+-- min build: 1207
+---@param volume number
+---@return boolean
+function DoesVolumeExist(volume) end
+
+-- GET_VOLUME_COORDS  (0xF70F00013A62F866)
+-- min build: 1207
+---@param volume number
+---@return vector3
+function GetVolumeCoords(volume) end
+
+-- GET_VOLUME_LOCK_REQUEST_STATUS  (0xB33A604345F58202)
+-- enum eVolumeLockRequestStatus
+-- {
+-- 	VOLUME_LOCK_REQUEST_STATUS_INVALID,
+-- 	VOLUME_LOCK_REQUEST_STATUS_READY,
+-- 	VOLUME_LOCK_REQUEST_STATUS_IN_PROGRESS,
+-- 	VOLUME_LOCK_REQUEST_STATUS_SUCCEEDED,
+-- 	VOLUME_LOCK_REQUEST_STATUS_FAILED
+-- };
+-- min build: 1207
+---@param volLockRequestId number
+---@return number
+function GetVolumeLockRequestStatus(volLockRequestId) end
+
+-- GET_VOLUME_ROTATION  (0x18675BC914891122)
+-- min build: 1207
+---@param volume number
+---@return vector3
+function GetVolumeRotation(volume) end
+
+-- GET_VOLUME_SCALE  (0x3E2A25B2416DD67E)
+-- min build: 1207
+---@param volume number
+---@return vector3
+function GetVolumeScale(volume) end
+
+-- IS_POINT_IN_VOLUME  (0xF256A75210C5C0EB)
+-- Old name: _IS_POSITION_INSIDE_VOLUME
+-- min build: 1207
+---@param volume number
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+function IsPointInVolume(volume, x, y, z) end
+
+-- IS_VOLUME_LOCK_REQUEST_VALID  (0xA4A4359320345B34)
+-- min build: 1207
+---@param volLockRequestId number
+---@return boolean
+function IsVolumeLockRequestValid(volLockRequestId) end
+
+-- REQUEST_VOLUME_LOCK  (0xF14BCEF290F869E1)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param radius number
+---@param p4 number
+---@param p5 number
+---@return number
+function RequestVolumeLock(x, y, z, radius, p4, p5) end
+
+-- REQUEST_VOLUME_LOCK_WITH_ARGS  (0x183C0B6CFEFFCAE4)
+-- min build: 1207
+---@return number
+---@return any
+function RequestVolumeLockWithArgs() end
+
+-- SET_VOLUME_COORDS  (0x541B8576615C33DE)
+-- min build: 1207
+---@param volume number
+---@param posX number
+---@param posY number
+---@param posZ number
+---@return boolean
+function SetVolumeCoords(volume, posX, posY, posZ) end
+
+-- SET_VOLUME_OWNER_PERSISTENT_CHARACTER  (0xE2BE6FFA4A13CBB0)
+-- min build: 1207
+---@param volume number
+---@param persChar number
+---@param p2 boolean
+function SetVolumeOwnerPersistentCharacter(volume, persChar, p2) end
+
+-- SET_VOLUME_ROTATION  (0xA07CF1B21B56F041)
+-- min build: 1207
+---@param volume number
+---@param rotX number
+---@param rotY number
+---@param rotZ number
+---@return boolean
+function SetVolumeRotation(volume, rotX, rotY, rotZ) end
+
+-- SET_VOLUME_SCALE  (0xA46E98BDC407E23D)
+-- min build: 1207
+---@param volume number
+---@param scaleX number
+---@param scaleY number
+---@param scaleZ number
+---@return boolean
+function SetVolumeScale(volume, scaleX, scaleY, scaleZ) end

--- a/.luals/redm-natives/WATER.lua
+++ b/.luals/redm-natives/WATER.lua
@@ -1,0 +1,138 @@
+---@meta
+
+-- RDR3 namespace: WATER -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x09A1C7DFDCE54FBC  (0x09A1C7DFDCE54FBC)
+-- Called together with REMOVE_EXTRA_CALMING_QUAD in rcm_crackpot1 R* Script: p0 = 0
+-- _REMOVE_*
+-- min build: 1207
+---@param p0 number
+function N_0x09A1C7DFDCE54FBC(p0) end
+
+-- _0x0DCEC6A92E497E17  (0x0DCEC6A92E497E17)
+-- Only used in native_son1 R* Script: p1 = 1
+-- min build: 1207
+---@param entity number
+---@param p1 number
+function N_0x0DCEC6A92E497E17(entity, p1) end
+
+-- _0xA33F5069B0CB89B8  (0xA33F5069B0CB89B8)
+-- Only used in fishing_core R* Script
+-- min build: 1207
+function N_0xA33F5069B0CB89B8() end
+
+-- _0xB34A6009A0DB80B8  (0xB34A6009A0DB80B8)
+-- Used in bounty1, fanale3, sean1 R* Scripts
+-- min build: 1207
+---@param entity number
+function N_0xB34A6009A0DB80B8(entity) end
+
+-- _0xE8126623008372AA  (0xE8126623008372AA)
+-- Only used in fussar1 / train_robbery2 R* Script
+-- min build: 1207
+function N_0xE8126623008372AA() end
+
+-- _0xF0FBF193F1F5C0EA  (0xF0FBF193F1F5C0EA)
+-- Only used in fishing_core R* Script
+-- min build: 1207
+---@param ped number
+function N_0xF0FBF193F1F5C0EA(ped) end
+
+-- _GET_WORLD_WATER_TYPE  (0x189739A7631C1867)
+-- min build: 1207
+---@return number
+function _GetWorldWaterType() end
+
+-- _RESET_GUARMA_WATER_STATE  (0xC63540AEF8384769)
+-- Only used in guama1 / guama3 R* Script
+-- _REQUEST_* or _RESET_*
+-- min build: 1207
+function _ResetGuarmaWaterState() end
+
+-- _SET_OCEAN_GUARMA_WATER_QUADRANT  (0xC63540AEF8384732)
+-- Only used in R* Script guama1
+-- min build: 1207
+---@param wavesHeight number
+---@param p1 number
+---@param wavesDirection number
+---@param p3 number
+---@param wavesAmount number
+---@param p5 number
+---@param wavesSpeed number
+---@param wavesStrength number
+---@param ignoreHeight boolean
+function _SetOceanGuarmaWaterQuadrant(wavesHeight, p1, wavesDirection, p3, wavesAmount, p5, wavesSpeed, wavesStrength, ignoreHeight) end
+
+-- _SET_WORLD_WATER_TYPE  (0xE8770EE02AEE45C2)
+-- 0 = World
+-- 1 = Guarma
+-- min build: 1207
+---@param waterType number
+function _SetWorldWaterType(waterType) end
+
+-- DISABLE_WATER_LOOKUP  (0x754616EC6965D1FB)
+-- Must be called every frame to take full effect.
+-- min build: 1207
+function DisableWaterLookup() end
+
+-- ENABLE_WATER_LOOKUP  (0x754616EC6965D1BF)
+-- min build: 1207
+function EnableWaterLookup() end
+
+-- GET_WATER_HEIGHT  (0xFCA8B23F28813F69)
+-- Checks against a global variable that is set by _SET_WORLD_WATER_TYPE. If that is set to one it will fail. Likely not the only issue but part of it.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return number
+function GetWaterHeight(x, y, z) end
+
+-- GET_WATER_HEIGHT_NO_WAVES  (0xDCF3690AA262C03F)
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return boolean
+---@return number
+function GetWaterHeightNoWaves(x, y, z) end
+
+-- REMOVE_EXTRA_CALMING_QUAD  (0x4BEF8DD75AF6C71C)
+-- Only used in rcm_crackpot1 R* Script: p0 = 0
+-- min build: 1207
+---@param index number
+function RemoveExtraCalmingQuad(index) end
+
+-- TEST_PROBE_AGAINST_ALL_WATER  (0x8974647ED222EA5F)
+-- enum eScriptWaterTestResult
+-- {
+-- 	SCRIPT_WATER_TEST_RESULT_NONE,
+-- 	SCRIPT_WATER_TEST_RESULT_WATER,
+-- 	SCRIPT_WATER_TEST_RESULT_BLOCKED,
+-- };
+-- min build: 1207
+---@param x1 number
+---@param y1 number
+---@param z1 number
+---@param x2 number
+---@param y2 number
+---@param z2 number
+---@param flags number
+---@return number
+---@return vector3
+function TestProbeAgainstAllWater(x1, y1, z1, x2, y2, z2, flags) end
+
+-- TEST_VERTICAL_PROBE_AGAINST_ALL_WATER  (0x2B3451FA1E3142E2)
+-- Checks against a global variable that is set by _SET_WORLD_WATER_TYPE. If it's set to 1 (Guarma) it will fail.
+-- 
+-- See TEST_PROBE_AGAINST_ALL_WATER.
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param flags number
+---@return number
+---@return number
+function TestVerticalProbeAgainstAllWater(x, y, z, flags) end

--- a/.luals/redm-natives/WEAPON.lua
+++ b/.luals/redm-natives/WEAPON.lua
@@ -1,0 +1,1827 @@
+---@meta
+
+-- RDR3 namespace: WEAPON -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _0x000FA7A4A8443AF7  (0x000FA7A4A8443AF7)
+-- min build: 1207
+---@param p0 any
+function N_0x000FA7A4A8443AF7(p0) end
+
+-- _0x07E1C35F0078C3F9  (0x07E1C35F0078C3F9)
+-- Seems to return true if the passed weapon is some sort of non-lethal melee weapon.
+-- Weapon must currently be held/equipped by the ped.
+-- min build: 1207
+---@param ped number
+---@param weapon number
+---@return boolean
+function N_0x07E1C35F0078C3F9(ped, weapon) end
+
+-- _0x16D9841A85FA627E  (0x16D9841A85FA627E)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function N_0x16D9841A85FA627E(ped, toggle) end
+
+-- _0x183CE355115B6E75  (0x183CE355115B6E75)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x183CE355115B6E75(p0, p1) end
+
+-- _0x431240A58484D5D0  (0x431240A58484D5D0)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function N_0x431240A58484D5D0(ped, toggle) end
+
+-- _0x457B16951AD77C1B  (0x457B16951AD77C1B)
+-- min build: 1436
+---@param p0 any
+function N_0x457B16951AD77C1B(p0) end
+
+-- _0x45E57FDD531C9477  (0x45E57FDD531C9477)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function N_0x45E57FDD531C9477(ped, toggle) end
+
+-- _0x63B83A526329AFBC  (0x63B83A526329AFBC)
+-- Only used in R* Script fme_escaped_convicts, p0 = 0
+-- min build: 1207
+---@param p0 any
+function N_0x63B83A526329AFBC(p0) end
+
+-- _0x641351E9AD103890  (0x641351E9AD103890)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x641351E9AD103890(p0, p1) end
+
+-- _0x74C2365FDD1BB48F  (0x74C2365FDD1BB48F)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+function N_0x74C2365FDD1BB48F(p0, p1) end
+
+-- _0x9409C62504A8F9E9  (0x9409C62504A8F9E9)
+-- Only used in R* SP Script guama3
+-- min build: 1207
+---@param vehicle number
+---@param p1 boolean
+function N_0x9409C62504A8F9E9(vehicle, p1) end
+
+-- _0x9CCA3131E6B53C68  (0x9CCA3131E6B53C68)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+---@return any
+function N_0x9CCA3131E6B53C68(p0, p1, p2) end
+
+-- _0xA2091482ED42EF85  (0xA2091482ED42EF85)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xA2091482ED42EF85(p0, p1) end
+
+-- _0xA3716A77DCF17424  (0xA3716A77DCF17424)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xA3716A77DCF17424(p0, p1, p2) end
+
+-- _0xA769D753922B031B  (0xA769D753922B031B)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xA769D753922B031B(p0, p1, p2) end
+
+-- _0xB0FB9B196A3D13F0  (0xB0FB9B196A3D13F0)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xB0FB9B196A3D13F0(p0, p1, p2) end
+
+-- _0xC5899C4CD2E2495D  (0xC5899C4CD2E2495D)
+-- min build: 1207
+---@param p0 any
+function N_0xC5899C4CD2E2495D(p0) end
+
+-- _0xD53846B9C931C181  (0xD53846B9C931C181)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xD53846B9C931C181(p0, p1, p2) end
+
+-- _0xE9B3FEC825668291  (0xE9B3FEC825668291)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@param p2 any
+function N_0xE9B3FEC825668291(p0, p1, p2) end
+
+-- _0xECBB26529A737EF6  (0xECBB26529A737EF6)
+-- min build: 1207
+---@param p0 any
+function N_0xECBB26529A737EF6(p0) end
+
+-- _0xF08D8FEB455F2C8C  (0xF08D8FEB455F2C8C)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function N_0xF08D8FEB455F2C8C(ped, toggle) end
+
+-- _0xF252A85B8F3F8C58  (0xF252A85B8F3F8C58)
+-- min build: 1207
+---@param weaponCollection number
+---@param dualwieldVariant number
+---@return boolean
+function N_0xF252A85B8F3F8C58(weaponCollection, dualwieldVariant) end
+
+-- _0xF2F585411E748B9C  (0xF2F585411E748B9C)
+-- min build: 1207
+---@param p0 any
+---@param p1 any
+---@return any
+function N_0xF2F585411E748B9C(p0, p1) end
+
+-- _0xF8204EF17410BF43  (0xF8204EF17410BF43)
+-- Returns weaponHash
+-- min build: 1207
+---@param weaponGroupHash number
+---@param p1 number
+---@param p2 number
+---@param p3 any
+---@return number
+function N_0xF8204EF17410BF43(weaponGroupHash, p1, p2, p3) end
+
+-- _ADD_AMMO_TO_PED  (0xB190BCA3F4042F95)
+-- addReason:
+-- enum eAddItemReason : Hash
+-- {
+-- 	ADD_REASON_AWARDS = 0xB784AD1E,
+-- 	ADD_REASON_CREATE_CHARACTER = 0xE2C4FF71,
+-- 	ADD_REASON_DEBUG = 0x5C05C64D,
+-- 	ADD_REASON_DEFAULT = 0x2CD419DC,
+-- 	ADD_REASON_GET_INVENTORY = 0xD8188685,
+-- 	ADD_REASON_INCENTIVE = 0x8ADC2E95,
+-- 	ADD_REASON_LOADOUT = 0xCA3454E6,
+-- 	ADD_REASON_LOAD_SAVEGAME = 0x56212906,
+-- 	ADD_REASON_LOOTED = 0xCA806A55,
+-- 	ADD_REASON_MELEE = 0x7B9BDCE7,
+-- 	ADD_REASON_MP_MISSION = 0xEC0E0194,
+-- 	ADD_REASON_NOTIFICATION = 0xC56292D2,
+-- 	ADD_REASON_PICKUP = 0x1A770E22,
+-- 	ADD_REASON_PURCHASED = 0x4A6726C9,
+-- 	ADD_REASON_SET_AMOUNT = 0x4504731E,
+-- 	ADD_REASON_SYNCING = 0x8D4B4FF4,
+-- 	ADD_REASON_USE_FAILED = 0xD385B670
+-- };
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param amount number
+---@param addReason number
+function _AddAmmoToPed(ped, weaponHash, amount, addReason) end
+
+-- _ADD_AMMO_TO_PED_BY_TYPE  (0x106A811C6D3035F3)
+-- addReason: see _ADD_AMMO_TO_PED
+-- min build: 1207
+---@param ped number
+---@param ammoType number
+---@param amount number
+---@param addReason number
+function _AddAmmoToPedByType(ped, ammoType, amount, addReason) end
+
+-- _ATTACH_WEAPON_TO_HORSE_HOLSTER  (0x14FF0C2545527F9B)
+-- Visually attaches the specified weapon to a horse holster/rack (shows the weapon model on the horse), even when the caller is not near the horse.
+-- 
+-- Typical flow:
+-- 	1) Move/assign the weapon into the horse inventory context first (commonly via 0xE9BD19F8121ADE3E).
+-- 	2) Call this native to force the visible attachment on the horse.
+-- 
+-- Notes:
+-- - This is about the *visible* holster/rack state; it is often paired with 0xE9BD19F8121ADE3E because that makes the weapon available in inventory terms, while this makes it appear on the horse.
+-- - Validate `horse` and `ownerPed` exist and are alive/valid before calling.
+-- 
+-- Related:
+-- - 0xE9BD19F8121ADE3E (commonly used before this)
+-- - 0xD4C6E24D955FF061 (_DELETE_WEAPON_OBJECTS_ON_HORSE)
+-- min build: 1207
+---@param horse number
+---@param weaponHash number
+---@param ownerPed number
+function _AttachWeaponToHorseHolster(horse, weaponHash, ownerPed) end
+
+-- _CAN_PED_ACCESS_MOUNT_WEAPONS  (0x23BF601A42F329A0)
+-- True if the ped can access their *owned* mount/horse inventory for saddle weapon stow/retrieve (used to gate longarm-slot selection in the weapon wheel).
+-- Notes: does not require holding a weapon; returns false if too far, wrong/non-owned mount, or the saddle interaction state is not allowed.
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _CanPedAccessMountWeapons(ped) end
+
+-- _CLEAR_PED_LAST_WEAPON_DAMAGE  (0x087D8F4BC65F68E4)
+-- min build: 1207
+---@param ped number
+function _ClearPedLastWeaponDamage(ped) end
+
+-- _CREATE_WEAPON_OBJECT  (0x9888652B8BA77F73)
+-- min build: 1207
+---@param weaponHash number
+---@param ammoCount number
+---@param x number
+---@param y number
+---@param z number
+---@param showWorldModel boolean
+---@param scale number
+---@return number
+function _CreateWeaponObject(weaponHash, ammoCount, x, y, z, showWorldModel, scale) end
+
+-- _DELETE_WEAPON_OBJECTS_ON_HORSE  (0xD4C6E24D955FF061)
+-- Deletes all visible weapon PROP objects attached to a horse's holsters/rack.
+-- This removes only the *rendered/attached objects*; it does not remove the weapons from inventory and they remain usable.
+-- 
+-- Parameters:
+-- - horse: Horse ped whose attached weapon objects should be removed.
+-- 
+-- Notes:
+-- - Useful to clear the horse's visible long-gun/holster props after manually attaching via 0x14FF0C2545527F9B.
+-- - Always validate the ped handle before calling.
+-- 
+-- Example video:
+-- - https://imgur.com/a/BavwEfE
+-- min build: 1311
+---@param horse number
+function _DeleteWeaponObjectsOnHorse(horse) end
+
+-- _DISABLE_ALL_SPECIAL_AMMO_FOR_PED  (0xD63B4BA3A02A99E0)
+-- Disables all special ammo variants for the given weapon on the specified ped, forcing regular/basic ammo only.
+-- 
+-- Notes:
+-- 	- Higher-level override vs. per-ammo-type disables (targets all special variants at once).
+-- 	- Useful to enforce "no special ammo" rules for a specific ped/weapon.
+-- 	- Per-ped/per-weapon setting.
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+function _DisableAllSpecialAmmoForPed(ped, weaponHash) end
+
+-- _DISABLE_AMMO_TYPE_FOR_PED  (0xAA5A52204E077883)
+-- min build: 1207
+---@param ped number
+---@param ammoHash number
+function _DisableAmmoTypeForPed(ped, ammoHash) end
+
+-- _DISABLE_AMMO_TYPE_FOR_PED_WEAPON  (0xF0D728EEA3C99775)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammoHash number
+function _DisableAmmoTypeForPedWeapon(ped, weaponHash, ammoHash) end
+
+-- _DOES_PED_HAVE_PISTOL  (0xBFCA7AFABF9D7967)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _DoesPedHavePistol(ped, p1) end
+
+-- _DOES_PED_HAVE_REPEATER  (0x495A04CAEC263AF8)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _DoesPedHaveRepeater(ped, p1) end
+
+-- _DOES_PED_HAVE_REVOLVER  (0x5B235F24472F2C3B)
+-- Preview: https://imgur.com/a/U8Q04Xu
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _DoesPedHaveRevolver(ped, p1) end
+
+-- _DOES_PED_HAVE_RIFLE  (0x95CA12E2C68043E5)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _DoesPedHaveRifle(ped, p1) end
+
+-- _DOES_PED_HAVE_SHOTGUN  (0xABC18A28BAD4B46F)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _DoesPedHaveShotgun(ped, p1) end
+
+-- _DOES_PED_HAVE_SNIPER  (0x80BB243789008A82)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return boolean
+function _DoesPedHaveSniper(ped, p1) end
+
+-- _ENABLE_ALL_SPECIAL_AMMO_FOR_PED  (0x404514D231DB27A0)
+-- Re-enables all special ammo variants for the given weapon on the specified ped (inverse of _DISABLE_ALL_SPECIAL_AMMO_FOR_PED).
+-- 
+-- Notes:
+-- 	- Restores access to any supported special ammo types for that weapon (e.g. express, high velocity, split point, explosive, etc.).
+-- 	- Useful to toggle back from a "regular ammo only" restriction.
+-- 	- Per-ped/per-weapon setting.
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+function _EnableAllSpecialAmmoForPed(ped, weaponHash) end
+
+-- _ENABLE_AMMO_TYPE_FOR_PED  (0x3B7B7908B7ADFB4B)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+function _EnableAmmoTypeForPed(ped, weaponHash) end
+
+-- _ENABLE_AMMO_TYPE_FOR_PED_WEAPON  (0x23FB9FACA28779C1)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammoHash number
+function _EnableAmmoTypeForPedWeapon(ped, weaponHash, ammoHash) end
+
+-- _ENABLE_WEAPON_RESTORE  (0xC395355843BE134B)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _EnableWeaponRestore(ped) end
+
+-- _EXPLODE_PED_AMMO_TYPE  (0x44C8F4908F1B2622)
+-- Triggers detonation/effect for a specific throwable ammo type associated with the given ped (commonly used to remotely detonate placed dynamite).
+-- Known ammo hashes seen in scripts:
+-- - AMMO_DYNAMITE
+-- - AMMO_MOLOTOV
+-- - AMMO_POISONBOTTLE
+-- Notes:
+-- - Only affects throwables of that ammo type that are attributable to the ped (i.e., their placed/owned instances).
+-- min build: 1207
+---@param ped number
+---@param ammoHash number
+---@return boolean
+function _ExplodePedAmmoType(ped, ammoHash) end
+
+-- _GET_AMMO_IN_CLIP_BY_INVENTORY_UID  (0x678F00858980F516)
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return number
+---@return any
+function _GetAmmoInClipByInventoryUid(ped) end
+
+-- _GET_AMMO_IN_PED_WEAPON_FROM_GUID  (0x4823F13A21F51964)
+-- Returns the full amount of ammo the ped has for the weapon identified by itemGuid.
+-- Use INVENTORY_GET_GUID_FROM_ITEMID to obtain the weapon GUID.
+-- Example: https://pastebin.com/u2Hcah3C
+-- min build: 1207
+---@param ped number
+---@return number
+---@return any
+function _GetAmmoInPedWeaponFromGuid(ped) end
+
+-- _GET_AMMO_RECOMMENDED_TYPE_FOR_WEAPON  (0xEC97101A8F311282)
+-- Identical to _GET_AMMO_TYPE_FOR_WEAPON (0x5C2EA6C44F515F34) -> same native handler address
+-- Technically returns the first type specified for a weapon
+-- Example: local ammoType = _GET_AMMO_RECOMMENDED_TYPE_FOR_WEAPON(joaat('WEAPON_REVOLVER_CATTLEMAN')) -- AmmoType: AMMO_REVOLVER
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function _GetAmmoRecommendedTypeForWeapon(weaponHash) end
+
+-- _GET_AMMO_TYPE_FOR_WEAPON  (0x5C2EA6C44F515F34)
+-- Identical to _GET_AMMO_RECOMMENDED_TYPE_FOR_WEAPON (0xEC97101A8F311282) -> same native handler address
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function _GetAmmoTypeForWeapon(weaponHash) end
+
+-- _GET_BEST_PED_WEAPON_IN_GROUP  (0x9F67929D98E7C6E8)
+-- If near your horse when called, weapons stored on your horse will be considered
+-- Returns weaponHash
+-- min build: 1207
+---@param ped number
+---@param weaponGroup number
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+function _GetBestPedWeaponInGroup(ped, weaponGroup, p2, p3) end
+
+-- _GET_BEST_PED_WEAPON_IN_INVENTORY  (0x7B98500614C8E8B8)
+-- min build: 1232
+---@param ped number
+---@param p1 any
+---@return any
+---@return any
+function _GetBestPedWeaponInInventory(ped, p1) end
+
+-- _GET_CAN_SWITCH_WEAPON  (0xBC9444F2FF94A9C0)
+-- Returns whether the ped is currently allowed to switch weapons (weapon switching not locked by internal code/state).
+-- 
+-- Script evidence: used as an additional gate in NPLOI__CAN_GUN_SPIN_PREVIEW; when it returns false scripts log "Prevented by Code" even if twirl-capable weapons exist in hand/holsters.
+-- 
+-- Example video: https://imgur.com/a/hawFMhN
+-- min build: 1355
+---@param ped number
+---@return boolean
+function _GetCanSwitchWeapon(ped) end
+
+-- _GET_CAN_TWIRL_WEAPON  (0x6554ECCE226F2A2A)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _GetCanTwirlWeapon(weaponHash) end
+
+-- _GET_CORRECT_KIT_EMOTE_TWIRL_GUN  (0xCD356B42C57BFE01)
+-- _GET_BEST_* - _GET_CLOSEST_*
+-- min build: 1355
+---@param ped number
+---@return boolean
+---@return any
+function _GetCorrectKitEmoteTwirlGun(ped) end
+
+-- _GET_CURRENT_AMMO_TYPE_FROM_GUID  (0xAF9D167A5656D6A6)
+-- Returns ammoHash
+-- min build: 1207
+---@param ped number
+---@return number
+---@return any
+function _GetCurrentAmmoTypeFromGuid(ped) end
+
+-- _GET_CURRENT_PED_WEAPON_AMMO_TYPE  (0x7E7B19A4355FEE13)
+-- Returns ammoHash from weaponObject (Returned by 0x6CA484C9A7377E4F)
+-- min build: 1207
+---@param ped number
+---@param weaponObject number
+---@return number
+function _GetCurrentPedWeaponAmmoType(ped, weaponObject) end
+
+-- _GET_DEFAULT_PED_WEAPON_COLLECTION  (0xD42514C182121C23)
+-- Returns weaponCollection Hash
+-- Example: RE_POLICECHASE_MALES_01: Carbine Repeater + Knife, LO_AGRO_PED
+-- min build: 1207
+---@param pedModel number
+---@return number
+function _GetDefaultPedWeaponCollection(pedModel) end
+
+-- _GET_DEFAULT_UNARMED_WEAPON_HASH  (0x08FF1099ED2E6E21)
+-- Returns the ped's default unarmed weapon hash as defined in CPedModelInfo (DefaultUnarmedWeapon).
+-- Falls back to WEAPON_UNARMED if the ped doesn't have a valid model info pointer, or 0 if the ped doesn't exist.
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetDefaultUnarmedWeaponHash(ped) end
+
+-- _GET_DEFAULT_WEAPON_ATTACH_POINT  (0x65DC4AC5B96614CB)
+-- Returns default attach point for given weapon hash. Returns -1 for melee as they can't be attached.
+-- Example: https://imgur.com/a/mUE5fug
+-- min build: 1311
+---@param weaponHash number
+---@return number
+function _GetDefaultWeaponAttachPoint(weaponHash) end
+
+-- _GET_IS_PED_TAKING_POISON_GAS_DAMAGE  (0x0DE0944ECCB3DF5D)
+-- True if the ped is currently being damaged by poison gas/fog (used by scripts to block actions like crafting). May be false if damage is suppressed/immune even while inside the fog.
+-- min build: 1232
+---@param ped number
+---@return boolean
+function _GetIsPedTakingPoisonGasDamage(ped) end
+
+-- _GET_LOCKON_RANGE_CURRENT_WEAPON  (0x3799EFCC3C8CD5E1)
+-- Returns the current weapon's lock-on/aim-assist range for this ped.
+-- Internally selects a different range when the ped is mounted or in a vehicle vs on foot. Returns -1.0 if the ped/weapon data is unavailable.
+-- Commonly used to derive a clamp for PLAYER::SET_PLAYER_LOCKON_RANGE_OVERRIDE (e.g., add a margin or cap to 18.0).
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetLockonRangeCurrentWeapon(ped) end
+
+-- _GET_LONGARMS_INSTANTLY_STORE_ON_DISMOUNT  (0x5A695BD328586B44)
+-- Gets the ped setting that controls whether longarms are instantly stored on the mount when dismounting.
+-- 
+-- Notes:
+-- - p1 selects one of two internal bits (WeaponComponent+0x1B5); scripts consistently pass 0.
+-- - SP scripts typically toggle this based on context (e.g., player on/near their saddle horse or horse has a holstered longarm, and the player is in a "safe/town" state and not under threat).
+-- - Reads the same setting toggled by WEAPON::_SET_INSTANTLY_STORE_LONGARMS_ON_DISMOUNT (0xB832F1A686B9B810).
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@return boolean
+function _GetLongarmsInstantlyStoreOnDismount(ped, p1) end
+
+-- _GET_MAX_LOCKON_DISTANCE_OF_CURRENT_PED_WEAPON  (0x79B1A6E780266DB0)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetMaxLockonDistanceOfCurrentPedWeapon(ped) end
+
+-- _GET_NUM_PEDS_RESTRAINED_FROM_BOLAS  (0x46D42883E873C1D7)
+-- min build: 1232
+---@param ped number
+---@return number
+function _GetNumPedsRestrainedFromBolas(ped) end
+
+-- _GET_PED_CURRENT_HELD_WEAPON  (0x8425C5F057012DAB)
+-- Returns eCurrentHeldWeapon
+-- _GET_R* - _GET_T*
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedCurrentHeldWeapon(ped) end
+
+-- _GET_PED_GUN_SPINNING_EQUIPPED_KIT_EMOTE_TWIRL  (0x2C4FEC3D0EFA9FC0)
+-- Returns emote Hash
+-- min build: 1355
+---@param ped number
+---@return number
+function _GetPedGunSpinningEquippedKitEmoteTwirl(ped) end
+
+-- _GET_PED_GUN_SPINNING_HASH_FROM_WEAPON_EMOTE_VARIATION  (0xF3B1620B920D1708)
+-- Returns iSpinHash / iVariationSpin
+-- min build: 1355
+---@param ped number
+---@param weaponEmoteVariation number
+---@return number
+function _GetPedGunSpinningHashFromWeaponEmoteVariation(ped, weaponEmoteVariation) end
+
+-- _GET_PED_HOGTIE_WEAPON  (0x90EB1CB189923587)
+-- min build: 1207
+---@param ped number
+---@return number
+function _GetPedHogtieWeapon(ped) end
+
+-- _GET_PED_WEAPON_IN_SLOT  (0xDBC4B552B2AE9A83)
+-- slotHash is usually just the weaponHash name, but WEAPON_* is replaced with SLOT_*
+-- min build: 1207
+---@param ped number
+---@param slotHash number
+---@return number
+function _GetPedWeaponInSlot(ped, slotHash) end
+
+-- _GET_PED_WEAPON_OBJECT  (0x6CA484C9A7377E4F)
+-- _GET_M* - _GET_PED_A*
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return number
+function _GetPedWeaponObject(ped, p1) end
+
+-- _GET_PED_WORST_WEAPON  (0xDA37A053C1522F5D)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@return number
+function _GetPedWorstWeapon(ped, p1, p2, p3) end
+
+-- _GET_PLAYER_PED_QUICK_SWAP_WEAPON_BY_GUID  (0xB7E52A058B07C7E2)
+-- Outputs cached guids
+-- min build: 1232
+---@param ped number
+---@return any
+---@return any
+function _GetPlayerPedQuickSwapWeaponByGuid(ped) end
+
+-- _GET_PROJECTILE_IGNITED_IN_VOLUME  (0x74C8000FDD1BB111)
+-- Finds an ignited (lit/fused) explosive projectile inside a Volume.
+-- 
+-- Parameters:
+-- - volume: Search volume.
+-- - outEntity: [out] Receives the projectile Entity handle.
+-- 
+-- Returns:
+-- - BOOL: true if an ignited projectile was found (outEntity set), false otherwise.
+-- 
+-- Notes:
+-- - Intended for explosives with a fuse/ignition state (e.g., lit dynamite).
+-- - If multiple ignited projectiles are present, returns the first match.
+-- - Requires a valid Volume; delete it when done.
+-- - Lua example: https://pastebin.com/N9p4anLU 
+-- 
+-- _GET_PO*
+-- min build: 1207
+---@param volume number
+---@return boolean
+---@return number
+function _GetProjectileIgnitedInVolume(volume) end
+
+-- _GET_PROJECTILE_IN_VOLUME  (0x74C8000FDD1BB222)
+-- Finds a projectile entity inside the given Volume and writes its handle to the out pointer.
+-- 
+-- Parameters:
+-- - volume: Volume to search in.
+-- - outEntity: [out] Receives the found projectile entity handle.
+-- 
+-- Returns:
+-- - BOOL: true if a projectile was found and written; false otherwise.
+-- 
+-- Notes:
+-- - Returns the first matching projectile the engine reports for that volume (order is unspecified).
+-- - Not limited to ignited projectiles (see 0x74C8000FDD1BB111 for the ignited-only variant).
+-- - The returned entity is typically an OBJECT; validate with ENTITY::DOES_ENTITY_EXIST.
+-- - Lua example: https://pastebin.com/ZgaUSEEP 
+-- 
+-- _GET_PO*
+-- min build: 1207
+---@param volume number
+---@return boolean
+---@return number
+function _GetProjectileInVolume(volume) end
+
+-- _GET_WEAPON_ATTACH_POINT  (0xCAD4FE9398820D24)
+-- Returns WeaponAttachPoint
+-- min build: 1207
+---@param ped number
+---@param attachPoint number
+---@return number
+function _GetWeaponAttachPoint(ped, attachPoint) end
+
+-- _GET_WEAPON_COMPONENT_TYPE_MODEL  (0x59DE03442B6C9598)
+-- min build: 1207
+---@param componentHash number
+---@return number
+function _GetWeaponComponentTypeModel(componentHash) end
+
+-- _GET_WEAPON_DAMAGE  (0x904103D5D2333977)
+-- Related to weapon visual damage, not actual damage.
+-- min build: 1207
+---@param weaponObject number
+---@return number
+function _GetWeaponDamage(weaponObject) end
+
+-- _GET_WEAPON_DIRT  (0x810E8AE9AFEA7E54)
+-- min build: 1207
+---@param weaponObject number
+---@return number
+function _GetWeaponDirt(weaponObject) end
+
+-- _GET_WEAPON_EMOTE_VARIATION  (0x86147D05FA831D3A)
+-- Returns weaponEmoteVariation
+-- 
+-- WEAPON_EMOTE_VARIATION_INVALID = -2,
+-- WEAPON_EMOTE_VARIATION_BASE,
+-- WEAPON_EMOTE_VARIATION_A,
+-- WEAPON_EMOTE_VARIATION_B,
+-- WEAPON_EMOTE_VARIATION_C,
+-- WEAPON_EMOTE_VARIATION_D,
+-- WEAPON_EMOTE_VARIATION_PREVIEW,
+-- WEAPON_EMOTE_NUM_VARIATIONS
+-- min build: 1355
+---@param ped number
+---@param variation number
+---@return number
+function _GetWeaponEmoteVariation(ped, variation) end
+
+-- _GET_WEAPON_FROM_DEFAULT_PED_WEAPON_COLLECTION  (0x9EEFD670F10656D7)
+-- Returns a random weaponHash from default ped weapon collection (see _GET_DEFAULT_PED_WEAPON_COLLECTION).
+-- min build: 1207
+---@param weaponCollection number
+---@param weaponGroup number
+---@return number
+function _GetWeaponFromDefaultPedWeaponCollection(weaponCollection, weaponGroup) end
+
+-- _GET_WEAPON_FROM_HORSE_HOLSTER  (0xAFFD0CCF31F469B8)
+-- Returns the weapon hash in the horse/mount's first holster slot, or 0 if empty/invalid.
+-- min build: 1207
+---@param horse number
+---@return number
+function _GetWeaponFromHorseHolster(horse) end
+
+-- _GET_WEAPON_GUN_SPINNING_WEAPON_EMOTE_TRICK_TYPE_HASH  (0xF4601C1203B1A78D)
+-- Returns iSpinHash
+-- min build: 1207
+---@param emote number
+---@param weaponEmoteTrickType number
+---@return number
+function _GetWeaponGunSpinningWeaponEmoteTrickTypeHash(emote, weaponEmoteTrickType) end
+
+-- _GET_WEAPON_HAS_MULTIPLE_AMMO_TYPES  (0x58425FCA3D3A2D15)
+-- Example: https://imgur.com/a/fCaPJ1x
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _GetWeaponHasMultipleAmmoTypes(weaponHash) end
+
+-- _GET_WEAPON_NAME  (0x89CF5FF3D363311E)
+-- Returns "WNS_INVALID" if the weapon is invalid/doesn't exist.
+-- min build: 1207
+---@param weaponHash number
+---@return string
+function _GetWeaponName(weaponHash) end
+
+-- _GET_WEAPON_NAME_2  (0x6D3AC61694A791C5)
+-- min build: 1207
+---@param weaponHash number
+---@return string
+function _GetWeaponName2(weaponHash) end
+
+-- _GET_WEAPON_NAME_WITH_PERMANENT_DEGRADATION  (0x7A56D66C78D8EF8E)
+-- min build: 1207
+---@param weaponHash number
+---@param permanentDegradationLevel number
+---@return string
+function _GetWeaponNameWithPermanentDegradation(weaponHash, permanentDegradationLevel) end
+
+-- _GET_WEAPON_OBJECT_FROM_PED  (0xC6A6789BB405D11C)
+-- Detaches the weapon from the ped and actually removes the ped's weapon
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return number
+function _GetWeaponObjectFromPed(ped, p1) end
+
+-- _GET_WEAPON_REPLACED_HASH  (0x9F0E1892C7F228A8)
+-- Returns the last weapon hash that was replaced due to a slot/holster swap when giving/equipping a weapon (set internally during weapon give/equip when another weapon gets displaced).
+-- If clear==true, the stored value is reset to 0 after reading (consume semantics); if clear==false, it is not cleared.
+-- Returns 0 if no replacement is pending.
+-- min build: 1207
+---@param clear boolean
+---@return number
+function _GetWeaponReplacedHash(clear) end
+
+-- _GET_WEAPON_SCALE  (0x22084CA699219624)
+-- min build: 1207
+---@param weaponObject number
+---@return number
+function _GetWeaponScale(weaponObject) end
+
+-- _GET_WEAPON_SOOT  (0x4BF66F8878F67663)
+-- min build: 1207
+---@param weaponObject number
+---@return number
+function _GetWeaponSoot(weaponObject) end
+
+-- _GET_WEAPON_STAT_ID  (0x8EC44AE8DECFF841)
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function _GetWeaponStatId(weaponHash) end
+
+-- _GET_WEAPON_TYPE_FROM_AMMO_TYPE  (0x7AA043F6C41D151E)
+-- min build: 1207
+---@param ammoType number
+---@return number
+function _GetWeaponTypeFromAmmoType(ammoType) end
+
+-- _GET_WEAPON_UNLOCK  (0x865F36299079FB75)
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function _GetWeaponUnlock(weaponHash) end
+
+-- _GET_WEAPONTYPE_MODEL  (0xF70825EB340E7D15)
+-- Gets the model hash from the weapon hash.
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function _GetWeapontypeModel(weaponHash) end
+
+-- _GET_WEAPONTYPE_SLOT  (0x46F032B8DDF46CDE)
+-- Returns hash where WEAPON_ is replaced with SLOT_
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function _GetWeapontypeSlot(weaponHash) end
+
+-- _GIVE_WEAPON_COLLECTION_TO_PED  (0x899A04AFCC725D04)
+-- min build: 1207
+---@param ped number
+---@param weaponCollection number
+function _GiveWeaponCollectionToPed(ped, weaponCollection) end
+
+-- _GIVE_WEAPON_COMPONENT_TO_ENTITY  (0x74C9090FDD1BB48E)
+-- entity can be a ped or weapon object.
+-- min build: 1207
+---@param entity number
+---@param componentHash number
+---@param weaponHash number
+---@param p3 boolean
+function _GiveWeaponComponentToEntity(entity, componentHash, weaponHash, p3) end
+
+-- _GIVE_WEAPON_COMPONENT_TO_WEAPON_OBJECT  (0x1A47699E8D533E8F)
+-- min build: 1207
+---@param ped number
+---@param componentHash number
+---@param p3 boolean
+---@return number
+function _GiveWeaponComponentToWeaponObject(ped, componentHash, p3) end
+
+-- _HAS_ENTITY_BEEN_DAMAGED_BY_WEAPON  (0xDCF06D0CDFF68424)
+-- min build: 1207
+---@param entity number
+---@param weaponName number
+---@param weaponType number
+---@return boolean
+function _HasEntityBeenDamagedByWeapon(entity, weaponName, weaponType) end
+
+-- _HAS_ENTITY_BEEN_DAMAGED_BY_WEAPON_RECENTLY  (0x9E2D5D6BC97A5F1E)
+-- min build: 1207
+---@param entity number
+---@param weaponHash number
+---@param ms number
+---@return boolean
+function _HasEntityBeenDamagedByWeaponRecently(entity, weaponHash, ms) end
+
+-- _HAS_PED_GOT_WEAPON_COMPONENT  (0xBBC67A6F965C688A)
+-- min build: 1207
+---@param ped number
+---@param componentHash number
+---@param weaponHash number
+---@return boolean
+function _HasPedGotWeaponComponent(ped, componentHash, weaponHash) end
+
+-- _HAS_WEAPON_ASSET_LOADED  (0xFF07CF465F48B830)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _HasWeaponAssetLoaded(weaponHash) end
+
+-- _HIDE_PED_WEAPONS  (0xFCCC886EDE3C63EC)
+-- Unequip current weapon and set current weapon to WEAPON_UNARMED.
+-- p0 usually 2 in R* scripts. Doesn't seem to have any effect if changed....
+-- immediately: if true it will instantly switch to unarmed
+-- min build: 1207
+---@param ped number
+---@param p0 number
+---@param immediately boolean
+function _HidePedWeapons(ped, p0, immediately) end
+
+-- _HOLSTER_PED_WEAPONS  (0x94A3C1B804D291EC)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@param p3 boolean
+---@param immediately boolean
+function _HolsterPedWeapons(ped, p1, p2, p3, immediately) end
+
+-- _IS_AMMO_SILENT  (0xD2866CBA797E872E)
+-- min build: 1232
+---@param ammoHash number
+---@return boolean
+function _IsAmmoSilent(ammoHash) end
+
+-- _IS_AMMO_SILENT_2  (0x7EFACC589B98C488)
+-- min build: 1207
+---@param ammoHash number
+---@return boolean
+function _IsAmmoSilent2(ammoHash) end
+
+-- _IS_AMMO_TYPE_VALID_FOR_WEAPON  (0xC570B881754DF609)
+-- min build: 1207
+---@param weaponHash number
+---@param ammoHash number
+---@return boolean
+function _IsAmmoTypeValidForWeapon(weaponHash, ammoHash) end
+
+-- _IS_AMMO_VALID  (0x1F7977C9101F807F)
+-- min build: 1207
+---@param ammoHash number
+---@return boolean
+function _IsAmmoValid(ammoHash) end
+
+-- _IS_PED_CARRYING_BACKUP_WEAPON  (0x486C96A0DCD2BC92)
+-- Returns true if the ped is carrying a backup weapon at the specified attach point. Use GET_PED_BACKUP_WEAPON to get the weapon hash.
+-- min build: 1232
+---@param ped number
+---@param attachPoint number
+---@return boolean
+function _IsPedCarryingBackupWeapon(ped, attachPoint) end
+
+-- _IS_PED_CARRYING_WEAPON_SNIPER_AT_ATTACH_POINT  (0xD2209866B0CB72EA)
+-- Checks whether the weapon stored/equipped at the specified ped attach point is classified as a sniper weapon.
+-- 
+-- Params:
+-- - ped: Target ped.
+-- - attachPoint: Attach point / weapon slot to check.
+-- 
+-- Returns:
+-- - BOOL: True if that slot contains a sniper-class weapon.
+-- 
+-- Video:
+-- - https://imgur.com/a/sRwan6L
+-- min build: 1207
+---@param ped number
+---@param attachPoint number
+---@return boolean
+function _IsPedCarryingWeaponSniperAtAttachPoint(ped, attachPoint) end
+
+-- _IS_PED_CURRENT_WEAPON_HOLSTERED  (0xBDD9C235D8D1052E)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsPedCurrentWeaponHolstered(ped) end
+
+-- _IS_TARGET_PED_CONSTRAINED_BY_PED_USING_BOLAS  (0x8D50F43298AB9545)
+-- min build: 1232
+---@param ped number
+---@param targetPed number
+---@return boolean
+function _IsTargetPedConstrainedByPedUsingBolas(ped, targetPed) end
+
+-- _IS_WEAPON_BINOCULARS  (0xC853230E76A152DF)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponBinoculars(weaponHash) end
+
+-- _IS_WEAPON_CLOSE_RANGE  (0xEA522F991E120D45)
+-- Returns true for lassos, melee, thrown weapons (machetes and unarmed return false)
+-- Returns false for all guns, bows and animal weapons
+-- _IS_WEAPON_S* - _IS_WEAPON_V*
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponCloseRange(weaponHash) end
+
+-- _IS_WEAPON_HOLSTER_STATE_CHANGING  (0x2387D6E9C6B478AA)
+-- Returns true if the ped is currently holstering or unholstering a weapon
+-- min build: 1207
+---@param ped number
+---@return boolean
+function _IsWeaponHolsterStateChanging(ped) end
+
+-- _IS_WEAPON_KIT  (0x6ABAD7B0A854F8FB)
+-- Returns true when the weapon passed is either a lasso, the camera or the binoculars
+-- _IS_WEAPON_M* - _IS_WEAPON_P*
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponKit(weaponHash) end
+
+-- _IS_WEAPON_KIT_2  (0x49E40483948AF062)
+-- Returns true when the weapon passed is either the fishingrod, a lasso, the camera or the binoculars
+-- _IS_WEAPON_M* - _IS_WEAPON_P*
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponKit2(weaponHash) end
+
+-- _IS_WEAPON_KNIFE  (0x792E3EF76C911959)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponKnife(weaponHash) end
+
+-- _IS_WEAPON_LANTERN  (0x79407D33328286C6)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponLantern(weaponHash) end
+
+-- _IS_WEAPON_LASSO  (0x6E4E1A82081EABED)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponLasso(weaponHash) end
+
+-- _IS_WEAPON_ONE_HANDED  (0xD955FEE4B87AFA07)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponOneHanded(weaponHash) end
+
+-- _IS_WEAPON_SILENT  (0x5809DBCA0A37C82B)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponSilent(weaponHash) end
+
+-- _IS_WEAPON_SNIPER  (0x6AD66548840472E5)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponSniper(weaponHash) end
+
+-- _IS_WEAPON_THROWABLE  (0x30E7C16B12DA8211)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponThrowable(weaponHash) end
+
+-- _IS_WEAPON_TORCH  (0x506F1DE1BFC75304)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponTorch(weaponHash) end
+
+-- _IS_WEAPON_TWO_HANDED  (0x0556E9D2ECF39D01)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function _IsWeaponTwoHanded(weaponHash) end
+
+-- _LISTEN_PROJECTILE_HIT_EVENTS  (0xDA5D3F2C6DD5B5D4)
+-- min build: 1207
+---@param listen boolean
+function _ListenProjectileHitEvents(listen) end
+
+-- _MAKE_PED_RELOAD  (0x79E1E511FF7EFB13)
+-- min build: 1207
+---@param ped number
+---@return any
+function _MakePedReload(ped) end
+
+-- _REFILL_AMMO_IN_CLIP  (0xDF4A3404D022ADDE)
+-- min build: 1207
+---@param ped number
+---@param p2 number
+---@return any
+---@return any
+function _RefillAmmoInClip(ped, p2) end
+
+-- _REFILL_AMMO_IN_CURRENT_PED_WEAPON  (0x0A2AB7B7ABC055F4)
+-- min build: 1207
+---@param ped number
+---@return any
+function _RefillAmmoInCurrentPedWeapon(ped) end
+
+-- _REGISTER_WEAPON_OBJECT_FOR_IGNITION  (0x74C90AAACC1DD48F)
+-- Registers a spawned weapon object as ignitable (enables fuse/lighting behavior).
+-- 
+-- Parameters:
+-- - weaponObject: Weapon OBJECT entity (e.g., from CREATE_WEAPON_OBJECT).
+-- 
+-- Notes:
+-- - Does not ignite instantly; it only enables ignition/fuse handling on the object.
+-- min build: 1207
+---@param weaponObject number
+function _RegisterWeaponObjectForIgnition(weaponObject) end
+
+-- _REMOVE_ALL_PED_AMMO  (0x1B83C0DEEBCBB214)
+-- min build: 1207
+---@param ped number
+function _RemoveAllPedAmmo(ped) end
+
+-- _REMOVE_AMMO_FROM_PED  (0xF4823C813CB8277D)
+-- removeReason must be REMOVE_REASON_USED, REMOVE_REASON_GIVEN, REMOVE_REASON_DROPPED or REMOVE_REASON_DEBUG, unless amount is -1
+-- 
+-- removeReason: see REMOVE_WEAPON_FROM_PED
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param amount number
+---@param removeReason number
+function _RemoveAmmoFromPed(ped, weaponHash, amount, removeReason) end
+
+-- _REMOVE_AMMO_FROM_PED_BY_TYPE  (0xB6CFEC32E3742779)
+-- removeReason must be REMOVE_REASON_USED, REMOVE_REASON_GIVEN, REMOVE_REASON_DROPPED or REMOVE_REASON_DEBUG, unless amount is -1
+-- 
+-- removeReason: see REMOVE_WEAPON_FROM_PED
+-- min build: 1207
+---@param ped number
+---@param ammoHash number
+---@param amount number
+---@param removeReason number
+function _RemoveAmmoFromPedByType(ped, ammoHash, amount, removeReason) end
+
+-- _REMOVE_WEAPON_ASSET  (0xC3896D03E2852236)
+-- min build: 1207
+---@param weaponHash number
+function _RemoveWeaponAsset(weaponHash) end
+
+-- _REMOVE_WEAPON_COMPONENT_FROM_PED  (0x19F70C4D80494FF8)
+-- min build: 1207
+---@param ped number
+---@param componentHash number
+---@param weaponHash number
+function _RemoveWeaponComponentFromPed(ped, componentHash, weaponHash) end
+
+-- _REMOVE_WEAPON_FROM_PED_BY_GUID  (0x51C3B71591811485)
+-- min build: 1311
+---@param ped number
+---@param removeReason number
+---@return any
+function _RemoveWeaponFromPedByGuid(ped, removeReason) end
+
+-- _REQUEST_WEAPON_ASSET  (0x72D4CB5DB927009C)
+-- min build: 1207
+---@param weaponHash number
+---@param p1 number
+---@param p2 boolean
+function _RequestWeaponAsset(weaponHash, p1, p2) end
+
+-- _SEND_WEAPON_TO_INVENTORY  (0xE9BD19F8121ADE3E)
+-- Appears to just send specified weapon to your horse holster without having to be close
+-- However, the weapon is not visible on the horse holster, but you can reach the weapon on the weapon wheel
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+function _SendWeaponToInventory(ped, weaponHash) end
+
+-- _SET_ACTIVE_GUN_SPINNING_EQUIP_KIT_EMOTE_TWIRL  (0xCBCFFF805F1B4596)
+-- emote hashes: KIT_EMOTE_TWIRL_GUN, KIT_EMOTE_TWIRL_GUN_LEFT_HOLSTER, KIT_EMOTE_TWIRL_GUN_DUAL, 0 (to unequip)
+-- min build: 1311
+---@param ped number
+---@param emote number
+function _SetActiveGunSpinningEquipKitEmoteTwirl(ped, emote) end
+
+-- _SET_ACTIVE_GUN_SPINNING_KIT_EMOTE_TWIRL  (0x01F661BB9C71B465)
+-- spinHash can be -1, 0 to disable
+-- min build: 1207
+---@param ped number
+---@param weaponEmoteTrickType number
+---@param spin number
+function _SetActiveGunSpinningKitEmoteTwirl(ped, weaponEmoteTrickType, spin) end
+
+-- _SET_ALLOW_DUAL_WIELD  (0x83B8D50EB9446BBA)
+-- min build: 1207
+---@param ped number
+---@param allow boolean
+function _SetAllowDualWield(ped, allow) end
+
+-- _SET_AMMO_IN_TURRET  (0xBDDA0C290C228159)
+-- turretHash: WEAPON_TURRET_MAXIUM, WEAPON_TURRET_GATLING, WEAPON_TURRET_CANNON, WEAPON_TURRET_REVOLVING_CANNON
+-- min build: 1207
+---@param vehicle number
+---@param turretHash number
+---@param ammo number
+function _SetAmmoInTurret(vehicle, turretHash, ammo) end
+
+-- _SET_AMMO_TYPE_FOR_PED_WEAPON  (0xCC9C4393523833E2)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammoHash number
+function _SetAmmoTypeForPedWeapon(ped, weaponHash, ammoHash) end
+
+-- _SET_AMMO_TYPE_FOR_PED_WEAPON_INVENTORY  (0xEBE46B501BC3FBCF)
+-- min build: 1207
+---@param ped number
+---@param ammoHash number
+---@return any
+function _SetAmmoTypeForPedWeaponInventory(ped, ammoHash) end
+
+-- _SET_ARROW_TRAIL_FX  (0x2EBF70E1D8C06683)
+-- Sets the arrow trail FX preset for arrows fired from a bow by this ped (applies to arrows fired after the call).
+-- trailHash: 658521773 is used by R* to enable a sparkly trail in some MP modes and to restore default via -1199552854.
+-- Visual-only; does not change ammo/damage.
+-- min build: 1207
+---@param ped number
+---@param trailHash number
+function _SetArrowTrailFx(ped, trailHash) end
+
+-- _SET_FORCE_AUTO_EQUIP  (0xBE711B14A159E84F)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetForceAutoEquip(ped, toggle) end
+
+-- _SET_FORCE_CURRENT_WEAPON_INTO_COCKED_STATE  (0x5230D3F6EE56CFE6)
+-- min build: 1207
+---@param ped number
+---@param attachPoint number
+function _SetForceCurrentWeaponIntoCockedState(ped, attachPoint) end
+
+-- _SET_GUN_SPINNING_INVENTORY_SLOT_ID_ACTIVATE  (0x408CF580C5E96D49)
+-- _STOP_* - _TEST_*
+-- min build: 1355
+---@param ped number
+---@param emoteType number
+function _SetGunSpinningInventorySlotIdActivate(ped, emoteType) end
+
+-- _SET_INSTANTLY_STORE_LONGARMS_ON_DISMOUNT  (0xB832F1A686B9B810)
+-- Stores longarms to your horse on dismount
+-- Params: p2 = 0
+-- SET_[I - M]*
+-- min build: 1207
+---@param ped number
+---@param storeLongarms boolean
+---@param p2 number
+function _SetInstantlyStoreLongarmsOnDismount(ped, storeLongarms, p2) end
+
+-- _SET_PED_ALL_WEAPONS_VISIBILITY  (0x4F806A6CFED89468)
+-- min build: 1207
+---@param ped number
+---@param visible boolean
+function _SetPedAllWeaponsVisibility(ped, visible) end
+
+-- _SET_PED_INFINITE_AMMO_CLIP  (0xFBAA1E06B6BCA741)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function _SetPedInfiniteAmmoClip(ped, toggle) end
+
+-- _SET_PED_WEAPON_ATTACH_POINT_VISIBILITY  (0x67E21ACC5C0C970C)
+-- attachPoint: see SET_CURRENT_PED_WEAPON
+-- min build: 1207
+---@param ped number
+---@param attachPoint number
+---@param visible boolean
+function _SetPedWeaponAttachPointVisibility(ped, attachPoint, visible) end
+
+-- _SET_PROJECTILE_EFFECT_RADIUS  (0x74C9080FDD1BB48F)
+-- Sets the explosion/impact effect radius for an existing projectile entity (e.g., thrown dynamite).
+-- 
+-- Notes:
+-- - Set before detonation/impact; no effect after.
+-- - Does not ignite/detonate; it only changes the projectile's later effect.
+-- - Typical R* flow: find projectile handle (e.g. GET_PROJECTILE_OF_PROJECTILE_TYPE_WITHIN_DISTANCE or _GET_PROJECTILE_IGNITED_IN_VOLUME) then apply a radius (e.g. 2.0f).
+-- - R* also sets very small values (e.g. 0.01f) when an ignited projectile is detected in a volume, likely to minimize the resulting blast/effect while keeping the same projectile.
+-- min build: 1207
+---@param projectile number
+---@param radius number
+function _SetProjectileEffectRadius(projectile, radius) end
+
+-- _SET_PROJECTILE_FUSE_TIME  (0x74C9080FDD1BB48E)
+-- Sets the remaining fuse time (seconds) for an ignited explosive projectile.
+-- 
+-- Parameters:
+-- - projectile: Projectile entity (e.g., lit dynamite).
+-- - time: Remaining fuse time in seconds (0.0 = immediate detonation).
+-- 
+-- Notes:
+-- - Typically only applies after the projectile has been ignited.
+-- min build: 1207
+---@param projectile number
+---@param time number
+function _SetProjectileFuseTime(projectile, time) end
+
+-- _SET_VEHICLE_WEAPON_HEADING_LIMITS  (0x56CB3B4305A4F7CE)
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+---@param minHeading number
+---@param maxHeading number
+function _SetVehicleWeaponHeadingLimits(vehicle, p1, minHeading, maxHeading) end
+
+-- _SET_VEHICLE_WEAPON_HEADING_LIMITS_2  (0xBF5987E1CDE63501)
+-- min build: 1207
+---@param vehicle number
+---@param p1 number
+---@param minHeading number
+---@param maxHeading number
+---@return any
+function _SetVehicleWeaponHeadingLimits2(vehicle, p1, minHeading, maxHeading) end
+
+-- _SET_VEHICLE_WEAPON_RELOAD_MODE  (0x8A779706DA5CA3DD)
+-- Toggles reload behavior for certain vehicle-mounted cannons.
+-- 
+-- Params:
+-- - vehicle: Vehicle with the mounted cannon.
+-- - noReload: true = disable reload (continuous fire), false = normal reload.
+-- - p2: unk, always -1 in R* scripts.
+-- 
+-- Notes:
+-- - Observed only in SP scripts (native_son2, native_son3, smuggler2).
+-- - Observed to apply to cannon vehicles (e.g., breach_cannon, hotchkiss_cannon), not general vehicle weapons/turrets.
+-- min build: 1207
+---@param vehicle number
+---@param noReload boolean
+---@param p2 number
+function _SetVehicleWeaponReloadMode(vehicle, noReload, p2) end
+
+-- _SET_WEAPON_DAMAGE  (0xE22060121602493B)
+-- Related to weapon visual damage, not actual damage.
+-- min build: 1207
+---@param weaponObject number
+---@param level number
+---@param p2 boolean
+function _SetWeaponDamage(weaponObject, level, p2) end
+
+-- _SET_WEAPON_DEGRADATION  (0xA7A57E89E965D839)
+-- min build: 1207
+---@param weaponObject number
+---@param level number
+function _SetWeaponDegradation(weaponObject, level) end
+
+-- _SET_WEAPON_DIRT  (0x812CE61DEBCAB948)
+-- min build: 1207
+---@param weaponObject number
+---@param level number
+---@param p2 boolean
+function _SetWeaponDirt(weaponObject, level, p2) end
+
+-- _SET_WEAPON_HOLSTERED  (0x4820A6939D7CEF28)
+-- min build: 1207
+---@param ped number
+---@param disableAnim boolean
+function _SetWeaponHolstered(ped, disableAnim) end
+
+-- _SET_WEAPON_LEVEL_THRESHOLD  (0xD4071EFC83794B2F)
+-- every other level will have the max value of (brokeLevel - threshold)
+-- min build: 1207
+---@param weaponObject number
+---@param threshold number
+function _SetWeaponLevelThreshold(weaponObject, threshold) end
+
+-- _SET_WEAPON_SCALE  (0xC3544AD0522E69B4)
+-- min build: 1207
+---@param weaponObject number
+---@param scale number
+function _SetWeaponScale(weaponObject, scale) end
+
+-- _SET_WEAPON_SOOT  (0xA9EF4AD10BDDDB57)
+-- min build: 1207
+---@param weaponObject number
+---@param level number
+---@param p2 boolean
+function _SetWeaponSoot(weaponObject, level, p2) end
+
+-- GET_ALLOW_DUAL_WIELD  (0x918990BD9CE08582)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function GetAllowDualWield(ped) end
+
+-- GET_AMMO_IN_CLIP  (0x2E1202248937775C)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@return boolean
+---@return number
+function GetAmmoInClip(ped, weaponHash) end
+
+-- GET_AMMO_IN_PED_WEAPON  (0x015A522136D7F951)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@return number
+function GetAmmoInPedWeapon(ped, weaponHash) end
+
+-- GET_BEST_PED_SHORTARM_GUID  (0xF52BD94B47CCF736)
+-- min build: 1207
+---@param ped number
+---@param p2 boolean
+---@param p3 boolean
+---@return any
+function GetBestPedShortarmGuid(ped, p2, p3) end
+
+-- GET_BEST_PED_WEAPON  (0x8483E98E8B888AE2)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+---@return number
+function GetBestPedWeapon(ped, p1, p2) end
+
+-- GET_CURRENT_PED_VEHICLE_WEAPON  (0x1017582BCD3832DC)
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return number
+function GetCurrentPedVehicleWeapon(ped) end
+
+-- GET_CURRENT_PED_WEAPON  (0x3A87E44BB9A01D54)
+-- attachPoint: see SET_CURRENT_PED_WEAPON
+-- min build: 1207
+---@param ped number
+---@param p2 boolean
+---@param attachPoint number
+---@param p4 boolean
+---@return boolean
+---@return number
+function GetCurrentPedWeapon(ped, p2, attachPoint, p4) end
+
+-- GET_CURRENT_PED_WEAPON_ENTITY_INDEX  (0x3B390A939AF0B5FC)
+-- Returns weaponObject, attachPoint: see SET_CURRENT_PED_WEAPON
+-- min build: 1207
+---@param ped number
+---@param attachPoint number
+---@return number
+function GetCurrentPedWeaponEntityIndex(ped, attachPoint) end
+
+-- GET_MAX_AMMO  (0xDC16122C7A20C933)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@return boolean
+---@return number
+function GetMaxAmmo(ped, weaponHash) end
+
+-- GET_MAX_AMMO_IN_CLIP  (0xA38DCFFCEA8962FA)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param p2 boolean
+---@return number
+function GetMaxAmmoInClip(ped, weaponHash, p2) end
+
+-- GET_PED_AMMO_BY_TYPE  (0x39D22031557946C1)
+-- min build: 1207
+---@param ped number
+---@param ammoType number
+---@return number
+function GetPedAmmoByType(ped, ammoType) end
+
+-- GET_PED_AMMO_TYPE_FROM_WEAPON  (0x7FEAD38B326B9F74)
+-- Returns the current ammo type of the specified ped's specified weapon.
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@return number
+function GetPedAmmoTypeFromWeapon(ped, weaponHash) end
+
+-- GET_PED_BACKUP_WEAPON  (0xC71FE230A513C30F)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@return number
+function GetPedBackupWeapon(ped, p1) end
+
+-- GET_PED_LAST_WEAPON_IMPACT_COORD  (0x6C4D0409BA1A2BC2)
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return vector3
+function GetPedLastWeaponImpactCoord(ped) end
+
+-- GET_PED_WEAPON_GUID_AT_ATTACH_POINT  (0x6929E22158E52265)
+-- min build: 1207
+---@param ped number
+---@param attachPoint number
+---@return boolean
+---@return any
+function GetPedWeaponGuidAtAttachPoint(ped, attachPoint) end
+
+-- GET_WEAPON_CLIP_SIZE  (0xD3750CCC00635FC2)
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function GetWeaponClipSize(weaponHash) end
+
+-- GET_WEAPON_DEGRADATION  (0x0D78E1097F89E637)
+-- 0.0: good condition, 1.0: poor condition
+-- min build: 1207
+---@param weaponObject number
+---@return number
+function GetWeaponDegradation(weaponObject) end
+
+-- GET_WEAPON_PERMANENT_DEGRADATION  (0xD56E5F336C675EFA)
+-- Related to rust of weapons
+-- min build: 1207
+---@param weaponObject number
+---@return number
+function GetWeaponPermanentDegradation(weaponObject) end
+
+-- GET_WEAPONTYPE_GROUP  (0xEDCA14CA5199FF25)
+-- min build: 1207
+---@param weaponHash number
+---@return number
+function GetWeapontypeGroup(weaponHash) end
+
+-- GIVE_DELAYED_WEAPON_TO_PED  (0xB282DC6EBD803C75)
+-- addReason: see _ADD_AMMO_TO_PED
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammoCount number
+---@param p3 boolean
+---@param addReason number
+function GiveDelayedWeaponToPed(ped, weaponHash, ammoCount, p3, addReason) end
+
+-- GIVE_WEAPON_TO_PED  (0x5E3BDDBCB83F3D84)
+-- Gives the ped the weapon.
+-- List: https://github.com/femga/rdr3_discoveries/blob/master/weapons/weapons.lua
+-- 
+-- Params: p7 is 0.5f, and p8 is 1.0f. p11 and p12 are both 0 in R* Scripts
+-- attachPoint: see SET_CURRENT_PED_WEAPON
+-- addReason: see _ADD_AMMO_TO_PED
+-- permanentDegradation: default 0.5, any higher than 0 it will automatically make the weapon worn, you can also adjust the value to change the weapons maximum cleanliness
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammoCount number
+---@param bForceInHand boolean
+---@param bForceInHolster boolean
+---@param attachPoint number
+---@param bAllowMultipleCopies boolean
+---@param p7 number
+---@param p8 number
+---@param addReason number
+---@param bIgnoreUnlocks boolean
+---@param permanentDegradation number
+---@param p12 boolean
+---@return number
+function GiveWeaponToPed(ped, weaponHash, ammoCount, bForceInHand, bForceInHolster, attachPoint, bAllowMultipleCopies, p7, p8, addReason, bIgnoreUnlocks, permanentDegradation, p12) end
+
+-- GIVE_WEAPON_TO_PED_WITH_OPTIONS  (0xBE7E42B07FD317AC)
+-- min build: 1207
+---@param ped number
+---@return boolean
+---@return any
+---@return any
+function GiveWeaponToPedWithOptions(ped) end
+
+-- HAS_PED_GOT_WEAPON  (0x8DECB02F88F428BC)
+-- onlyCheckPlayerInventory: If true, it will only check the players current inventory. If false, it also checks your horse inventory
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param p2 number
+---@param onlyCheckPlayerInventory boolean
+---@return boolean
+function HasPedGotWeapon(ped, weaponHash, p2, onlyCheckPlayerInventory) end
+
+-- HAS_WEAPON_GOT_WEAPON_COMPONENT  (0x76A18844E743BF91)
+-- min build: 1207
+---@param weapon number
+---@param addonHash number
+---@return boolean
+function HasWeaponGotWeaponComponent(weapon, addonHash) end
+
+-- HIDE_PED_WEAPON_FOR_SCRIPTED_CUTSCENE  (0x6F6981D2253C208F)
+-- Hides the ped's weapon during a cutscene.
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function HidePedWeaponForScriptedCutscene(ped, toggle) end
+
+-- IS_PED_ARMED  (0xCB690F680A3EA971)
+-- min build: 1207
+---@param ped number
+---@param flags number
+---@return boolean
+function IsPedArmed(ped, flags) end
+
+-- IS_PED_CARRYING_WEAPON  (0xF29A186ED428B552)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@return boolean
+function IsPedCarryingWeapon(ped, weaponHash) end
+
+-- IS_PED_WEAPON_READY_TO_SHOOT  (0xB80CA294F2F26749)
+-- min build: 1207
+---@param ped number
+---@return boolean
+function IsPedWeaponReadyToShoot(ped) end
+
+-- IS_WEAPON_A_GUN  (0x705BE297EEBDB95D)
+-- Returns true if CWeaponInfoFlags::Flags::Gun is set.
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponAGun(weaponHash) end
+
+-- IS_WEAPON_BOW  (0xC4DEC3CA8C365A5D)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponBow(weaponHash) end
+
+-- IS_WEAPON_MELEE_WEAPON  (0x959383DCD42040DA)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponMeleeWeapon(weaponHash) end
+
+-- IS_WEAPON_PISTOL  (0xDDC64F5E31EEDAB6)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponPistol(weaponHash) end
+
+-- IS_WEAPON_REPEATER  (0xDDB2578E95EF7138)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponRepeater(weaponHash) end
+
+-- IS_WEAPON_REVOLVER  (0xC212F1D05A8232BB)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponRevolver(weaponHash) end
+
+-- IS_WEAPON_RIFLE  (0x0A82317B7EBFC420)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponRifle(weaponHash) end
+
+-- IS_WEAPON_SHOTGUN  (0xC75386174ECE95D5)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponShotgun(weaponHash) end
+
+-- IS_WEAPON_VALID  (0x937C71165CF334B3)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function IsWeaponValid(weaponHash) end
+
+-- MAKE_PED_DROP_WEAPON  (0xCEF4C65DE502D367)
+-- Old name: _DROP_CURRENT_PED_WEAPON
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param attachPoint number
+---@param p3 boolean
+---@param p4 boolean
+---@return number
+function MakePedDropWeapon(ped, p1, attachPoint, p3, p4) end
+
+-- REMOVE_ALL_PED_WEAPONS  (0xF25DF915FA38C5F3)
+-- min build: 1207
+---@param ped number
+---@param p1 boolean
+---@param p2 boolean
+function RemoveAllPedWeapons(ped, p1, p2) end
+
+-- REMOVE_WEAPON_COMPONENT_FROM_WEAPON_OBJECT  (0xF7D82B0D66777611)
+-- min build: 1207
+---@param weaponObject number
+---@param component number
+function RemoveWeaponComponentFromWeaponObject(weaponObject, component) end
+
+-- REMOVE_WEAPON_FROM_PED  (0x4899CB088EDF59B8)
+-- removeReason:
+-- enum eRemoveItemReason : Hash
+-- {
+-- 	REMOVE_REASON_CLIENT_PURGED = 0x4A4E94DC,
+-- 	REMOVE_REASON_COALESCE = 0x2ABE393E,
+-- 	REMOVE_REASON_DEBUG = 0xA07362E6,
+-- 	REMOVE_REASON_DEFAULT = 0xF77DE93D,
+-- 	REMOVE_REASON_DELETE_CHARACTER = 0x20AFBDE9,
+-- 	REMOVE_REASON_DROPPED = 0xEC7FB5D5,
+-- 	REMOVE_REASON_DUPLICATE = 0x19047132,
+-- 	REMOVE_REASON_GIFTED_INCORRECTLY = 0x9C4E3829,
+-- 	REMOVE_REASON_GIVEN = 0xAD5377D4,
+-- 	REMOVE_REASON_INSUFFICIENT_INVENTORY = 0x518D1AAE,
+-- 	REMOVE_REASON_ITEM_DOES_NOT_EXIST = 0xEAD5D889,
+-- 	REMOVE_REASON_LOADOUT = 0x1B94E3BA,
+-- 	REMOVE_REASON_SET_AMOUNT = 0x19D5CFA5,
+-- 	REMOVE_REASON_SOLD = 0x76C4B482,
+-- 	REMOVE_REASON_USED = 0x2188E0A3,
+-- 	REMOVE_REASON_USE_FAILED = 0x671F9EAD
+-- };
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param p2 boolean
+---@param removeReason number
+function RemoveWeaponFromPed(ped, weaponHash, p2, removeReason) end
+
+-- SET_ALLOW_ANY_WEAPON_DROP  (0x78030C7867D8B9B6)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetAllowAnyWeaponDrop(ped, toggle) end
+
+-- SET_AMMO_IN_CLIP  (0xDCD2A934D65CB497)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammo number
+---@return boolean
+function SetAmmoInClip(ped, weaponHash, ammo) end
+
+-- SET_CURRENT_PED_VEHICLE_WEAPON  (0x75C55983C2C39DAA)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@return boolean
+function SetCurrentPedVehicleWeapon(ped, weaponHash) end
+
+-- SET_CURRENT_PED_WEAPON  (0xADF692B254977C0C)
+-- attachPoint:
+-- enum eWeaponAttachPoint
+-- {
+-- 	WEAPON_ATTACH_POINT_INVALID = -1,
+-- 	WEAPON_ATTACH_POINT_HAND_PRIMARY = 0,
+-- 	WEAPON_ATTACH_POINT_HAND_SECONDARY = 1,
+-- 	WEAPON_ATTACH_POINT_PISTOL_R = 2,
+-- 	MAX_HAND_WEAPON_ATTACH_POINTS = 2,
+-- 	WEAPON_ATTACH_POINT_PISTOL_L = 3,
+-- 	WEAPON_ATTACH_POINT_KNIFE = 4,
+-- 	WEAPON_ATTACH_POINT_LASSO = 5,
+-- 	WEAPON_ATTACH_POINT_THROWER = 6,
+-- 	WEAPON_ATTACH_POINT_BOW = 7,
+-- 	WEAPON_ATTACH_POINT_BOW_ALTERNATE = 8,
+-- 	WEAPON_ATTACH_POINT_RIFLE = 9,
+-- 	WEAPON_ATTACH_POINT_RIFLE_ALTERNATE = 10,
+-- 	WEAPON_ATTACH_POINT_LANTERN = 11,
+-- 	WEAPON_ATTACH_POINT_TEMP_LANTERN = 12,
+-- 	WEAPON_ATTACH_POINT_MELEE = 13,
+-- 	MAX_SYNCED_WEAPON_ATTACH_POINTS = 13,
+-- 	WEAPON_ATTACH_POINT_HIP = 14,
+-- 	WEAPON_ATTACH_POINT_BOOT = 15,
+-- 	WEAPON_ATTACH_POINT_BACK = 16,
+-- 	WEAPON_ATTACH_POINT_FRONT = 17,
+-- 	WEAPON_ATTACH_POINT_SHOULDERSLING = 18,
+-- 	WEAPON_ATTACH_POINT_LEFTBREAST = 19,
+-- 	WEAPON_ATTACH_POINT_RIGHTBREAST = 20,
+-- 	WEAPON_ATTACH_POINT_LEFTARMPIT = 21,
+-- 	WEAPON_ATTACH_POINT_RIGHTARMPIT = 22,
+-- 	WEAPON_ATTACH_POINT_LEFTARMPIT_RIFLE = 23,
+-- 	WEAPON_ATTACH_POINT_SATCHEL = 24,
+-- 	WEAPON_ATTACH_POINT_LEFTARMPIT_BOW = 25,
+-- 	WEAPON_ATTACH_POINT_RIGHT_HAND_EXTRA = 26,
+-- 	WEAPON_ATTACH_POINT_LEFT_HAND_EXTRA = 27,
+-- 	WEAPON_ATTACH_POINT_RIGHT_HAND_AUX = 28,
+-- 	MAX_WEAPON_ATTACH_POINTS = 29
+-- };
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param equipNow boolean
+---@param attachPoint number
+---@param p4 boolean
+---@param p5 boolean
+function SetCurrentPedWeapon(ped, weaponHash, equipNow, attachPoint, p4, p5) end
+
+-- SET_CURRENT_PED_WEAPON_BY_GUID  (0x12FB95FE3D579238)
+-- Equips a weapon from a weaponItem, similar to GIVE_WEAPON_TO_PED
+-- min build: 1207
+---@param ped number
+---@param p2 boolean
+---@param p3 boolean
+---@param p4 boolean
+---@param p5 boolean
+---@return any
+function SetCurrentPedWeaponByGuid(ped, p2, p3, p4, p5) end
+
+-- SET_INSTANTLY_EQUIP_WEAPON_PICKUPS  (0x739B9C6D0E7F7F93)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetInstantlyEquipWeaponPickups(ped, toggle) end
+
+-- SET_PED_AMMO  (0x14E56BC5B5DB6A19)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param ammo number
+function SetPedAmmo(ped, weaponHash, ammo) end
+
+-- SET_PED_AMMO_BY_TYPE  (0x5FD1E1F011E76D7E)
+-- min build: 1207
+---@param ped number
+---@param ammoType number
+---@param ammo number
+function SetPedAmmoByType(ped, ammoType, ammo) end
+
+-- SET_PED_AMMO_TO_DROP  (0xA4EFEF9440A5B0EF)
+-- min build: 1207
+---@param ped number
+---@param p1 number
+---@param p2 number
+function SetPedAmmoToDrop(ped, p1, p2) end
+
+-- SET_PED_CURRENT_WEAPON_VISIBLE  (0x0725A4CCFDED9A70)
+-- min build: 1207
+---@param ped number
+---@param visible boolean
+---@param deselectWeapon boolean
+---@param p3 boolean
+---@param p4 boolean
+function SetPedCurrentWeaponVisible(ped, visible, deselectWeapon, p3, p4) end
+
+-- SET_PED_DROPS_INVENTORY_WEAPON  (0x208A1888007FC0E6)
+-- min build: 1207
+---@param ped number
+---@param weaponHash number
+---@param xOffset number
+---@param yOffset number
+---@param zOffset number
+---@param ammoCount number
+function SetPedDropsInventoryWeapon(ped, weaponHash, xOffset, yOffset, zOffset, ammoCount) end
+
+-- SET_PED_DROPS_WEAPONS_WHEN_DEAD  (0x476AE72C1D19D1A8)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+function SetPedDropsWeaponsWhenDead(ped, toggle) end
+
+-- SET_PED_INFINITE_AMMO  (0x3EDCB0505123623B)
+-- min build: 1207
+---@param ped number
+---@param toggle boolean
+---@param weaponHash number
+function SetPedInfiniteAmmo(ped, toggle, weaponHash) end
+
+-- SET_PLAYER_PED_QUICK_SWAP_WEAPON_BY_GUID  (0xEC1F85DA51D3D6C4)
+-- min build: 1232
+---@param ped number
+---@return any
+---@return any
+function SetPlayerPedQuickSwapWeaponByGuid(ped) end
+
+-- SET_VEHICLE_WEAPON_HEADING  (0x194D877FC5597B7D)
+-- min build: 1207
+---@param vehicle number
+---@param seatIndex number
+---@param heading number
+---@param p3 boolean
+function SetVehicleWeaponHeading(vehicle, seatIndex, heading, p3) end
+
+-- SHOULD_WEAPON_BE_DISCARDED_WHEN_SWAPPED  (0x2C83212A7AA51D3D)
+-- min build: 1207
+---@param weaponHash number
+---@return boolean
+function ShouldWeaponBeDiscardedWhenSwapped(weaponHash) end

--- a/.luals/redm-natives/ZONE.lua
+++ b/.luals/redm-natives/ZONE.lua
@@ -1,0 +1,55 @@
+---@meta
+
+-- RDR3 namespace: ZONE -- generated from rdr3-nativedb-data, do not hand-edit.
+-- Regenerate via generate_natives.js if the source natives.json is updated.
+
+-- _GET_MAP_ZONE_AT_COORDS  (0x43AD8FC02B429D33)
+-- Returns name hash, see common:/data/levels/rdr3/mapzones.meta
+-- 
+-- type (-1 matches any type):
+-- class CMapZone
+-- {
+-- public:
+-- 	enum class Type
+-- 	{
+-- 		STATE,
+-- 		TOWN,
+-- 		LAKE,
+-- 		RIVER,
+-- 		OIL_SPILL,
+-- 		SWAMP,
+-- 		OCEAN,
+-- 		CREEK,
+-- 		POND,
+-- 		GLACIER,
+-- 		DISTRICT,
+-- 		TEXT_PRINTED,
+-- 		TEXT_WRITTEN
+-- 	};
+-- };
+-- 
+-- https://github.com/femga/rdr3_discoveries/tree/master/zones & https://alloc8or.re/rdr3/doc/enums/CMapZone__Type.txt
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@param type number
+---@return number
+function _GetMapZoneAtCoords(x, y, z, type) end
+
+-- _GET_WATER_MAP_ZONE_AT_COORDS  (0x5BA7A68A346A5A91)
+-- Returns the zone's name hash if its type matches one of the following:
+-- - LAKE
+-- - RIVER
+-- - OIL_SPILL
+-- - SWAMP
+-- - OCEAN
+-- - CREEK
+-- - POND
+-- - GLACIER
+-- min build: 1207
+---@param x number
+---@param y number
+---@param z number
+---@return number
+function _GetWaterMapZoneAtCoords(x, y, z) end

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+  "runtime.version": "Lua 5.4",
+  "workspace.checkThirdParty": false,
+  "workspace.library": [
+    "./.luals"
+  ]
+}


### PR DESCRIPTION
The Lua language server flags every RDR3 native, oxmysql call, and CFX runtime function (RegisterNetEvent, TriggerEvent, SendNUIMessage, etc.) as an undefined global, since none of them are defined anywhere in this repo's own source -- they're provided by the game/runtime/oxmysql at load time.

Adds .luarc.json (LuaLS's own project config, not VS-Code-specific) plus .luals/, a self-contained stub library:
- cfx-runtime.lua: hand-written stubs for the CFX scripting runtime
- oxmysql.lua: hand-written stub for the MySQL global oxmysql provides
- redm-natives/*.lua: all 7,132 RDR3 natives across 86 namespaces, generated from the redm-natives skill's rdr3-nativedb-data via generate-redm-natives.js (included, for regenerating later)

Unlike a bare Lua.diagnostics.globals allowlist, these are real ---@meta function declarations with actual parameter/return types, so this gives working IntelliSense (signature help, hover docs), not just warning suppression. See .luals/../README.md (copied from the shared template at the workspace root) for the native-naming caveat and regeneration steps.